### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.13"
       - run: uv sync --all-groups
-      - run: uv run pyright mcpscore/
+      - run: uv run pyright mcpscore/ scripts/
 
   test:
     name: Test / ${{ matrix.os }} / py${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint: ## Lint code (no auto-fix)
 
 .PHONY: typecheck
 typecheck: ## Type check with pyright
-	uv run pyright mcpscore/
+	uv run pyright mcpscore/ scripts/
 
 .PHONY: test
 test: ## Run tests

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,14 @@ docs-serve: docs-rules ## Serve the documentation locally (Mintlify, needs Node)
 docs-check: docs-rules ## Validate the documentation (broken links)
 	cd docs && npx mint broken-links
 
+.PHONY: release
+release: ## Cut a release: create the GitHub Release that publishes to PyPI
+	uv run python scripts/release.py
+
+.PHONY: release-dry-run
+release-dry-run: ## Run all release checks without creating anything
+	uv run python scripts/release.py --dry-run
+
 .PHONY: all
 all: lint typecheck testcov ## Run all checks (mirrors CI)
 

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -209,7 +209,7 @@ class MCPAuditor:
         if not isinstance(value, dict):
             return None
         try:
-            return model.model_validate(value)  # type: ignore[attr-defined]
+            return model.model_validate(value)
         except ValidationError as e:
             logger.info("Could not parse %s from probe payload: %s", model.__name__, e)
             return None

--- a/mcpscore/rules/readiness.py
+++ b/mcpscore/rules/readiness.py
@@ -394,7 +394,7 @@ class ResultTypeReadinessRule(ReadinessBaseRule):
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
         """Apply the same gating as the cache-metadata rule (needs a modern result)."""
-        return CacheMetadataReadinessRule.skip_reason(self, audit_data)  # type: ignore[arg-type]
+        return CacheMetadataReadinessRule.skip_reason(self, audit_data)
 
     def check(self, audit_data: AuditData) -> RuleResult:
         probes = audit_data.probes or {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ skip = "uv.lock"
 [tool.ruff]
 target-version = "py311"
 line-length = 120
-extend-exclude = ["scripts/*.py"]
+
 
 [tool.ruff.lint]
 select = [
@@ -255,6 +255,9 @@ ignore = [
 
 
 [tool.ruff.lint.per-file-ignores]
+# Maintainer CLI scripts: console output and fixed-arg subprocess calls are
+# their job; scripts/ is not a package; the en dash is intentional typography.
+"scripts/*.py" = ["T201", "S603", "S607", "INP001", "RUF001"]
 "**/tests/*" = [
     "S",      # ignore bandit security issues in tests
     "B018",   # ignore useless expressions in tests

--- a/scripts/generate_rules_doc.py
+++ b/scripts/generate_rules_doc.py
@@ -62,11 +62,11 @@ def generate() -> str:
             lines.append(f"## {group_name.replace('_', ' ').title()}\n\n")
         lines.append("| Rule ID | Name | Severity | Weight | Applies to |\n")
         lines.append("|---|---|---|---|---|\n")
-        for rule in rules:
-            lines.append(
-                f"| `{rule.rule_id}` | {rule.rule_name} | {rule.severity.name} "
-                f"| {int(rule.severity)} | {_applies_to(rule)} |\n"
-            )
+        lines.extend(
+            f"| `{rule.rule_id}` | {rule.rule_name} | {rule.severity.name} "
+            f"| {int(rule.severity)} | {_applies_to(rule)} |\n"
+            for rule in rules
+        )
         lines.append("\n")
     # Single trailing newline at EOF (keeps the end-of-file-fixer hook happy).
     return "".join(lines).rstrip("\n") + "\n"

--- a/scripts/generate_rules_doc.py
+++ b/scripts/generate_rules_doc.py
@@ -74,5 +74,5 @@ def generate() -> str:
 
 if __name__ == "__main__":
     output = Path(__file__).parent.parent / "docs" / "rules.mdx"
-    output.write_text(generate())
+    output.write_text(generate(), encoding="utf-8")
     print(f"Wrote {output}")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Cut a release: create the GitHub Release that triggers PyPI publishing.
+
+Usage:
+    uv run python scripts/release.py [--dry-run]
+    make release          # same, with confirmation prompt
+    make release-dry-run  # checks only, creates nothing
+
+The version to release is read from pyproject.toml. The script verifies the
+repo is actually releasable, extracts the CHANGELOG section as the release
+notes, and creates the GitHub Release (tag v<version>) — which triggers
+.github/workflows/publish.yml to build and publish to PyPI via Trusted
+Publishing. It then waits until the version is live on PyPI.
+
+Checks performed before anything is created:
+  1. on `main`, clean working tree, local HEAD == origin/main
+  2. CHANGELOG.md has a `## [<version>]` section AND the `[<version>]:`
+     compare link at the bottom (the link block is easy to forget)
+  3. tag v<version> does not already exist on the remote
+  4. CI is green for HEAD
+
+Requires: git, gh (authenticated). No third-party Python dependencies.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import tomllib
+from typing import NoReturn
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = "mcp-box/mcpscore"
+ROOT = Path(__file__).parent.parent
+PYPI_WAIT_SECONDS = 300
+
+
+def run(*args: str, capture: bool = True) -> str:
+    result = subprocess.run(args, capture_output=capture, text=True, check=True)
+    return (result.stdout or "").strip()
+
+
+def fail(message: str) -> NoReturn:
+    print(f"✗ {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def ok(message: str) -> None:
+    print(f"✓ {message}")
+
+
+def read_version() -> str:
+    with (ROOT / "pyproject.toml").open("rb") as f:
+        return tomllib.load(f)["project"]["version"]
+
+
+def check_git_state() -> str:
+    branch = run("git", "branch", "--show-current")
+    if branch != "main":
+        fail(f"must release from main (currently on '{branch}')")
+    if run("git", "status", "--porcelain"):
+        fail("working tree is not clean")
+    head = run("git", "rev-parse", "HEAD")
+    remote_head = run("gh", "api", f"repos/{REPO}/commits/main", "--jq", ".sha")
+    if head != remote_head:
+        fail(f"local main ({head[:9]}) != origin/main ({remote_head[:9]}) — push or pull first")
+    ok(f"on main, clean, in sync with origin ({head[:9]})")
+    return head
+
+
+def check_changelog(version: str) -> str:
+    """Verify the CHANGELOG section and link block, and return the section body."""
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+    match = re.search(
+        rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
+        changelog,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        fail(f"CHANGELOG.md has no '## [{version}]' section")
+    if f"[{version}]: https://" not in changelog:
+        fail(f"CHANGELOG.md is missing the '[{version}]: ...' compare link at the bottom")
+    ok(f"CHANGELOG has the [{version}] section and compare link")
+    return match.group(1).strip()
+
+
+def check_tag_absent(version: str) -> None:
+    result = subprocess.run(
+        ["gh", "api", f"repos/{REPO}/git/ref/tags/v{version}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        fail(f"tag v{version} already exists on the remote")
+    ok(f"tag v{version} is unused")
+
+
+def check_ci_green(sha: str) -> None:
+    raw = run(
+        "gh", "api", f"repos/{REPO}/commits/{sha}/check-runs", "--jq",
+        "[.check_runs[] | {name, status, conclusion}]",
+    )
+    runs = json.loads(raw)
+    if not runs:
+        fail("no CI check runs found for HEAD — has CI finished?")
+    bad = [r for r in runs if r["status"] != "completed" or r["conclusion"] not in ("success", "skipped", "neutral")]
+    if bad:
+        details = ", ".join(f"{r['name']}: {r['conclusion'] or r['status']}" for r in bad)
+        fail(f"CI is not green for HEAD — {details}")
+    ok(f"CI green for HEAD ({len(runs)} checks)")
+
+
+def create_release(version: str, notes: str) -> None:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+        f.write(notes + "\n")
+        notes_file = f.name
+    run(
+        "gh", "release", "create", f"v{version}",
+        "--repo", REPO,
+        "--title", f"v{version}",
+        "--notes-file", notes_file,
+        "--latest",
+    )
+    ok(f"GitHub Release v{version} created — publish workflow triggered")
+
+
+def wait_for_pypi(version: str) -> None:
+    url = f"https://pypi.org/pypi/mcpscore/{version}/json"
+    print(f"… waiting for mcpscore {version} on PyPI (up to {PYPI_WAIT_SECONDS}s)")
+    deadline = time.monotonic() + PYPI_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url) as response:  # noqa: S310 — fixed https URL
+                if response.status == 200:
+                    ok(f"mcpscore {version} is live on PyPI")
+                    print(f"\nSmoke test:\n  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp")
+                    return
+        except urllib.error.HTTPError:
+            pass
+        time.sleep(10)
+    fail(
+        f"PyPI did not report {version} within {PYPI_WAIT_SECONDS}s — "
+        f"check the workflow: https://github.com/{REPO}/actions/workflows/publish.yml"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="run all checks, create nothing")
+    args = parser.parse_args()
+
+    version = read_version()
+    print(f"Releasing mcpscore {version}\n")
+
+    head = check_git_state()
+    notes = check_changelog(version)
+    check_tag_absent(version)
+    check_ci_green(head)
+
+    print(f"\n--- release notes (from CHANGELOG) ---\n{notes}\n--------------------------------------\n")
+
+    if args.dry_run:
+        ok(f"dry run: all checks passed — would create release v{version}")
+        return
+
+    answer = input(f"Create GitHub Release v{version} and publish to PyPI? [y/N] ")
+    if answer.strip().lower() != "y":
+        print("aborted")
+        sys.exit(1)
+
+    create_release(version, notes)
+    wait_for_pypi(version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -24,6 +24,7 @@ Requires: git, gh (authenticated). No third-party Python dependencies.
 
 import argparse
 import json
+from pathlib import Path
 import re
 import subprocess
 import sys
@@ -33,7 +34,6 @@ import tomllib
 from typing import NoReturn
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 REPO = "mcp-box/mcpscore"
 ROOT = Path(__file__).parent.parent
@@ -113,7 +113,10 @@ def check_tag_absent(version: str) -> None:
 
 def check_ci_green(sha: str) -> None:
     raw = run(
-        "gh", "api", f"repos/{REPO}/commits/{sha}/check-runs", "--jq",
+        "gh",
+        "api",
+        f"repos/{REPO}/commits/{sha}/check-runs",
+        "--jq",
         "[.check_runs[] | {name, status, conclusion, started_at, completed_at}]",
     )
     runs = json.loads(raw)
@@ -142,11 +145,18 @@ def create_release(version: str, notes: str, target: str) -> None:
         notes_file = f.name
     try:
         run(
-            "gh", "release", "create", f"v{version}",
-            "--repo", REPO,
-            "--target", target,
-            "--title", f"v{version}",
-            "--notes-file", notes_file,
+            "gh",
+            "release",
+            "create",
+            f"v{version}",
+            "--repo",
+            REPO,
+            "--target",
+            target,
+            "--title",
+            f"v{version}",
+            "--notes-file",
+            notes_file,
             "--latest",
         )
     finally:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -104,11 +104,21 @@ def check_tag_absent(version: str) -> None:
 def check_ci_green(sha: str) -> None:
     raw = run(
         "gh", "api", f"repos/{REPO}/commits/{sha}/check-runs", "--jq",
-        "[.check_runs[] | {name, status, conclusion}]",
+        "[.check_runs[] | {name, status, conclusion, started_at, completed_at}]",
     )
     runs = json.loads(raw)
     if not runs:
         fail("no CI check runs found for HEAD — has CI finished?")
+
+    latest_runs = {}
+    for run in runs:
+        timestamp = run["completed_at"] or run["started_at"] or ""
+        latest = latest_runs.get(run["name"])
+        latest_timestamp = (latest["completed_at"] or latest["started_at"] or "") if latest else ""
+        if latest is None or timestamp > latest_timestamp:
+            latest_runs[run["name"]] = run
+
+    runs = list(latest_runs.values())
     bad = [r for r in runs if r["status"] != "completed" or r["conclusion"] not in ("success", "skipped", "neutral")]
     if bad:
         details = ", ".join(f"{r['name']}: {r['conclusion'] or r['status']}" for r in bad)
@@ -116,13 +126,14 @@ def check_ci_green(sha: str) -> None:
     ok(f"CI green for HEAD ({len(runs)} checks)")
 
 
-def create_release(version: str, notes: str) -> None:
+def create_release(version: str, notes: str, target: str) -> None:
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
         f.write(notes + "\n")
         notes_file = f.name
     run(
         "gh", "release", "create", f"v{version}",
         "--repo", REPO,
+        "--target", target,
         "--title", f"v{version}",
         "--notes-file", notes_file,
         "--latest",
@@ -137,13 +148,13 @@ def wait_for_pypi(version: str) -> None:
     while time.monotonic() < deadline:
         try:
             with urllib.request.urlopen(url) as response:  # noqa: S310 — fixed https URL
-                if response.status == 200:
+                if response.getcode() == 200:
                     ok(f"mcpscore {version} is live on PyPI")
                     print(f"\nSmoke test:\n  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp")
                     return
-        except urllib.error.HTTPError:
-            # Expected while the new release is propagating on PyPI (often 404); retry until timeout.
-            continue
+        except urllib.error.URLError:
+            # Expected while PyPI propagates or during transient network errors; retry until timeout.
+            pass
         time.sleep(10)
     fail(
         f"PyPI did not report {version} within {PYPI_WAIT_SECONDS}s — "
@@ -175,7 +186,7 @@ def main() -> None:
         print("aborted")
         sys.exit(1)
 
-    create_release(version, notes)
+    create_release(version, notes, head)
     wait_for_pypi(version)
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -142,7 +142,8 @@ def wait_for_pypi(version: str) -> None:
                     print(f"\nSmoke test:\n  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp")
                     return
         except urllib.error.HTTPError:
-            pass
+            # Expected while the new release is propagating on PyPI (often 404); retry until timeout.
+            continue
         time.sleep(10)
     fail(
         f"PyPI did not report {version} within {PYPI_WAIT_SECONDS}s — "

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -36,14 +36,20 @@ import urllib.error
 import urllib.request
 
 REPO = "mcp-box/mcpscore"
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).resolve().parent.parent
 PYPI_WAIT_SECONDS = 300
 PYPI_REQUEST_TIMEOUT_SECONDS = 15
 
 
 def run(*args: str, capture: bool = True) -> str:
     try:
-        result = subprocess.run(args, capture_output=capture, text=True, check=True)
+        result = subprocess.run(
+            args,
+            capture_output=capture,
+            text=True,
+            check=True,
+            cwd=ROOT,
+        )
     except FileNotFoundError:
         fail(f"required tool not found: {args[0]} — install it and retry")
     except subprocess.CalledProcessError as e:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -42,7 +42,13 @@ PYPI_REQUEST_TIMEOUT_SECONDS = 15
 
 
 def run(*args: str, capture: bool = True) -> str:
-    result = subprocess.run(args, capture_output=capture, text=True, check=True)
+    try:
+        result = subprocess.run(args, capture_output=capture, text=True, check=True)
+    except FileNotFoundError:
+        fail(f"required tool not found: {args[0]} — install it and retry")
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        fail(f"command failed: {' '.join(args)}\n  {stderr or e}")
     return (result.stdout or "").strip()
 
 
@@ -99,6 +105,9 @@ def check_tag_absent(version: str) -> None:
     )
     if result.returncode == 0:
         fail(f"tag v{version} already exists on the remote")
+    stderr = (result.stderr or "") + (result.stdout or "")
+    if "404" not in stderr and "Not Found" not in stderr:
+        fail(f"could not verify tag v{version} (gh api error, not a 404):\n  {stderr.strip()}")
     ok(f"tag v{version} is unused")
 
 
@@ -112,12 +121,12 @@ def check_ci_green(sha: str) -> None:
         fail("no CI check runs found for HEAD — has CI finished?")
 
     latest_runs = {}
-    for run in runs:
-        timestamp = run["completed_at"] or run["started_at"] or ""
-        latest = latest_runs.get(run["name"])
+    for check in runs:
+        timestamp = check["completed_at"] or check["started_at"] or ""
+        latest = latest_runs.get(check["name"])
         latest_timestamp = (latest["completed_at"] or latest["started_at"] or "") if latest else ""
         if latest is None or timestamp > latest_timestamp:
-            latest_runs[run["name"]] = run
+            latest_runs[check["name"]] = check
 
     runs = list(latest_runs.values())
     bad = [r for r in runs if r["status"] != "completed" or r["conclusion"] not in ("success", "skipped", "neutral")]
@@ -131,14 +140,17 @@ def create_release(version: str, notes: str, target: str) -> None:
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
         f.write(notes + "\n")
         notes_file = f.name
-    run(
-        "gh", "release", "create", f"v{version}",
-        "--repo", REPO,
-        "--target", target,
-        "--title", f"v{version}",
-        "--notes-file", notes_file,
-        "--latest",
-    )
+    try:
+        run(
+            "gh", "release", "create", f"v{version}",
+            "--repo", REPO,
+            "--target", target,
+            "--title", f"v{version}",
+            "--notes-file", notes_file,
+            "--latest",
+        )
+    finally:
+        Path(notes_file).unlink(missing_ok=True)
     ok(f"GitHub Release v{version} created — publish workflow triggered")
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -82,7 +82,7 @@ def check_git_state() -> str:
 
 def check_changelog(version: str) -> str:
     """Verify the CHANGELOG section and link block, and return the section body."""
-    changelog = (ROOT / "CHANGELOG.md").read_text()
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     match = re.search(
         rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
         changelog,
@@ -140,7 +140,7 @@ def check_ci_green(sha: str) -> None:
 
 
 def create_release(version: str, notes: str, target: str) -> None:
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
         f.write(notes + "\n")
         notes_file = f.name
     try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -38,6 +38,7 @@ from pathlib import Path
 REPO = "mcp-box/mcpscore"
 ROOT = Path(__file__).parent.parent
 PYPI_WAIT_SECONDS = 300
+PYPI_REQUEST_TIMEOUT_SECONDS = 15
 
 
 def run(*args: str, capture: bool = True) -> str:
@@ -146,16 +147,22 @@ def wait_for_pypi(version: str) -> None:
     print(f"… waiting for mcpscore {version} on PyPI (up to {PYPI_WAIT_SECONDS}s)")
     deadline = time.monotonic() + PYPI_WAIT_SECONDS
     while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
         try:
-            with urllib.request.urlopen(url) as response:  # noqa: S310 — fixed https URL
+            with urllib.request.urlopen(  # noqa: S310 — fixed https URL
+                url,
+                timeout=min(PYPI_REQUEST_TIMEOUT_SECONDS, remaining),
+            ) as response:
                 if response.getcode() == 200:
                     ok(f"mcpscore {version} is live on PyPI")
                     print(f"\nSmoke test:\n  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp")
                     return
-        except urllib.error.URLError:
+        except (TimeoutError, urllib.error.URLError):
             # Expected while PyPI propagates or during transient network errors; retry until timeout.
             pass
-        time.sleep(10)
+        time.sleep(min(10, max(0, deadline - time.monotonic())))
     fail(
         f"PyPI did not report {version} within {PYPI_WAIT_SECONDS}s — "
         f"check the workflow: https://github.com/{REPO}/actions/workflows/publish.yml"
@@ -185,6 +192,10 @@ def main() -> None:
     if answer.strip().lower() != "y":
         print("aborted")
         sys.exit(1)
+
+    head = check_git_state()
+    check_tag_absent(version)
+    check_ci_green(head)
 
     create_release(version, notes, head)
     wait_for_pypi(version)

--- a/tests/test_generate_rules_doc.py
+++ b/tests/test_generate_rules_doc.py
@@ -1,0 +1,41 @@
+"""Tests for scripts/generate_rules_doc.py — the generated rules reference."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import generate_rules_doc
+
+from mcpscore.rules import create_all_rules
+
+
+def test_generated_page_has_mdx_frontmatter():
+    output = generate_rules_doc.generate()
+    assert output.startswith("---\ntitle:")
+    assert "description:" in output.split("---")[1]
+
+
+def test_every_registered_rule_appears():
+    output = generate_rules_doc.generate()
+    for rule in create_all_rules():
+        assert f"`{rule.rule_id}`" in output, rule.rule_id
+
+
+def test_readiness_rules_are_in_their_own_section():
+    output = generate_rules_doc.generate()
+    assert "## Readiness rules (separate score)" in output
+    readiness_section = output.split("## Readiness rules (separate score)")[1]
+    assert "`readiness_2026_server_discover`" in readiness_section
+
+
+def test_single_trailing_newline():
+    """The end-of-file-fixer pre-commit hook rejects extra blank lines at EOF."""
+    output = generate_rules_doc.generate()
+    assert output.endswith("\n")
+    assert not output.endswith("\n\n")
+
+
+def test_committed_reference_matches_the_registry():
+    """docs/rules.mdx must be regenerated whenever the registry changes."""
+    committed = (Path(__file__).parent.parent / "docs" / "rules.mdx").read_text()
+    assert committed == generate_rules_doc.generate()

--- a/tests/test_generate_rules_doc.py
+++ b/tests/test_generate_rules_doc.py
@@ -37,5 +37,5 @@ def test_single_trailing_newline():
 
 def test_committed_reference_matches_the_registry():
     """docs/rules.mdx must be regenerated whenever the registry changes."""
-    committed = (Path(__file__).parent.parent / "docs" / "rules.mdx").read_text()
+    committed = (Path(__file__).parent.parent / "docs" / "rules.mdx").read_text(encoding="utf-8")
     assert committed == generate_rules_doc.generate()

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,242 @@
+"""Tests for scripts/release.py — the release preflight and publish flow.
+
+The release script runs with real git/gh/network in production; here every
+external effect is stubbed so the decision logic is verified hermetically.
+"""
+
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+import urllib.error
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import release
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the script at a temporary repo root with a valid CHANGELOG."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "mcpscore"\nversion = "1.2.3"\n')
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [1.2.3] - 2026-07-10\n\nThe notes body.\n\n"
+        "## [1.2.2] - 2026-07-01\n\nOlder notes.\n\n"
+        "[1.2.3]: https://github.com/mcp-box/mcpscore/compare/v1.2.2...v1.2.3\n"
+        "[1.2.2]: https://github.com/mcp-box/mcpscore/releases/tag/v1.2.2\n"
+    )
+    monkeypatch.setattr(release, "ROOT", tmp_path)
+    return tmp_path
+
+
+class TestReadVersion:
+    def test_reads_project_version(self, repo: Path):
+        assert release.read_version() == "1.2.3"
+
+
+class TestCheckChangelog:
+    def test_extracts_the_matching_section(self, repo: Path):
+        assert release.check_changelog("1.2.3") == "The notes body."
+
+    def test_fails_without_a_section(self, repo: Path):
+        with pytest.raises(SystemExit):
+            release.check_changelog("9.9.9")
+
+    def test_fails_without_the_compare_link(self, repo: Path):
+        changelog = repo / "CHANGELOG.md"
+        changelog.write_text(changelog.read_text().replace("[1.2.3]: https://", "[nope]: https://"))
+        with pytest.raises(SystemExit):
+            release.check_changelog("1.2.3")
+
+
+class TestCheckGitState:
+    def _stub_run(self, monkeypatch: pytest.MonkeyPatch, responses: dict[str, str]) -> None:
+        def fake_run(*args: str, capture: bool = True) -> str:
+            return responses[" ".join(args)]
+
+        monkeypatch.setattr(release, "run", fake_run)
+
+    def test_passes_on_clean_synced_main(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_run(
+            monkeypatch,
+            {
+                "git branch --show-current": "main",
+                "git status --porcelain": "",
+                "git rev-parse HEAD": "abc123",
+                f"gh api repos/{release.REPO}/commits/main --jq .sha": "abc123",
+            },
+        )
+        assert release.check_git_state() == "abc123"
+
+    def test_fails_off_main(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_run(monkeypatch, {"git branch --show-current": "feature"})
+        with pytest.raises(SystemExit):
+            release.check_git_state()
+
+    def test_fails_on_dirty_tree(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_run(
+            monkeypatch,
+            {"git branch --show-current": "main", "git status --porcelain": " M file.py"},
+        )
+        with pytest.raises(SystemExit):
+            release.check_git_state()
+
+    def test_fails_when_out_of_sync_with_origin(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_run(
+            monkeypatch,
+            {
+                "git branch --show-current": "main",
+                "git status --porcelain": "",
+                "git rev-parse HEAD": "abc123",
+                f"gh api repos/{release.REPO}/commits/main --jq .sha": "def456",
+            },
+        )
+        with pytest.raises(SystemExit):
+            release.check_git_state()
+
+
+class TestCheckTagAbsent:
+    def _stub_gh(self, monkeypatch: pytest.MonkeyPatch, returncode: int, stderr: str = "") -> None:
+        def fake_subprocess_run(*args, **kwargs):
+            return SimpleNamespace(returncode=returncode, stdout="", stderr=stderr)
+
+        monkeypatch.setattr(subprocess, "run", fake_subprocess_run)
+
+    def test_absent_tag_passes(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_gh(monkeypatch, returncode=1, stderr="gh: Not Found (HTTP 404)")
+        release.check_tag_absent("1.2.3")  # must not raise
+
+    def test_existing_tag_fails(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_gh(monkeypatch, returncode=0)
+        with pytest.raises(SystemExit):
+            release.check_tag_absent("1.2.3")
+
+    def test_non_404_error_fails_instead_of_passing(self, monkeypatch: pytest.MonkeyPatch):
+        """An unauthenticated/rate-limited gh must not be mistaken for an absent tag."""
+        self._stub_gh(monkeypatch, returncode=1, stderr="gh: HTTP 401 Bad credentials")
+        with pytest.raises(SystemExit):
+            release.check_tag_absent("1.2.3")
+
+
+class TestCheckCiGreen:
+    def _stub_checks(self, monkeypatch: pytest.MonkeyPatch, runs: list[dict]) -> None:
+        import json
+
+        monkeypatch.setattr(release, "run", lambda *_args, **_kwargs: json.dumps(runs))
+
+    @staticmethod
+    def _run(name: str, conclusion: str, completed_at: str) -> dict:
+        return {
+            "name": name,
+            "status": "completed",
+            "conclusion": conclusion,
+            "started_at": completed_at,
+            "completed_at": completed_at,
+        }
+
+    def test_all_green_passes(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_checks(monkeypatch, [self._run("lint", "success", "2026-07-10T10:00:00Z")])
+        release.check_ci_green("abc123")  # must not raise
+
+    def test_failure_blocks(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_checks(monkeypatch, [self._run("test", "failure", "2026-07-10T10:00:00Z")])
+        with pytest.raises(SystemExit):
+            release.check_ci_green("abc123")
+
+    def test_stale_failed_run_is_superseded_by_newer_success(self, monkeypatch: pytest.MonkeyPatch):
+        """A re-run that succeeded must win over the older failed attempt."""
+        self._stub_checks(
+            monkeypatch,
+            [
+                self._run("test", "failure", "2026-07-10T10:00:00Z"),
+                self._run("test", "success", "2026-07-10T11:00:00Z"),
+            ],
+        )
+        release.check_ci_green("abc123")  # must not raise
+
+    def test_no_checks_blocks(self, monkeypatch: pytest.MonkeyPatch):
+        self._stub_checks(monkeypatch, [])
+        with pytest.raises(SystemExit):
+            release.check_ci_green("abc123")
+
+
+class TestCreateRelease:
+    def test_passes_validated_target_and_cleans_up_notes_file(self, monkeypatch: pytest.MonkeyPatch):
+        seen: dict = {}
+
+        def fake_run(*args: str, capture: bool = True) -> str:
+            seen["args"] = args
+            seen["notes_path"] = Path(args[args.index("--notes-file") + 1])
+            seen["notes_existed_during_run"] = seen["notes_path"].exists()
+            return ""
+
+        monkeypatch.setattr(release, "run", fake_run)
+        release.create_release("1.2.3", "notes body", target="abc123")
+
+        assert "--target" in seen["args"]
+        assert seen["args"][seen["args"].index("--target") + 1] == "abc123"
+        assert seen["notes_existed_during_run"] is True
+        assert not seen["notes_path"].exists()  # cleaned up afterwards
+
+    def test_notes_file_cleaned_up_even_when_gh_fails(self, monkeypatch: pytest.MonkeyPatch):
+        seen: dict = {}
+
+        def failing_run(*args: str, capture: bool = True) -> str:
+            seen["notes_path"] = Path(args[args.index("--notes-file") + 1])
+            raise SystemExit(1)
+
+        monkeypatch.setattr(release, "run", failing_run)
+        with pytest.raises(SystemExit):
+            release.create_release("1.2.3", "notes body", target="abc123")
+        assert not seen["notes_path"].exists()
+
+
+class TestWaitForPypi:
+    def test_returns_once_pypi_reports_the_version(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def getcode(self):
+                return 200
+
+        monkeypatch.setattr(release.urllib.request, "urlopen", lambda _url, **_kwargs: FakeResponse())
+        release.wait_for_pypi("1.2.3")  # must not raise
+
+    def test_times_out_when_version_never_appears(self, monkeypatch: pytest.MonkeyPatch):
+        def always_missing(url, timeout):
+            raise urllib.error.URLError("boom")
+
+        clock = iter(range(0, 10_000, 60))
+        monkeypatch.setattr(release.urllib.request, "urlopen", always_missing)
+        monkeypatch.setattr(release.time, "monotonic", lambda: next(clock))
+        monkeypatch.setattr(release.time, "sleep", lambda _seconds: None)
+        with pytest.raises(SystemExit):
+            release.wait_for_pypi("1.2.3")
+
+
+class TestMainDryRun:
+    def test_dry_run_checks_everything_and_creates_nothing(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        monkeypatch.setattr(sys, "argv", ["release.py", "--dry-run"])
+        monkeypatch.setattr(release, "check_git_state", lambda: "abc123")
+        monkeypatch.setattr(release, "check_tag_absent", lambda _version: None)
+        monkeypatch.setattr(release, "check_ci_green", lambda _sha: None)
+
+        def must_not_be_called(*args, **kwargs):
+            pytest.fail("create_release must not run in --dry-run")
+
+        monkeypatch.setattr(release, "create_release", must_not_be_called)
+        monkeypatch.setattr(release, "wait_for_pypi", must_not_be_called)
+
+        release.main()
+
+        out = capsys.readouterr().out
+        assert "dry run: all checks passed" in out
+        assert "The notes body." in out


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The release script can create GitHub releases and trigger PyPI publishing when run interactively; logic is heavily tested but production mistakes still depend on maintainer discipline and preflight checks.
> 
> **Overview**
> Adds **`scripts/release.py`** and **`make release`** / **`make release-dry-run`** to cut releases from `pyproject.toml`: preflight checks (clean synced `main`, CHANGELOG section + compare link, unused tag, green CI), optional confirmation, GitHub Release creation (triggering PyPI publish), and polling until the version appears on PyPI.
> 
> **CI and local `typecheck`** now run **pyright on `scripts/`** as well as `mcpscore/`. **`scripts/`** is no longer blanket-excluded from Ruff; maintainer scripts get targeted per-file ignores instead. Small cleanups: drop unnecessary `type: ignore` comments, `generate_rules_doc` uses `lines.extend` and explicit UTF-8 writes.
> 
> **Tests** cover the release preflight logic (stubbed git/gh/network) and rules doc generation (including committed `docs/rules.mdx` parity with the registry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7db4f4ce36487075e552e069582b48662f4a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->