### PR TITLE
Improve CI workflow with separate lint, typecheck, and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,62 +2,49 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
-  lint-and-test:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.13"]
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
+          python-version: "3.13"
+      - uses: pre-commit/action@v3.0.1
         with:
-          enable-cache: true
-
-      - name: Set up project
-        run: |
-          uv sync --dev
-
-      - name: Run ruff check
-        run: |
-          uv run ruff check .
-
-      - name: Run ruff format check
-        run: |
-          uv run ruff format --check
-
-      - name: Run pyright
-        run: |
-          uv run pyright
-
-      - name: Run tests
-        run: |
-          uv run pytest -v --tb=short
-
-      - name: Generate test coverage
-        run: |
-          uv run pytest --cov=mcpaudit --cov-report=xml --cov-report=term
-        continue-on-error: true
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-        continue-on-error: true
+          extra_args: --all-files
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          SKIP: no-commit-to-branch,typecheck
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --all-groups
+      - run: uv run pyright mcpaudit/
+
+  test:
+    name: Test / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --all-groups
+      - run: uv run pytest --cov --cov-report=xml
+      - uses: codecov/codecov-action@v4
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Split single combined job into 3 independent parallel jobs
- lint: runs pre-commit (ruff, codespell, file checks)
- typecheck: runs pyright against mcpaudit/
- test: matrix across ubuntu, windows, and macos
- Tests now run once (not twice as before)
- Upgrade setup-uv from v4 to v5