### PR TITLE
Prepare for the 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-19
+
 ### Changed
 
 - Bounded runtime dependencies below their upcoming majors (`mcp>=1.28.1,<2`,
@@ -214,7 +216,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/mcp-box/mcpscore/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mcp-box/mcpscore/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mcp-box/mcpscore/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mcp-box/mcpscore/compare/v0.5.1...v0.6.0

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-box/mcpscore",
-  "version": "0.8.0",
-  "description": "Lighthouse for MCP — audit any MCP server and get a scored, actionable report in seconds. Node wrapper for the Python mcpscore CLI.",
+  "version": "0.9.0",
+  "description": "Lighthouse for MCP \u2014 audit any MCP server and get a scored, actionable report in seconds. Node wrapper for the Python mcpscore CLI.",
   "bin": {
     "mcpscore": "bin/mcpscore.js"
   },
@@ -33,7 +33,7 @@
     "developer-tools"
   ],
   "mcpscore": {
-    "pythonVersion": "0.8.0"
+    "pythonVersion": "0.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "0.8.0"
+version = "0.9.0"
 description = "CLI tool to analyze your MCP server and get a comprehensive report on its quality"
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime code modifications.
> 
> **Overview**
> **Release bookkeeping for v0.9.0** — bumps package versions and finalizes the changelog for publish; no application logic changes in this diff.
> 
> Version identifiers move from **0.8.0** to **0.9.0** in `pyproject.toml`, `npm/package.json` (including `mcpscore.pythonVersion`), and `uv.lock`. The changelog adds a dated **[0.9.0] - 2026-07-19** section documenting **bounded runtime deps** (`mcp>=1.28.1,<2`, `httpx>=0.28.1,<1`) and updates GitHub compare links so `[Unreleased]` points at `v0.9.0...HEAD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626aff1f4f9980a01b878cf9ccc5f56c2fed058f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->