### PR TITLE
Unified publishing both to PyPi and npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,7 +20,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      # No dependency caching is enabled (the `cache:` input is omitted), so
+      # there is no cache to poison; the publish is OIDC + provenance built
+      # from the checked-out release source.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6  # zizmor: ignore[cache-poisoning]
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,14 +1,11 @@
 name: Publish npm
 
 # Publishes the npm wrapper (npm/) with OIDC Trusted Publishing + provenance.
-# Manual dispatch: the wrapper versions independently of the Python package
-# (it pins the Python version via package.json -> mcpscore.pythonVersion).
-#
-# One-time setup before this workflow can run: publish the first version
-# manually (`cd npm && npm publish --access public`), then on npmjs.com →
-# package Settings → Publishing access, add this repo + workflow file as a
-# Trusted Publisher.
+# Fires on a published GitHub Release (same event as the PyPI publish.yml, so
+# `make release` ships both registries), plus manual dispatch as a fallback.
 on:
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions: {}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,23 +1,25 @@
 #!/usr/bin/env python3
-"""Cut a release: create the GitHub Release that triggers PyPI publishing.
+"""Cut a release: create the GitHub Release that publishes to PyPI and npm.
 
 Usage:
-    uv run python scripts/release.py [--dry-run]
+    uv run python scripts/release.py [--dry-run] [--yes]
     make release          # same, with confirmation prompt
     make release-dry-run  # checks only, creates nothing
 
 The version to release is read from pyproject.toml. The script verifies the
 repo is actually releasable, extracts the CHANGELOG section as the release
-notes, and creates the GitHub Release (tag v<version>) — which triggers
-.github/workflows/publish.yml to build and publish to PyPI via Trusted
-Publishing. It then waits until the version is live on PyPI.
+notes, and creates the GitHub Release (tag v<version>) — which triggers both
+.github/workflows/publish.yml (PyPI) and publish-npm.yml (npm) via Trusted
+Publishing. It then waits until the version is live on both registries.
 
 Checks performed before anything is created:
   1. on `main`, clean working tree, local HEAD == origin/main
   2. CHANGELOG.md has a `## [<version>]` section AND the `[<version>]:`
      compare link at the bottom (the link block is easy to forget)
