### PR TITLE
Add a wrapper for npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,32 @@
+name: Publish npm
+
+# Publishes the npm wrapper (npm/) with OIDC Trusted Publishing + provenance.
+# Manual dispatch: the wrapper versions independently of the Python package
+# (it pins the Python version via package.json -> mcpscore.pythonVersion).
+#
+# One-time setup before this workflow can run: publish the first version
+# manually (`cd npm && npm publish --access public`), then on npmjs.com →
+# package Settings → Publishing access, add this repo + workflow file as a
+# Trusted Publisher.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish with provenance
+        working-directory: npm
+        run: npm publish --access public --provenance

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,6 +13,10 @@ server and get a scored, actionable report in seconds.
 uvx mcpscore https://your-server.example/mcp
 ```
 
+```bash npx (no install)
+npx mcpscore https://your-server.example/mcp
+```
+
 ```bash uv
 uv tool install mcpscore
 mcpscore https://your-server.example/mcp

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,30 @@
+# mcpscore
+
+**Lighthouse for MCP** — audit any [Model Context Protocol](https://modelcontextprotocol.io)
+server and get a scored, actionable report in seconds.
+
+```bash
+npx mcpscore https://your-server.example/mcp
+```
+
+This npm package is a thin wrapper around the Python
+[mcpscore](https://pypi.org/project/mcpscore/) CLI, pinned to the matching
+version — `npx mcpscore` and `uvx mcpscore` behave identically. It requires
+[uv](https://docs.astral.sh/uv/) or [pipx](https://pipx.pypa.io/) on your PATH
+(no packages are installed into your environment).
+
+## What you get
+
+- A severity-weighted quality score across protocol compliance, server
+  metadata, capabilities, tools, security, and transport — deterministic,
+  no API keys, CI-ready (`--json`).
+- A separate readiness score for the upcoming MCP spec revision
+  (2026-07-28, stateless lifecycle).
+- Actionable messages: every failed check says what to fix, and every rule
+  is anchored to the spec.
+
+## Documentation
+
+- [docs.mcpscore.dev](https://docs.mcpscore.dev) — quick start, scoring
+  methodology, full rules reference
+- [GitHub](https://github.com/mcp-box/mcpscore) — source, issues, contributing

--- a/npm/bin/mcpscore.js
+++ b/npm/bin/mcpscore.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// mcpscore npm wrapper: runs the Python mcpscore CLI at the exact version
+// this package pins (package.json -> mcpscore.pythonVersion), so
+// `npx mcpscore <target>` and `uvx mcpscore <target>` behave identically.
+//
+// Resolution order: uvx (uv) -> pipx. No implicit installs into the user's
+// environment; if neither runner exists, print clear instructions and exit 1.
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+
+const pkg = require("../package.json");
+const spec = `mcpscore==${pkg.mcpscore.pythonVersion}`;
+const args = process.argv.slice(2);
+
+/**
+ * Run the CLI through one Python runner; returns only if the runner is absent.
+ * @param {string} cmd - runner executable name
+ * @param {string[]} prefix - runner arguments placed before the mcpscore args
+ */
+function tryRun(cmd, prefix) {
+  const result = spawnSync(cmd, [...prefix, ...args], { stdio: "inherit" });
+  if (result.error) {
+    if (result.error.code === "ENOENT") return; // runner not installed — try the next one
+    console.error(`mcpscore: failed to run ${cmd}: ${result.error.message}`);
+    process.exit(1);
+  }
+  // Propagate the CLI's exit code (mcpscore's codes are a documented contract:
+  // 0 ok, 1 usage error, 2 connection failure).
+  process.exit(result.status === null ? 1 : result.status);
+}
+
+tryRun("uvx", [spec]);
+tryRun("pipx", ["run", spec]);
+
+console.error(
+  [
+    `mcpscore is a Python CLI (this npm package is a thin wrapper for ${spec}).`,
+    "It needs one of these Python runners on your PATH:",
+    "",
+    "  uv    https://docs.astral.sh/uv/  (then this command just works)",
+    "  pipx  https://pipx.pypa.io/",
+    "",
+    "Or install it directly:  pip install mcpscore",
+    "Docs: https://docs.mcpscore.dev",
+  ].join("\n"),
+);
+process.exit(1);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "mcpscore",
+  "version": "0.8.0",
+  "description": "Lighthouse for MCP — audit any MCP server and get a scored, actionable report in seconds. Node wrapper for the Python mcpscore CLI.",
+  "bin": {
+    "mcpscore": "bin/mcpscore.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT",
+  "author": "Alex Akimov",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcp-box/mcpscore.git",
+    "directory": "npm"
+  },
+  "homepage": "https://mcpscore.dev",
+  "bugs": "https://github.com/mcp-box/mcpscore/issues",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "mcp-server",
+    "audit",
+    "quality",
+    "lint",
+    "cli",
+    "score",
+    "compliance",
+    "developer-tools"
+  ],
+  "mcpscore": {
+    "pythonVersion": "0.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Distribution and documentation only; no changes to scoring, protocol handling, or Python CLI logic.
> 
> **Overview**
> Adds an **`npm/`** package so users can run **`npx mcpscore`** alongside existing **`uvx`** / pip installs. The **`bin/mcpscore.js`** entrypoint forwards argv to **`uvx mcpscore==<pinned>`** or **`pipx run`**, propagates CLI exit codes, and prints setup help when neither runner is on PATH. The pinned Python version lives in **`package.json`** under **`mcpscore.pythonVersion`** (independent from npm semver).
> 
> Docs **`index.mdx`** now documents the no-install **`npx`** quick-start. **`npm/README.md`** explains the wrapper behavior. A new **`.github/workflows/publish-npm.yml`** workflow supports **manual** npm publish with **OIDC trusted publishing** and **`--provenance`** (one-time npm trusted-publisher setup noted in comments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d0e64a661b2589ca77749d5d799ab7951e69cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->