### PR TITLE
Updated AGENTS.md

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,7 +3,9 @@ name: Canary
 # Daily run against the newest resolvable dependencies, so upstream breakage
 # (MCP SDK, httpx, pydantic, ...) is caught before users hit it. A second lane
 # tracks the mcp 2.x betas ahead of the 2026-07-28 spec-final SDK release; it
-# is advisory (continue-on-error) until mcpscore targets SDK v2.
+# is advisory (continue-on-error) until mcpscore targets SDK v2. A third lane
+# runs the latest zizmor (CI pins it) so new workflow audits surface here
+# instead of failing unrelated PRs.
 on:
   schedule:
     - cron: "0 5 * * *"
@@ -27,6 +29,19 @@ jobs:
         run: uv sync --all-groups --upgrade
       - run: uv run pyright mcpscore/
       - run: uv run pytest -q
+
+  zizmor-latest:
+    name: Latest zizmor workflow audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+      - name: Audit workflows with the latest zizmor
+        run: uvx zizmor --no-progress .github/workflows/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   mcp-sdk-v2-beta:
     name: mcp SDK 2.x beta (advisory)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
         with:
           python-version: "3.13"
       - name: Audit workflows with zizmor
-        run: uvx zizmor --no-progress .github/workflows/
+        # Pinned so new zizmor audits can't fail PRs on unchanged code; the canary
+        # workflow runs the latest zizmor to surface new findings on a schedule.
+        run: uvx zizmor==1.27.0 --no-progress .github/workflows/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           uv run python scripts/generate_rules_doc.py
           git diff --exit-code docs/rules.mdx
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
       - name: Check for broken links

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,7 +23,7 @@ jobs:
       # No dependency caching is enabled (the `cache:` input is omitted), so
       # there is no cache to poison; the publish is OIDC + provenance built
       # from the checked-out release source.
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6  # zizmor: ignore[cache-poisoning]
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0  # zizmor: ignore[cache-poisoning]
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,32 @@
   format). Docstrings: imperative first line, ≤120-char lines.
 - Do not commit to `main`; work on a branch. Do not add strategy or planning documents
   to this repository — it is public.
+
+## Gotchas (learned the hard way)
+
+- **Imports inside the package**: `reportImportCycles` is on, so `from mcpscore import spec`
+  inside `mcpscore/rules/` is flagged as a cycle through `__init__.py` even though it runs.
+  Import submodules directly (`from mcpscore.spec import ...`), matching the existing
+  `from mcpscore.enums import ...` pattern.
+- **Unit tests must stay hermetic**: any new network phase in `MCPAuditor.audit()` silently
+  makes tests using `https://example.com` URLs hit the live network. Tripwire: a sudden
+  pytest wall-time jump (0.6s → 5s+) is a network leak until proven otherwise. Fix pattern:
+  autouse conftest fixture stubbing the runner at the consuming module's attribute
+  (`monkeypatch.setattr(mcp_auditor, "run_all_probes", ...)`); tests needing real probe
+  behavior re-patch or inject an `httpx.MockTransport` client.
+- **`MagicMock(spec=SomeClass)` exposes only class-level attributes** — instance attributes
+  assigned in `__init__` (e.g. `MCPAuditor.audit_data`) raise `AttributeError`; assign them
+  on the mock explicitly. Corollary: adding a method to a spec'd class makes existing mocks
+  auto-create it returning a truthy `MagicMock` — check tests whose behavior that flips.
+- **Always pass `encoding="utf-8"`** to `read_text`/`write_text`/temp files — Windows
+  defaults to the locale codepage and the 3-OS CI matrix exists to catch exactly this.
+- **Rule details vs payload**: large payloads (tools lists, DiscoverResult) go in
+  `ProbeResult.payload`, excluded from `to_dict()`. Spreading `**probe.details` into rule
+  results puts everything in the JSON report — keep `details` small.
+- **Spec citations**: don't trust secondary sources — the MCP blog's own RC summary was
+  wrong twice vs the spec text, and error codes were renumbered after the RC lock. Cite the
+  spec section each rule enforces and re-verify citations against the dated spec URL when a
+  revision goes final.
+- **Zero-behavior-change refactors need a live invariant**: re-audit the same live server
+  (`uv run mcpscore https://mcp.deepwiki.com/mcp`) before and after; the score must be
+  identical.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are CI pinning, advisory canary auditing, and contributor documentation; no application runtime or security logic changes.
> 
> **Overview**
> **CI workflow security** now runs **pinned** `zizmor==1.27.0` so new upstream audit rules do not fail PRs on unchanged workflows. The **canary** workflow gains a **`zizmor-latest`** job that audits `.github/workflows/` with unpinned `uvx zizmor` on the daily schedule, so new findings surface there instead of blocking unrelated changes.
> 
> **AGENTS.md** adds a **Gotchas** section covering import cycles in `mcpscore/rules/`, keeping unit tests hermetic when `MCPAuditor.audit()` grows network phases, `MagicMock(spec=...)` pitfalls, UTF-8 on file I/O, keeping rule `details` small vs `ProbeResult.payload`, verifying MCP spec citations, and live re-audit invariants for refactors.
> 
> Minor workflow comment tweaks label `actions/setup-node` as **v6.4.0** in docs and npm publish workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf5d838d6dd547c6deedaf270111620205a4b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->