-  3. tag v<version> does not already exist on the remote
-  4. CI is green for HEAD
+  3. the npm wrapper (npm/package.json) version and its pinned Python version
+     both match pyproject.toml (so the wrapper never ships stale)
+  4. tag v<version> does not already exist on the remote
+  5. CI is green for HEAD
 
 Requires: git, gh (authenticated). No third-party Python dependencies.
 """
@@ -36,9 +38,10 @@ import urllib.error
 import urllib.request
 
 REPO = "mcp-box/mcpscore"
+NPM_PACKAGE = "@mcp-box/mcpscore"
 ROOT = Path(__file__).resolve().parent.parent
-PYPI_WAIT_SECONDS = 300
-PYPI_REQUEST_TIMEOUT_SECONDS = 15
+REGISTRY_WAIT_SECONDS = 300
+REGISTRY_REQUEST_TIMEOUT_SECONDS = 15
 
 
 def run(*args: str, capture: bool = True) -> str:
@@ -100,6 +103,24 @@ def check_changelog(version: str) -> str:
         fail(f"CHANGELOG.md is missing the '[{version}]: ...' compare link at the bottom")
     ok(f"CHANGELOG has the [{version}] section and compare link")
     return match.group(1).strip()
+
+
+def check_npm_version_sync(version: str) -> None:
+    """Verify the npm wrapper's version and its Python pin both match the release.
+
+    The wrapper is a thin shim over the Python CLI; if either its own version
+    or the mcpscore.pythonVersion it installs drifts from pyproject, `npx`
+    users get a different tool than `uvx` users. Fail fast rather than ship
+    that skew.
+    """
+    package_json = json.loads((ROOT / "npm" / "package.json").read_text(encoding="utf-8"))
+    wrapper_version = package_json.get("version")
+    pinned_python = package_json.get("mcpscore", {}).get("pythonVersion")
+    if wrapper_version != version:
+        fail(f"npm/package.json version is {wrapper_version}, expected {version} — bump the wrapper")
+    if pinned_python != version:
+        fail(f"npm/package.json mcpscore.pythonVersion is {pinned_python}, expected {version} — bump the pin")
+    ok(f"npm wrapper version and Python pin both match {version}")
 
 
 def check_tag_absent(version: str) -> None:
@@ -170,45 +191,80 @@ def create_release(version: str, notes: str, target: str) -> None:
     ok(f"GitHub Release v{version} created — publish workflow triggered")
 
 
-def wait_for_pypi(version: str) -> None:
-    url = f"https://pypi.org/pypi/mcpscore/{version}/json"
-    print(f"… waiting for mcpscore {version} on PyPI (up to {PYPI_WAIT_SECONDS}s)")
-    deadline = time.monotonic() + PYPI_WAIT_SECONDS
+def wait_for_registry(registry: str, url: str, workflow: str) -> None:
+    """Poll a registry until it reports the version, or fail after the deadline.
+
+    Args:
+        registry: Human name for messages (e.g. "PyPI", "npm").
+        url: Version endpoint that returns HTTP 200 once the version is live.
+        workflow: Publish workflow filename, cited if the wait times out.
+
+    """
+    print(f"… waiting for {registry} to report the release (up to {REGISTRY_WAIT_SECONDS}s)")
+    deadline = time.monotonic() + REGISTRY_WAIT_SECONDS
     while time.monotonic() < deadline:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             break
         try:
-            with urllib.request.urlopen(  # noqa: S310 — fixed https URL
+            with urllib.request.urlopen(  # noqa: S310 — fixed https registry URL
                 url,
-                timeout=min(PYPI_REQUEST_TIMEOUT_SECONDS, remaining),
+                timeout=min(REGISTRY_REQUEST_TIMEOUT_SECONDS, remaining),
             ) as response:
                 if response.getcode() == 200:
-                    ok(f"mcpscore {version} is live on PyPI")
-                    print(f"\nSmoke test:\n  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp")
+                    ok(f"live on {registry}")
                     return
         except (TimeoutError, urllib.error.URLError):
-            # Expected while PyPI propagates or during transient network errors; retry until timeout.
+            # Expected while the registry propagates or on transient network errors; retry until timeout.
             pass
         time.sleep(min(10, max(0, deadline - time.monotonic())))
     fail(
-        f"PyPI did not report {version} within {PYPI_WAIT_SECONDS}s — "
-        f"check the workflow: https://github.com/{REPO}/actions/workflows/publish.yml"
+        f"{registry} did not report the release within {REGISTRY_WAIT_SECONDS}s — "
+        f"check the workflow: https://github.com/{REPO}/actions/workflows/{workflow}"
     )
+
+
+def wait_for_publish(version: str) -> None:
+    """Wait for the release to appear on both PyPI and npm, then print a smoke test."""
+    wait_for_registry("PyPI", f"https://pypi.org/pypi/mcpscore/{version}/json", "publish.yml")
+    wait_for_registry("npm", f"https://registry.npmjs.org/{NPM_PACKAGE}/{version}", "publish-npm.yml")
+    print(
+        f"\nSmoke test:\n"
+        f"  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp\n"
+        f"  npx {NPM_PACKAGE}@{version} https://mcp.deepwiki.com/mcp"
+    )
+
+
+def _run_preflight(version: str) -> tuple[str, str]:
+    """Run every releasable-state check; return (head sha, release notes)."""
+    head = check_git_state()
+    notes = check_changelog(version)
+    check_npm_version_sync(version)
+    check_tag_absent(version)
+    check_ci_green(head)
+    return head, notes
+
+
+def _confirm(version: str) -> bool:
+    """Prompt for release confirmation; a closed stdin (EOF) counts as 'no'."""
+    try:
+        answer = input(f"Create GitHub Release v{version} and publish to PyPI + npm? [y/N] ")
+    except (EOFError, KeyboardInterrupt):
+        print("\naborted (no confirmation)")
+        return False
+    return answer.strip().lower() == "y"
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true", help="run all checks, create nothing")
+    parser.add_argument("--yes", action="store_true", help="skip the confirmation prompt (for non-interactive use)")
     args = parser.parse_args()
 
     version = read_version()
     print(f"Releasing mcpscore {version}\n")
 
-    head = check_git_state()
-    notes = check_changelog(version)
-    check_tag_absent(version)
-    check_ci_green(head)
+    head, notes = _run_preflight(version)
 
     print(f"\n--- release notes (from CHANGELOG) ---\n{notes}\n--------------------------------------\n")
 
@@ -216,17 +272,14 @@ def main() -> None:
         ok(f"dry run: all checks passed — would create release v{version}")
         return
 
-    answer = input(f"Create GitHub Release v{version} and publish to PyPI? [y/N] ")
-    if answer.strip().lower() != "y":
-        print("aborted")
+    if not args.yes and not _confirm(version):
         sys.exit(1)
 
-    head = check_git_state()
-    check_tag_absent(version)
-    check_ci_green(head)
+    # Re-check the fast-moving state in case main advanced during the prompt.
+    head, notes = _run_preflight(version)
 
     create_release(version, notes, head)
-    wait_for_pypi(version)
+    wait_for_publish(version)
 
 
 if __name__ == "__main__":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,7 +113,13 @@ def check_npm_version_sync(version: str) -> None:
     users get a different tool than `uvx` users. Fail fast rather than ship
     that skew.
     """
