### PR TITLE
Fix the package name

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,7 +14,7 @@ uvx mcpscore https://your-server.example/mcp
 ```
 
 ```bash npx (no install)
-npx mcpscore https://your-server.example/mcp
+npx @mcp-box/mcpscore https://your-server.example/mcp
 ```
 
 ```bash uv

--- a/npm/README.md
+++ b/npm/README.md
@@ -4,12 +4,12 @@
 server and get a scored, actionable report in seconds.
 
 ```bash
-npx mcpscore https://your-server.example/mcp
+npx @mcp-box/mcpscore https://your-server.example/mcp
 ```
 
 This npm package is a thin wrapper around the Python
 [mcpscore](https://pypi.org/project/mcpscore/) CLI, pinned to the matching
-version — `npx mcpscore` and `uvx mcpscore` behave identically. It requires
+version — `npx @mcp-box/mcpscore` and `uvx mcpscore` behave identically. It requires
 [uv](https://docs.astral.sh/uv/) or [pipx](https://pipx.pypa.io/) on your PATH
 (no packages are installed into your environment).
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mcpscore",
+  "name": "@mcp-box/mcpscore",
   "version": "0.8.0",
   "description": "Lighthouse for MCP — audit any MCP server and get a scored, actionable report in seconds. Node wrapper for the Python mcpscore CLI.",
   "bin": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped package rename and documentation only; no runtime or CLI behavior changes beyond the published npm name.
> 
> **Overview**
> Renames the npm package from **`mcpscore`** to the scoped **`@mcp-box/mcpscore`** in `npm/package.json`.
> 
> Docs and **`npm/README.md`** now tell users to run **`npx @mcp-box/mcpscore`** instead of **`npx mcpscore`**, including the note that it should match **`uvx mcpscore`**. The **`mcpscore`** binary name in `bin` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13175acd72d7dfc2245145f2d0ffb6460e13e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->