### PR TITLE
Pin the mcp package version below 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bounded runtime dependencies below their upcoming majors (`mcp>=1.28.1,<2`,
+  `httpx>=0.28.1,<1`). MCP Python SDK 2.0 (a breaking rework that replaces
+  `httpx` with the separate `httpx2` package) is expected to go stable alongside
+  the 2026-07-28 spec release; without the bound, fresh installs would resolve to
+  it and break. Migration to SDK v2 is planned separately.
+
 ## [0.8.0] - 2026-07-10
 
 **Preview of MCP 2026-07-28 support.** This release audits servers on every spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
-    "mcp>=1.28.1",
-    "httpx>=0.28.1",
+    "mcp>=1.28.1,<2",
+    "httpx>=0.28.1,<1",
     "httpx-sse>=0.4.3",
     "jsonschema>=4.21",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -437,10 +437,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "httpx-sse", specifier = ">=0.4.3" },
     { name = "jsonschema", specifier = ">=4.21" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency metadata and lockfile only; no application code changes, and the caps preserve the existing resolved versions.
> 
> **Overview**
> **Caps runtime dependencies** so fresh installs stay on MCP Python SDK 1.x and `httpx` 0.x: `mcp>=1.28.1,<2` and `httpx>=0.28.1,<1` in `pyproject.toml`, with matching `uv.lock` metadata.
> 
> This is a **preventive** change ahead of MCP SDK 2.0 (breaking rework, including a move away from `httpx` toward `httpx2`). Without the upper bound, resolvers could pull 2.x and break mcpscore’s current `mcp`/`httpx` client usage. The **[Unreleased]** changelog entry documents the rationale; SDK v2 migration is called out as separate work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96335eeb1db7e34b1c9824459fa30f718550d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->