-    package_json = json.loads((ROOT / "npm" / "package.json").read_text(encoding="utf-8"))
+    path = ROOT / "npm" / "package.json"
+    try:
+        package_json = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"npm wrapper manifest not found: {path}")
+    except json.JSONDecodeError as e:
+        fail(f"npm/package.json is not valid JSON: {e}")
     wrapper_version = package_json.get("version")
     pinned_python = package_json.get("mcpscore", {}).get("pythonVersion")
     if wrapper_version != version:
@@ -219,15 +225,17 @@ def wait_for_registry(registry: str, url: str, workflow: str) -> None:
             pass
         time.sleep(min(10, max(0, deadline - time.monotonic())))
     fail(
-        f"{registry} did not report the release within {REGISTRY_WAIT_SECONDS}s — "
+        f"{registry} did not report the release within {REGISTRY_WAIT_SECONDS}s ({url}) — "
         f"check the workflow: https://github.com/{REPO}/actions/workflows/{workflow}"
     )
 
 
 def wait_for_publish(version: str) -> None:
     """Wait for the release to appear on both PyPI and npm, then print a smoke test."""
+    # npm requires the scope slash URL-encoded (%2F) — canonical registry form.
+    npm_path = NPM_PACKAGE.replace("/", "%2F")
     wait_for_registry("PyPI", f"https://pypi.org/pypi/mcpscore/{version}/json", "publish.yml")
