### PR TITLE
Fix the npm package for the 0.9.0 release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,9 +33,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       # Node 22 bundles npm 10.x, but OIDC Trusted Publishing needs npm >=
       # 11.5.1. Without it, npm authenticates with setup-node's placeholder
-      # token and the registry rejects the publish with E404.
+      # token and the registry rejects the publish with E404. Exact-pinned
+      # official npm package — deterministic, no lockfile to install from.
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@11
+        run: npm install -g npm@11.18.0  # zizmor: ignore[adhoc-packages]
       - name: Publish with provenance
         working-directory: npm
         run: npm publish --access public --provenance

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,6 +13,10 @@ permissions: {}
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # PyPI pre-releases (PEP 440 versions like 1.1.0b1) are not valid npm
+    # semver and ship without the npm wrapper — skip npm for GitHub Releases
+    # marked "pre-release". Manual dispatch still always publishes.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
     permissions:
       contents: read
       id-token: write
@@ -27,6 +31,11 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
+      # Node 22 bundles npm 10.x, but OIDC Trusted Publishing needs npm >=
+      # 11.5.1. Without it, npm authenticates with setup-node's placeholder
+      # token and the registry rejects the publish with E404.
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@11
       - name: Publish with provenance
         working-directory: npm
         run: npm publish --access public --provenance

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -17,7 +17,9 @@ Checks performed before anything is created:
   2. CHANGELOG.md has a `## [<version>]` section AND the `[<version>]:`
      compare link at the bottom (the link block is easy to forget)
   3. the npm wrapper (npm/package.json) version and its pinned Python version
-     both match pyproject.toml (so the wrapper never ships stale)
+     both match pyproject.toml (so the wrapper never ships stale) — skipped
+     for PEP 440 pre-releases (e.g. 1.1.0b1), which publish to PyPI only: the
+     GitHub Release is marked pre-release and publish-npm.yml skips those
   4. tag v<version> does not already exist on the remote
   5. CI is green for HEAD
 
@@ -73,6 +75,17 @@ def ok(message: str) -> None:
 def read_version() -> str:
     with (ROOT / "pyproject.toml").open("rb") as f:
         return tomllib.load(f)["project"]["version"]
+
+
+def is_prerelease(version: str) -> bool:
+    """Whether the version is a PEP 440 pre-release (e.g. 1.1.0b1).
+
+    Pre-releases publish to PyPI only: their versions are not valid npm
+    semver, so the npm wrapper sits releases like these out entirely — no
+    version-sync check, a GitHub Release marked pre-release (which
+    publish-npm.yml skips), and no npm registry wait.
+    """
+    return re.search(r"\d(a|b|rc)\d+$", version) is not None
 
 
 def check_git_state() -> str:
@@ -176,6 +189,9 @@ def create_release(version: str, notes: str, target: str) -> None:
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
         f.write(notes + "\n")
         notes_file = f.name
+    # A pre-release must never become the repo's "latest" release, and the
+    # --prerelease flag is what publish-npm.yml keys off to skip npm.
+    flag = "--prerelease" if is_prerelease(version) else "--latest"
     try:
         run(
             "gh",
@@ -190,7 +206,7 @@ def create_release(version: str, notes: str, target: str) -> None:
             f"v{version}",
             "--notes-file",
             notes_file,
-            "--latest",
+            flag,
         )
     finally:
         Path(notes_file).unlink(missing_ok=True)
@@ -231,10 +247,14 @@ def wait_for_registry(registry: str, url: str, workflow: str) -> None:
 
 
 def wait_for_publish(version: str) -> None:
-    """Wait for the release to appear on both PyPI and npm, then print a smoke test."""
+    """Wait for the release to appear on each targeted registry, then print a smoke test."""
+    wait_for_registry("PyPI", f"https://pypi.org/pypi/mcpscore/{version}/json", "publish.yml")
+    if is_prerelease(version):
+        ok("npm skipped (pre-release publishes to PyPI only)")
+        print(f"\nSmoke test:\n  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp")
+        return
     # npm requires the scope slash URL-encoded (%2F) — canonical registry form.
     npm_path = NPM_PACKAGE.replace("/", "%2F")
-    wait_for_registry("PyPI", f"https://pypi.org/pypi/mcpscore/{version}/json", "publish.yml")
     wait_for_registry("npm", f"https://registry.npmjs.org/{npm_path}/{version}", "publish-npm.yml")
     print(
         f"\nSmoke test:\n"
@@ -247,7 +267,10 @@ def _run_preflight(version: str) -> tuple[str, str]:
     """Run every releasable-state check; return (head sha, release notes)."""
     head = check_git_state()
     notes = check_changelog(version)
-    check_npm_version_sync(version)
+    if is_prerelease(version):
+        ok(f"npm version sync skipped ({version} is a pre-release — PyPI only)")
+    else:
+        check_npm_version_sync(version)
     check_tag_absent(version)
     check_ci_green(head)
     return head, notes
@@ -255,8 +278,9 @@ def _run_preflight(version: str) -> tuple[str, str]:
 
 def _confirm(version: str) -> bool:
     """Prompt for release confirmation; a closed stdin (EOF) counts as 'no'."""
+    registries = "PyPI only (pre-release)" if is_prerelease(version) else "PyPI + npm"
     try:
-        answer = input(f"Create GitHub Release v{version} and publish to PyPI + npm? [y/N] ")
+        answer = input(f"Create GitHub Release v{version} and publish to {registries}? [y/N] ")
     except (EOFError, KeyboardInterrupt):
         print("\naborted (no confirmation)")
         return False


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches release automation and npm OIDC publishing paths; mistakes could block or mis-route releases, but runtime product code is unchanged.
> 
> **Overview**
> **Fixes npm publishing** by upgrading the workflow’s npm to **11.18.0** before `npm publish --provenance`. Node 22’s bundled npm 10.x doesn’t satisfy OIDC Trusted Publishing (needs ≥11.5.1), which led to failed publishes (registry **E404**).
> 
> **Aligns pre-releases with PyPI-only shipping:** PEP 440 versions (e.g. `1.1.0b1`) aren’t valid npm semver, so **`publish-npm.yml`** now skips jobs when the GitHub release is marked pre-release (manual `workflow_dispatch` still publishes). **`scripts/release.py`** detects pre-releases, skips npm wrapper version sync, creates releases with **`--prerelease`** instead of **`--latest`**, waits only on PyPI, and updates prompts/smoke-test output accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ec5b0778d96a9921c4eeaf0314b975b089d607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->