-    wait_for_registry("npm", f"https://registry.npmjs.org/{NPM_PACKAGE}/{version}", "publish-npm.yml")
+    wait_for_registry("npm", f"https://registry.npmjs.org/{npm_path}/{version}", "publish-npm.yml")
     print(
         f"\nSmoke test:\n"
         f"  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp\n"

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -215,6 +215,16 @@ class TestCheckNpmVersionSync:
         with pytest.raises(SystemExit):
             release.check_npm_version_sync("1.2.3")
 
+    def test_fails_when_manifest_missing(self, repo: Path):
+        (repo / "npm" / "package.json").unlink()
+        with pytest.raises(SystemExit):
+            release.check_npm_version_sync("1.2.3")
+
+    def test_fails_on_invalid_json(self, repo: Path):
+        (repo / "npm" / "package.json").write_text("{ not valid json")
+        with pytest.raises(SystemExit):
+            release.check_npm_version_sync("1.2.3")
+
 
 class TestWaitForRegistry:
     def test_returns_once_registry_reports_the_version(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -18,7 +18,7 @@ import release
 
 @pytest.fixture
 def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point the script at a temporary repo root with a valid CHANGELOG."""
+    """Point the script at a temporary repo root with a valid CHANGELOG and npm wrapper."""
     (tmp_path / "pyproject.toml").write_text('[project]\nname = "mcpscore"\nversion = "1.2.3"\n')
     (tmp_path / "CHANGELOG.md").write_text(
         "# Changelog\n\n"
@@ -26,6 +26,10 @@ def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "## [1.2.2] - 2026-07-01\n\nOlder notes.\n\n"
         "[1.2.3]: https://github.com/mcp-box/mcpscore/compare/v1.2.2...v1.2.3\n"
         "[1.2.2]: https://github.com/mcp-box/mcpscore/releases/tag/v1.2.2\n"
+    )
+    (tmp_path / "npm").mkdir()
+    (tmp_path / "npm" / "package.json").write_text(
+        '{"name": "@mcp-box/mcpscore", "version": "1.2.3", "mcpscore": {"pythonVersion": "1.2.3"}}'
     )
     monkeypatch.setattr(release, "ROOT", tmp_path)
     return tmp_path
@@ -193,23 +197,42 @@ class TestCreateRelease:
         assert not seen["notes_path"].exists()
 
 
-class TestWaitForPypi:
-    def test_returns_once_pypi_reports_the_version(self, monkeypatch: pytest.MonkeyPatch):
+class TestCheckNpmVersionSync:
+    def test_passes_when_wrapper_and_pin_match(self, repo: Path):
+        release.check_npm_version_sync("1.2.3")  # must not raise
+
+    def test_fails_on_wrapper_version_drift(self, repo: Path):
+        (repo / "npm" / "package.json").write_text(
+            '{"name": "@mcp-box/mcpscore", "version": "1.2.2", "mcpscore": {"pythonVersion": "1.2.3"}}'
+        )
+        with pytest.raises(SystemExit):
+            release.check_npm_version_sync("1.2.3")
+
+    def test_fails_on_python_pin_drift(self, repo: Path):
+        (repo / "npm" / "package.json").write_text(
+            '{"name": "@mcp-box/mcpscore", "version": "1.2.3", "mcpscore": {"pythonVersion": "1.2.2"}}'
+        )
+        with pytest.raises(SystemExit):
+            release.check_npm_version_sync("1.2.3")
+
+
+class TestWaitForRegistry:
+    def test_returns_once_registry_reports_the_version(self, monkeypatch: pytest.MonkeyPatch):
         class FakeResponse:
             def __enter__(self):
                 return self
 
-            def __exit__(self, *args):
+            def __exit__(self, *_args):
                 return False
 
             def getcode(self):
                 return 200
 
         monkeypatch.setattr(release.urllib.request, "urlopen", lambda _url, **_kwargs: FakeResponse())
-        release.wait_for_pypi("1.2.3")  # must not raise
+        release.wait_for_registry("PyPI", "https://example/x", "publish.yml")  # must not raise
 
     def test_times_out_when_version_never_appears(self, monkeypatch: pytest.MonkeyPatch):
-        def always_missing(url, timeout):
+        def always_missing(_url, timeout=None):
             raise urllib.error.URLError("boom")
 
         clock = iter(range(0, 10_000, 60))
@@ -217,7 +240,13 @@ class TestWaitForPypi:
         monkeypatch.setattr(release.time, "monotonic", lambda: next(clock))
         monkeypatch.setattr(release.time, "sleep", lambda _seconds: None)
         with pytest.raises(SystemExit):
-            release.wait_for_pypi("1.2.3")
+            release.wait_for_registry("npm", "https://example/x", "publish-npm.yml")
+
+    def test_wait_for_publish_polls_both_registries(self, monkeypatch: pytest.MonkeyPatch):
+        polled: list[str] = []
+        monkeypatch.setattr(release, "wait_for_registry", lambda name, _url, _workflow: polled.append(name))
+        release.wait_for_publish("1.2.3")
+        assert polled == ["PyPI", "npm"]
 
 
 class TestMainDryRun:
@@ -229,14 +258,47 @@ class TestMainDryRun:
         monkeypatch.setattr(release, "check_tag_absent", lambda _version: None)
         monkeypatch.setattr(release, "check_ci_green", lambda _sha: None)
 
-        def must_not_be_called(*args, **kwargs):
+        def must_not_be_called(*_args, **_kwargs):
             pytest.fail("create_release must not run in --dry-run")
 
         monkeypatch.setattr(release, "create_release", must_not_be_called)
-        monkeypatch.setattr(release, "wait_for_pypi", must_not_be_called)
+        monkeypatch.setattr(release, "wait_for_publish", must_not_be_called)
 
         release.main()
 
         out = capsys.readouterr().out
         assert "dry run: all checks passed" in out
-        assert "The notes body." in out
+        assert "npm wrapper version and Python pin both match" in out
+
+    def test_yes_flag_skips_prompt_and_publishes(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        monkeypatch.setattr(sys, "argv", ["release.py", "--yes"])
+        monkeypatch.setattr(release, "check_git_state", lambda: "abc123")
+        monkeypatch.setattr(release, "check_tag_absent", lambda _version: None)
+        monkeypatch.setattr(release, "check_ci_green", lambda _sha: None)
+
+        created: list[str] = []
+        monkeypatch.setattr(release, "create_release", lambda _version, _notes, target: created.append(target))
+        monkeypatch.setattr(release, "wait_for_publish", lambda _version: None)
+
+        def no_prompt(*_args, **_kwargs):
+            pytest.fail("--yes must not prompt")
+
+        monkeypatch.setattr("builtins.input", no_prompt)
+
+        release.main()
+        assert created == ["abc123"]
+
+    def test_eof_at_prompt_aborts_cleanly(self, repo: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(sys, "argv", ["release.py"])
+        monkeypatch.setattr(release, "check_git_state", lambda: "abc123")
+        monkeypatch.setattr(release, "check_tag_absent", lambda _version: None)
+        monkeypatch.setattr(release, "check_ci_green", lambda _sha: None)
+
+        def raise_eof(_prompt):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", raise_eof)
+        with pytest.raises(SystemExit):
+            release.main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes release automation and publishing triggers; mistakes could ship version-skewed npm wrappers or block releases, but checks and tests reduce that risk.
> 
> **Overview**
> **`make release` now ships PyPI and npm together** by triggering `publish-npm.yml` on `release: published` (matching `publish.yml`), with manual dispatch kept as a fallback. The npm workflow comment documents why `setup-node` omits caching (zizmor cache-poisoning note).
> 
> **`scripts/release.py`** is extended so a single GitHub Release drives both registries: preflight adds **`check_npm_version_sync`** (wrapper `version` and `mcpscore.pythonVersion` must match `pyproject.toml`), post-release polling uses generic **`wait_for_registry`** / **`wait_for_publish`** for PyPI and npm, and the confirmation prompt mentions both registries. **`--yes`** skips the prompt for non-interactive runs; preflight runs again after confirmation in case `main` moved.
> 
> **Tests** cover npm sync failures, dual-registry wait, `--yes`, and EOF-at-prompt abort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a05fbf5de13add3d21fd18b37989cb59c2a119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->