### PR TITLE
Adding support for the MCP SDK v2, preparing a new release

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -19,7 +19,7 @@ jobs:
     name: Latest dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -34,7 +34,7 @@ jobs:
     name: Latest zizmor workflow audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -51,7 +51,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -69,7 +69,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       # No dependency caching is enabled (the `cache:` input is omitted), so

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ document they need is unreachable, avoiding double-counting one defect.
 
 ### Fixed
 
+- Auth-posture messages no longer hard-code "401": the WWW-Authenticate and
+  challenge-metadata rules report the observed HTTP status (401 or 403), and
+  `auth_www_authenticate`'s display name is now "Auth - WWW-Authenticate
+  Challenge" (rule_id unchanged).
+- A partial audit now distinguishes missing credentials from rejected ones:
+  when `--token`/`--header` were provided and the server still answered
+  401/403, the log and `partial_reason` say the credentials were rejected and
+  suggest verifying them, instead of advising to pass a token.
 - The unauthenticated auth-posture probe no longer crashes against a server
   that returns a 401 with an RFC 6750 OAuth error body (a JSON object whose
   `error` field is a string like `"invalid_token"`, not a JSON-RPC error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0b1] - Unreleased
+
+**Pre-release: engine migrated to MCP Python SDK v2 (beta).** Published as a
+PyPI pre-release only — plain `pip install mcpscore` keeps resolving the stable
+0.x line until SDK 2.0 goes stable. Audit output is unchanged: the same live
+server audited before and after the migration produces an identical report
+(score and all rule results).
+
+### Changed
+
+- Migrated from MCP Python SDK v1 to `mcp==2.0.0b2` (exact pin — SDK
+  pre-releases may break each other, so each mcpscore beta pins the SDK beta it
+  was verified against).
+- HTTP stack switched from `httpx`/`httpx-sse` to `httpx2` (the SDK v2 HTTP
+  client) for both the MCP transports and the readiness probes. TLS is now
+  validated against the OS trust store (via `truststore`) instead of certifi's
+  bundle.
+- Report messages and details keep the MCP spec's wire field names (e.g.
+  `listChanged`) even though SDK v2 renamed Python attributes to snake_case —
+  the report schema is a public contract and does not follow SDK naming.
+
+### Removed
+
+- The `mcp>=1.28.1,<2` / `httpx>=0.28.1,<1` bounds added in 0.9.0 (this
+  line tracks SDK v2 directly; the bounds remain correct for the stable 0.x
+  line).
+
+## [0.9.0] - Unreleased
+
 ### Changed
 
 - Bounded runtime dependencies below their upcoming majors (`mcp>=1.28.1,<2`,
@@ -214,7 +243,9 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b1...HEAD
+[1.1.0b1]: https://github.com/mcp-box/mcpscore/compare/v0.9.0...v1.1.0b1
+[0.9.0]: https://github.com/mcp-box/mcpscore/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mcp-box/mcpscore/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mcp-box/mcpscore/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mcp-box/mcpscore/compare/v0.5.1...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0b2] - 2026-07-20
+
+**Pre-release: auth-gated audits and new rules on the SDK v2 line.** Published
+as a PyPI pre-release only (`uvx --prerelease=allow mcpscore==1.1.0b2 …`); plain
+`pip install mcpscore` keeps resolving the stable 0.x line.
+
 ### Added
 
 **Authenticated and partial audits of auth-gated servers** — production MCP
@@ -289,7 +295,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b1...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b2...HEAD
+[1.1.0b2]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b1...v1.1.0b2
 [1.1.0b1]: https://github.com/mcp-box/mcpscore/compare/v0.9.0...v1.1.0b1
 [0.9.0]: https://github.com/mcp-box/mcpscore/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mcp-box/mcpscore/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ document they need is unreachable, avoiding double-counting one defect.
   error now identifies the bad argument by position (`--header #2: …`).
 - The "custom header(s)" log line no longer says "for authentication" —
   `--header` is also valid for non-auth headers.
+- The report's `authenticated` flag is now set only when an Authorization
+  credential was sent (`--token` or an explicit `Authorization` header) —
+  previously any custom header marked the audit authenticated.
 - Auth-posture messages no longer hard-code "401": the WWW-Authenticate and
   challenge-metadata rules report the observed HTTP status (401 or 403), and
   `auth_www_authenticate`'s display name is now "Auth - WWW-Authenticate
@@ -353,7 +356,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b2...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b3...HEAD
+[1.1.0b3]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b2...v1.1.0b3
 [1.1.0b2]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b1...v1.1.0b2
 [1.1.0b1]: https://github.com/mcp-box/mcpscore/compare/v0.9.0...v1.1.0b1
 [0.9.0]: https://github.com/mcp-box/mcpscore/compare/v0.8.0...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ document they need is unreachable, avoiding double-counting one defect.
 - The report's `authenticated` flag is now set only when an Authorization
   credential was sent (`--token` or an explicit `Authorization` header) —
   previously any custom header marked the audit authenticated.
+- The auth-posture rules' `details["basis"]` now carries a per-rule,
+  section-level citation (e.g. `RFC 9728 §5.1`) instead of one broad string
+  shared across rules, matching the readiness rules' per-rule SEP citations.
+- The CLI now releases client resources on every exit path: the modern-only
+  and partial-audit early returns and the connection-failure exit previously
+  bypassed the cleanup that closes the client's exit stack.
 - Auth-posture messages no longer hard-code "401": the WWW-Authenticate and
   challenge-metadata rules report the observed HTTP status (401 or 403), and
   `auth_www_authenticate`'s display name is now "Auth - WWW-Authenticate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Deeper auth-posture rules** — the auth-discovery probe now follows the chain
+from the RFC 9728 protected-resource metadata to the first authorization
+server's RFC 8414 metadata, enabling five new credential-free rules that score
+a gated server's authorization surface:
+
+- `auth_server_metadata_pkce` (Security, HIGH): the authorization server
+  advertises PKCE with S256 (`code_challenge_methods_supported`), as required
+  by the OAuth security BCP (RFC 9700) and the MCP authorization spec.
+- `auth_server_metadata_present` (Security, HIGH): the authorization server's
+  RFC 8414 metadata is reachable and advertises the authorization and token
+  endpoints (OpenID `/.well-known/openid-configuration` is accepted as a
+  fallback location).
+- `auth_challenge_references_metadata` (Security, MEDIUM): the 401
+  `WWW-Authenticate` header carries a `resource_metadata` parameter that points
+  at the protected-resource metadata (RFC 9728 §5.1).
+- `auth_metadata_https` (Security, MEDIUM): the protected-resource metadata URL
+  and its `resource` identifier use HTTPS.
+- `auth_scopes_advertised` (Security, LOW): the metadata advertises
+  `scopes_supported` so clients can request least privilege.
+
+Like the existing auth-posture rules, all five run credential-free (including
+in a partial audit of a gated server) and skip rather than fail when the
+document they need is unreachable, avoiding double-counting one defect.
+
+### Fixed
+
+- The unauthenticated auth-posture probe no longer crashes against a server
+  that returns a 401 with an RFC 6750 OAuth error body (a JSON object whose
+  `error` field is a string like `"invalid_token"`, not a JSON-RPC error
+  object). Such a body is now correctly treated as having no JSON-RPC error,
+  so the auth-posture rules score normally instead of the probe erroring out.
+
 ## [1.1.0b2] - 2026-07-20
 
 **Pre-release: auth-gated audits and new rules on the SDK v2 line.** Published

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**Authenticated and partial audits of auth-gated servers** — production MCP
+servers behind OAuth 2.x can now be audited:
+
+- `--token <TOKEN>` sends `Authorization: Bearer <TOKEN>`; `--header 'Name: Value'`
+  (repeatable) sends arbitrary headers for API-key or custom-auth servers. Both
+  also read from the `MCPSCORE_TOKEN` environment variable (CI-friendly). Header
+  and token values are never logged or written to the report — only an
+  `authenticated` boolean is recorded.
+- **Partial audit**: an auth-gated (HTTP 401/403) server audited *without* a
+  token no longer exits with an error. Instead the observable surface — the
+  auth-posture rules, TLS, and transport — is scored, session-dependent rules
+  are skipped as `insufficient-data`, and the report is flagged `partial` (with
+  `partial_reason`). A partial score is not comparable to a full audit's.
+- Report gains `authenticated`, `partial`, and `partial_reason` fields.
+
 **Auth-posture rules** — the first rules that score auth-gated servers (which
 previously could not be audited at all). All observations are read-only; the
 rules skip as not-applicable for servers that serve anonymous requests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,8 @@ document they need is unreachable, avoiding double-counting one defect.
   Challenge" (rule_id unchanged).
 - A partial audit now distinguishes missing credentials from rejected ones:
   when an Authorization credential was sent (`--token` or an explicit
-  `Authorization` header — the same predicate as the report's `authenticated`
-  flag) and the server still answered 401/403, the log and `partial_reason`
+  non-blank `Authorization` header — the same predicate as the report's
+  `authenticated` flag) and the server still answered 401/403, the log and `partial_reason`
   say the credentials were rejected and suggest verifying them, instead of
   advising to pass a token. Non-auth custom headers (e.g. tracing) get the
   missing-credential guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,12 +243,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-<<<<<<< HEAD
 [Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b1...HEAD
 [1.1.0b1]: https://github.com/mcp-box/mcpscore/compare/v0.9.0...v1.1.0b1
-=======
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v0.9.0...HEAD
->>>>>>> origin/main
 [0.9.0]: https://github.com/mcp-box/mcpscore/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mcp-box/mcpscore/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mcp-box/mcpscore/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Auth-posture rules** — the first rules that score auth-gated servers (which
+previously could not be audited at all). All observations are read-only; the
+rules skip as not-applicable for servers that serve anonymous requests:
+
+- New probe `probe_auth_metadata`: fetches RFC 9728 protected resource
+  metadata from its well-known locations (path-aware form first, then
+  origin root).
+- `auth_www_authenticate` (Security, HIGH): 401 responses must carry a
+  `WWW-Authenticate` challenge.
+- `auth_protected_resource_metadata` (Security, HIGH): the RFC 9728 metadata
+  document exists and its `resource` names this server.
+- `auth_authorization_servers_https` (Security, HIGH): the metadata lists at
+  least one authorization server and every entry uses HTTPS (skipped when the
+  metadata document is absent — that is the previous rule's finding).
+
+**Metadata completeness and consistency rules** (2025-11-25 fields; skipped
+for servers on older spec revisions):
+
+- `server_websiteurl_present` (Server Info, LOW): `serverInfo.websiteUrl`
+  is present.
+- `server_icons_present` (Server Info, LOW): the server declares icons and
+  every icon `src` is an `https://` or `data:` URI.
+- `tools_execution_consistent` (Tools, MEDIUM): tools declaring
+  task-augmented execution (`execution.taskSupport` of `optional`/`required`)
+  require the server to declare the `tasks` capability.
+
+Spec citations for the auth rules reference the MCP Authorization spec and
+RFC 9728; re-verify against the dated spec URL at the 2026-07-28 release.
+
 ## [1.1.0b1] - 2026-07-19
 
 **Pre-release: engine migrated to MCP Python SDK v2 (beta).** Published as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,12 @@ document they need is unreachable, avoiding double-counting one defect.
   `auth_www_authenticate`'s display name is now "Auth - WWW-Authenticate
   Challenge" (rule_id unchanged).
 - A partial audit now distinguishes missing credentials from rejected ones:
-  when `--token`/`--header` were provided and the server still answered
-  401/403, the log and `partial_reason` say the credentials were rejected and
-  suggest verifying them, instead of advising to pass a token.
+  when an Authorization credential was sent (`--token` or an explicit
+  `Authorization` header — the same predicate as the report's `authenticated`
+  flag) and the server still answered 401/403, the log and `partial_reason`
+  say the credentials were rejected and suggest verifying them, instead of
+  advising to pass a token. Non-auth custom headers (e.g. tracing) get the
+  missing-credential guidance.
 - The unauthenticated auth-posture probe no longer crashes against a server
   that returns a 401 with an RFC 6750 OAuth error body (a JSON object whose
   `error` field is a string like `"invalid_token"`, not a JSON-RPC error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ document they need is unreachable, avoiding double-counting one defect.
 
 ### Fixed
 
+- **Anonymous probes no longer carry any caller-supplied headers.** The
+  unauthenticated-behavior probe and the auth-metadata discovery fetches now
+  run on a separate HTTP client with none of the `--header` values (previously
+  only `Authorization` was stripped): a non-Authorization credential such as an
+  API key or cookie could defeat the unauthenticated observation, and RFC 8414
+  discovery can leave the server's origin for the authorization server's — no
+  caller credential belongs on those requests.
+- A malformed `--header` value (e.g. a missing colon) is no longer echoed in
+  the error message, which is logged — the value may be a mistyped secret. The
+  error now identifies the bad argument by position (`--header #2: …`).
+- The "custom header(s)" log line no longer says "for authentication" —
+  `--header` is also valid for non-auth headers.
 - Auth-posture messages no longer hard-code "401": the WWW-Authenticate and
   challenge-metadata rules report the observed HTTP status (401 or 403), and
   `auth_www_authenticate`'s display name is now "Auth - WWW-Authenticate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0b3] - 2026-07-22
+
+**Pre-release: deeper auth-posture rules on the SDK v2 line.** Published as a
+PyPI pre-release only (`uvx --prerelease=allow mcpscore==1.1.0b3 …`); plain
+`pip install mcpscore` keeps resolving the stable 0.x line.
 
 ### Added
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -57,7 +57,26 @@ mcpscore https://example.com/mcp
 
 # Machine-readable report for CI
 mcpscore https://example.com/mcp --json > report.json
+
+# Auth-gated servers: pass a token to audit behind the gate
+mcpscore https://example.com/mcp --token "$MY_TOKEN"
+mcpscore https://example.com/mcp --header "Authorization: Bearer $MY_TOKEN"
 ```
+
+## Auditing auth-gated servers
+
+Many production MCP servers require OAuth 2.x. mcpscore handles them two ways:
+
+- **Without a token**, an auth-gated server still gets a **partial audit** — the
+  authorization posture (`WWW-Authenticate` on 401, RFC 9728 protected-resource
+  metadata, HTTPS authorization servers), TLS, and transport are scored. The
+  report is marked `partial` and its score is not comparable to a full audit's.
+- **With a token**, mcpscore audits behind the gate like any client. Pass
+  `--token <TOKEN>` (sent as `Authorization: Bearer …`) or an arbitrary
+  `--header 'Name: Value'` (repeatable, for API-key or custom-auth servers).
+  For CI, set `MCPSCORE_TOKEN` in the environment to keep tokens out of shell
+  history. Token and header values are never logged or written to the report —
+  only an `authenticated` flag is recorded.
 
 Example output tail:
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -76,7 +76,8 @@ Many production MCP servers require OAuth 2.x. mcpscore handles them two ways:
   `--header 'Name: Value'` (repeatable, for API-key or custom-auth servers).
   For CI, set `MCPSCORE_TOKEN` in the environment to keep tokens out of shell
   history. Token and header values are never logged or written to the report —
-  only an `authenticated` flag is recorded.
+  only an `authenticated` flag is recorded (set when an Authorization
+  credential was sent; other custom headers do not set it).
 
 Example output tail:
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -52,7 +52,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `security_tls_enabled` | HTTPS/TLS Enabled | CRITICAL | 5 | all versions |
 | `security_malformed_request_handling` | Malformed Request Handling | MEDIUM | 2 | all versions |
 | `security_error_data_leak` | No Sensitive Data in Error Messages | MEDIUM | 2 | all versions |
-| `auth_www_authenticate` | Auth - 401 Carries WWW-Authenticate | HIGH | 3 | 2025-06-18 – … |
+| `auth_www_authenticate` | Auth - WWW-Authenticate Challenge | HIGH | 3 | 2025-06-18 – … |
 | `auth_protected_resource_metadata` | Auth - Protected Resource Metadata | HIGH | 3 | 2025-06-18 – … |
 | `auth_authorization_servers_https` | Auth - Authorization Servers Present and HTTPS | HIGH | 3 | 2025-06-18 – … |
 | `auth_challenge_references_metadata` | Auth - Challenge References Resource Metadata | MEDIUM | 2 | 2025-06-18 – … |

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -29,6 +29,8 @@ Every rule mcpscore runs, generated from the rule registry
 | `server_version_present` | Server Info - Version Present | HIGH | 3 | all versions |
 | `server_title_present` | Server Info - Title Present | MEDIUM | 2 | all versions |
 | `server_instructions_present` | Server Info - Instructions Present | LOW | 1 | all versions |
+| `server_websiteurl_present` | Server Info - Website URL Present | LOW | 1 | 2025-11-25 – … |
+| `server_icons_present` | Server Info - Icons Present and Valid | LOW | 1 | 2025-11-25 – … |
 
 ## Capabilities
 
@@ -50,6 +52,9 @@ Every rule mcpscore runs, generated from the rule registry
 | `security_tls_enabled` | HTTPS/TLS Enabled | CRITICAL | 5 | all versions |
 | `security_malformed_request_handling` | Malformed Request Handling | MEDIUM | 2 | all versions |
 | `security_error_data_leak` | No Sensitive Data in Error Messages | MEDIUM | 2 | all versions |
+| `auth_www_authenticate` | Auth - 401 Carries WWW-Authenticate | HIGH | 3 | 2025-06-18 – … |
+| `auth_protected_resource_metadata` | Auth - Protected Resource Metadata | HIGH | 3 | 2025-06-18 – … |
+| `auth_authorization_servers_https` | Auth - Authorization Servers Present and HTTPS | HIGH | 3 | 2025-06-18 – … |
 
 ## Tools
 
@@ -64,6 +69,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `tools_input_schema_valid` | Tools - All tools must have a valid input schema | HIGH | 3 | all versions |
 | `tools_output_schema_valid` | Tools - All tools must have a valid output schema | HIGH | 3 | all versions |
 | `tools_annotations_present` | Tools - All tools should declare behavior annotations | MEDIUM | 2 | all versions |
+| `tools_execution_consistent` | Tools - Task Execution Backed by Tasks Capability | MEDIUM | 2 | 2025-11-25 – … |
 
 ## Transport
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -55,6 +55,11 @@ Every rule mcpscore runs, generated from the rule registry
 | `auth_www_authenticate` | Auth - 401 Carries WWW-Authenticate | HIGH | 3 | 2025-06-18 – … |
 | `auth_protected_resource_metadata` | Auth - Protected Resource Metadata | HIGH | 3 | 2025-06-18 – … |
 | `auth_authorization_servers_https` | Auth - Authorization Servers Present and HTTPS | HIGH | 3 | 2025-06-18 – … |
+| `auth_challenge_references_metadata` | Auth - Challenge References Resource Metadata | MEDIUM | 2 | 2025-06-18 – … |
+| `auth_metadata_https` | Auth - Resource Metadata Uses HTTPS | MEDIUM | 2 | 2025-06-18 – … |
+| `auth_scopes_advertised` | Auth - Scopes Advertised | LOW | 1 | 2025-06-18 – … |
+| `auth_server_metadata_present` | Auth - Authorization Server Metadata Present | HIGH | 3 | 2025-06-18 – … |
+| `auth_server_metadata_pkce` | Auth - Authorization Server Enforces PKCE (S256) | HIGH | 3 | 2025-06-18 – … |
 
 ## Tools
 

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 from mcpscore import MCPAuditor, MCPClient
 from mcpscore.enums import ConnectionErrorReason
+from mcpscore.mcp_auditor import has_authorization_credential
 
 if TYPE_CHECKING:
     from mcpscore import MCPTransportType
@@ -262,7 +263,11 @@ async def async_main() -> None:
                     status = failure.status_code or (
                         401 if failure.reason is ConnectionErrorReason.UNAUTHORIZED else 403
                     )
-                    if headers:
+                    # Key off the same predicate as the report's authenticated
+                    # flag: only an Authorization credential counts — a 401
+                    # with only tracing/custom headers is a missing credential,
+                    # not a rejected one.
+                    if has_authorization_credential(headers):
                         logger.info(
                             "Server rejected the provided credentials — "
                             "running a partial audit of the observable surface."

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -250,13 +250,23 @@ async def async_main() -> None:
                 ConnectionErrorReason.UNAUTHORIZED,
                 ConnectionErrorReason.FORBIDDEN,
             ):
-                logger.info("Server requires authentication — running a partial audit of the observable surface.")
-                logger.info("(Pass a token with --token or --header to audit behind the gate.)")
                 status = failure.status_code or (401 if failure.reason is ConnectionErrorReason.UNAUTHORIZED else 403)
-                partial_reason = (
-                    f"Server requires authentication (HTTP {status}); scored the unauthenticated surface "
-                    "only — pass a token to audit behind the gate."
-                )
+                if headers:
+                    logger.info(
+                        "Server rejected the provided credentials — running a partial audit of the observable surface."
+                    )
+                    logger.info("(Check that the --token/--header credentials are valid for this server.)")
+                    partial_reason = (
+                        f"Server rejected the provided credentials (HTTP {status}); scored the unauthenticated "
+                        "surface only — check that the token or headers are valid for this server."
+                    )
+                else:
+                    logger.info("Server requires authentication — running a partial audit of the observable surface.")
+                    logger.info("(Pass a token with --token or --header to audit behind the gate.)")
+                    partial_reason = (
+                        f"Server requires authentication (HTTP {status}); scored the unauthenticated surface "
+                        "only — pass a token to audit behind the gate."
+                    )
                 await auditor.audit_partial(args.target, reason=partial_reason)
                 log_audit_outcome(auditor)
                 if args.json:

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -91,12 +91,14 @@ def parse_header(raw: str) -> tuple[str, str]:
         The (name, value) tuple, both stripped.
 
     Raises:
-        ValueError: If there is no colon separating name and value.
+        ValueError: If there is no colon separating name and value. The
+            malformed input is deliberately not echoed — header values may
+            carry secrets and the error text is logged.
 
     """
     name, sep, value = raw.partition(":")
     if not sep or not name.strip():
-        raise ValueError(f"invalid header (expected 'Name: Value'): {raw!r}")
+        raise ValueError("invalid header (expected 'Name: Value'; the value is not shown — headers may carry secrets)")
     return name.strip(), value.strip()
 
 
@@ -118,8 +120,11 @@ def collect_headers(args: argparse.Namespace) -> dict[str, str]:
 
     """
     headers: dict[str, str] = {}
-    for raw in args.header or []:
-        name, value = parse_header(raw)
+    for position, raw in enumerate(args.header or [], start=1):
+        try:
+            name, value = parse_header(raw)
+        except ValueError as e:
+            raise ValueError(f"--header #{position}: {e}") from None
         headers[name] = value
     token = args.token or os.environ.get("MCPSCORE_TOKEN")
     if token and not any(name.lower() == "authorization" for name in headers):
@@ -225,7 +230,7 @@ async def async_main() -> None:
         sys.exit(1)
 
     if headers:
-        logger.info("Using %d custom header(s) for authentication.", len(headers))
+        logger.info("Using %d custom header(s).", len(headers))
 
     client: MCPClient = MCPClient(headers=headers or None)
     auditor: MCPAuditor = MCPAuditor(headers=headers or None)

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -235,56 +235,64 @@ async def async_main() -> None:
     client: MCPClient = MCPClient(headers=headers or None)
     auditor: MCPAuditor = MCPAuditor(headers=headers or None)
 
-    success, transport = await client.detect_and_connect(args.target)
-
-    if not success:
-        if args.target.startswith(("http://", "https://")):
-            logger.info("Legacy connection failed — checking for a modern-only (stateless lifecycle) MCP server...")
-            if await auditor.audit_modern_only(args.target):
-                logger.info(
-                    "Modern-only MCP server detected: audited via stateless probes (no legacy session available)."
-                )
-                log_audit_outcome(auditor)
-                if args.json:
-                    report = build_report(args.target, auditor.audit_data.transport_type, auditor)
-                    sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
-                return
-
-            failure = client.last_connection_error
-            if failure is not None and failure.reason in (
-                ConnectionErrorReason.UNAUTHORIZED,
-                ConnectionErrorReason.FORBIDDEN,
-            ):
-                status = failure.status_code or (401 if failure.reason is ConnectionErrorReason.UNAUTHORIZED else 403)
-                if headers:
-                    logger.info(
-                        "Server rejected the provided credentials — running a partial audit of the observable surface."
-                    )
-                    logger.info("(Check that the --token/--header credentials are valid for this server.)")
-                    partial_reason = (
-                        f"Server rejected the provided credentials (HTTP {status}); scored the unauthenticated "
-                        "surface only — check that the token or headers are valid for this server."
-                    )
-                else:
-                    logger.info("Server requires authentication — running a partial audit of the observable surface.")
-                    logger.info("(Pass a token with --token or --header to audit behind the gate.)")
-                    partial_reason = (
-                        f"Server requires authentication (HTTP {status}); scored the unauthenticated surface "
-                        "only — pass a token to audit behind the gate."
-                    )
-                await auditor.audit_partial(args.target, reason=partial_reason)
-                log_audit_outcome(auditor)
-                if args.json:
-                    report = build_report(args.target, auditor.audit_data.transport_type, auditor)
-                    sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
-                return
-        logger.error("Error connecting to the MCP server: %s", args.target)
-        sys.exit(2)
-
-    logger.info("Connected to the MCP server: %s", args.target)
-    logger.info("Transport: %s", transport)
-
+    # Everything below runs inside one try/finally: failed detection attempts
+    # can leave resources on the client's exit stack, so every path out —
+    # early returns, sys.exit(2), audit errors — must reach cleanup().
     try:
+        success, transport = await client.detect_and_connect(args.target)
+
+        if not success:
+            if args.target.startswith(("http://", "https://")):
+                logger.info("Legacy connection failed — checking for a modern-only (stateless lifecycle) MCP server...")
+                if await auditor.audit_modern_only(args.target):
+                    logger.info(
+                        "Modern-only MCP server detected: audited via stateless probes (no legacy session available)."
+                    )
+                    log_audit_outcome(auditor)
+                    if args.json:
+                        report = build_report(args.target, auditor.audit_data.transport_type, auditor)
+                        sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
+                    return
+
+                failure = client.last_connection_error
+                if failure is not None and failure.reason in (
+                    ConnectionErrorReason.UNAUTHORIZED,
+                    ConnectionErrorReason.FORBIDDEN,
+                ):
+                    status = failure.status_code or (
+                        401 if failure.reason is ConnectionErrorReason.UNAUTHORIZED else 403
+                    )
+                    if headers:
+                        logger.info(
+                            "Server rejected the provided credentials — "
+                            "running a partial audit of the observable surface."
+                        )
+                        logger.info("(Check that the --token/--header credentials are valid for this server.)")
+                        partial_reason = (
+                            f"Server rejected the provided credentials (HTTP {status}); scored the unauthenticated "
+                            "surface only — check that the token or headers are valid for this server."
+                        )
+                    else:
+                        logger.info(
+                            "Server requires authentication — running a partial audit of the observable surface."
+                        )
+                        logger.info("(Pass a token with --token or --header to audit behind the gate.)")
+                        partial_reason = (
+                            f"Server requires authentication (HTTP {status}); scored the unauthenticated surface "
+                            "only — pass a token to audit behind the gate."
+                        )
+                    await auditor.audit_partial(args.target, reason=partial_reason)
+                    log_audit_outcome(auditor)
+                    if args.json:
+                        report = build_report(args.target, auditor.audit_data.transport_type, auditor)
+                        sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
+                    return
+            logger.error("Error connecting to the MCP server: %s", args.target)
+            sys.exit(2)
+
+        logger.info("Connected to the MCP server: %s", args.target)
+        logger.info("Transport: %s", transport)
+
         logger.info("Starting the audit...")
         await auditor.audit(client)
         log_audit_outcome(auditor)

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -252,7 +252,12 @@ async def async_main() -> None:
             ):
                 logger.info("Server requires authentication — running a partial audit of the observable surface.")
                 logger.info("(Pass a token with --token or --header to audit behind the gate.)")
-                await auditor.audit_partial(args.target, reason=failure.message)
+                status = failure.status_code or (401 if failure.reason is ConnectionErrorReason.UNAUTHORIZED else 403)
+                partial_reason = (
+                    f"Server requires authentication (HTTP {status}); scored the unauthenticated surface "
+                    "only — pass a token to audit behind the gate."
+                )
+                await auditor.audit_partial(args.target, reason=partial_reason)
                 log_audit_outcome(auditor)
                 if args.json:
                     report = build_report(args.target, auditor.audit_data.transport_type, auditor)

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -8,10 +8,12 @@ from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
 import json
 import logging
+import os
 import sys
 from typing import TYPE_CHECKING, NoReturn
 
 from mcpscore import MCPAuditor, MCPClient
+from mcpscore.enums import ConnectionErrorReason
 
 if TYPE_CHECKING:
     from mcpscore import MCPTransportType
@@ -59,7 +61,70 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit a machine-readable JSON report to stdout (logs go to stderr)",
     )
+    parser.add_argument(
+        "--header",
+        action="append",
+        metavar="'Name: Value'",
+        help=(
+            "Extra HTTP header sent to the server, e.g. --header 'Authorization: Bearer <token>' "
+            "to audit an auth-gated server. Repeatable. Header values are never logged or reported."
+        ),
+    )
+    parser.add_argument(
+        "--token",
+        metavar="TOKEN",
+        help=(
+            "Convenience for --header 'Authorization: Bearer <TOKEN>'. "
+            "Defaults to the MCPSCORE_TOKEN environment variable (keeps tokens out of shell history)."
+        ),
+    )
     return parser
+
+
+def parse_header(raw: str) -> tuple[str, str]:
+    """Parse a ``Name: Value`` header string into a (name, value) pair.
+
+    Args:
+        raw: A header in ``Name: Value`` form.
+
+    Returns:
+        The (name, value) tuple, both stripped.
+
+    Raises:
+        ValueError: If there is no colon separating name and value.
+
+    """
+    name, sep, value = raw.partition(":")
+    if not sep or not name.strip():
+        raise ValueError(f"invalid header (expected 'Name: Value'): {raw!r}")
+    return name.strip(), value.strip()
+
+
+def collect_headers(args: argparse.Namespace) -> dict[str, str]:
+    """Build the request-header dict from --header, --token, and MCPSCORE_TOKEN.
+
+    Precedence: explicit --header entries first, then a bearer from --token or
+    the MCPSCORE_TOKEN env var (an explicit Authorization header is not
+    overwritten).
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        A header dict (possibly empty).
+
+    Raises:
+        ValueError: If a --header value is malformed.
+
+    """
+    headers: dict[str, str] = {}
+    for raw in args.header or []:
+        name, value = parse_header(raw)
+        headers[name] = value
+    token = args.token or os.environ.get("MCPSCORE_TOKEN")
+    if token and not any(name.lower() == "authorization" for name in headers):
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 
 def _mcpscore_version() -> str:
@@ -82,6 +147,9 @@ def log_audit_outcome(auditor: MCPAuditor) -> None:
     readiness = report["readiness"]
 
     logger.info("")
+    if report["partial"]:
+        logger.info("⚠️  Partial audit (%s).", report["partial_reason"])
+        logger.info("Only the auth, TLS, and transport surface was scored — not comparable to a full audit.")
     logger.info("Audit finished. Final score: %s/%s", report["score"], report["max_score"])
     logger.info(
         "Spec: %s negotiated (latest: %s) · era: %s",
@@ -150,8 +218,17 @@ async def async_main() -> None:
 
     args = build_parser().parse_args()
 
-    client: MCPClient = MCPClient()
-    auditor: MCPAuditor = MCPAuditor()
+    try:
+        headers = collect_headers(args)
+    except ValueError as e:
+        logger.error("Usage error: %s", e)  # noqa: TRY400 — usage error, not an exception to trace
+        sys.exit(1)
+
+    if headers:
+        logger.info("Using %d custom header(s) for authentication.", len(headers))
+
+    client: MCPClient = MCPClient(headers=headers or None)
+    auditor: MCPAuditor = MCPAuditor(headers=headers or None)
 
     success, transport = await client.detect_and_connect(args.target)
 
@@ -162,6 +239,20 @@ async def async_main() -> None:
                 logger.info(
                     "Modern-only MCP server detected: audited via stateless probes (no legacy session available)."
                 )
+                log_audit_outcome(auditor)
+                if args.json:
+                    report = build_report(args.target, auditor.audit_data.transport_type, auditor)
+                    sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
+                return
+
+            failure = client.last_connection_error
+            if failure is not None and failure.reason in (
+                ConnectionErrorReason.UNAUTHORIZED,
+                ConnectionErrorReason.FORBIDDEN,
+            ):
+                logger.info("Server requires authentication — running a partial audit of the observable surface.")
+                logger.info("(Pass a token with --token or --header to audit behind the gate.)")
+                await auditor.audit_partial(args.target, reason=failure.message)
                 log_audit_outcome(auditor)
                 if args.json:
                     report = build_report(args.target, auditor.audit_data.transport_type, auditor)

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -28,13 +28,6 @@ logger = logging.getLogger(__name__)
 TLS_PROBE_TIMEOUT_S = 10
 """Timeout for probing the negotiated TLS version of an HTTPS server."""
 
-_SESSION_FIELDS = frozenset(
-    {"protocol_version", "server_info", "capabilities", "tools", "resources", "prompts", "instructions"}
-)
-"""AuditData fields that come from a server session (vs. probe/transport data).
-A partial audit lacks all of these, so rules depending solely on them are
-skipped rather than failed (see _skipped_for_partial)."""
-
 
 class MCPAuditor:
     """Orchestrates the MCP server audit process.
@@ -208,7 +201,9 @@ class MCPAuditor:
         self.audit_data.partial = True
         self.audit_data.partial_reason = reason
         self.audit_data.url = url
-        self.audit_data.transport_type = MCPTransportType.STREAMABLE_HTTP
+        # No session connected, so the transport is not verified — leave it
+        # None. The transport rule skips rather than claiming a transport we
+        # could not confirm (see StreamableHTTPTransportRule.skip_reason).
         self.audit_data.probes = await run_all_probes(url, headers=self.headers)
         if url.startswith("https://"):
             # The probes reached the server over HTTPS with certificate
@@ -276,18 +271,19 @@ class MCPAuditor:
     def _skipped_for_partial(self, rule: BaseRule) -> bool:
         """Whether a rule must be skipped in a partial audit (no server session).
 
-        In a partial audit only probe-derived rules can run. A rule is skipped
-        when it depends *solely* on session-derived data (via its @requires_*
-        decorator) and all of that data is absent — so it cannot judge and must
-        not fail the server for a missing observation. Rules needing probe- or
-        transport-derived data (url, tls, probes) or the full AuditData run
-        normally; their own logic/skip_reason handles missing pieces.
+        A partial audit never established a session, so any rule whose every
+        ``@requires_*`` field went uncollected (all ``None``) cannot judge and
+        must be skipped as insufficient-data — otherwise it would pass or fail
+        the server on absent data (e.g. the error-response rules auto-pass on a
+        missing observation, inflating the partial score). Rules that still
+        have data to work with (e.g. TLS, which has the url) run normally, and
+        full-data rules (auth-posture) gate themselves via skip_reason.
         """
         if not self.audit_data.partial:
             return False
         requires = getattr(rule.check, "_requires", None)
         names: tuple[str, ...] = (requires,) if isinstance(requires, str) else tuple(requires or ())
-        if not names or not all(name in _SESSION_FIELDS for name in names):
+        if not names or "full_data" in names:
             return False
         return all(getattr(self.audit_data, name, None) is None for name in names)
 

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -20,13 +20,20 @@ from .probes import (
     run_all_probes,
 )
 from .rules import AuditData, BaseRule, RuleResult, RuleSeverity, SkippedRule, create_all_rules
-from .rules.base import READINESS_GROUP, SKIP_REASON_NOT_APPLICABLE
+from .rules.base import READINESS_GROUP, SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
 from .spec import DRAFT, LATEST, Era
 
 logger = logging.getLogger(__name__)
 
 TLS_PROBE_TIMEOUT_S = 10
 """Timeout for probing the negotiated TLS version of an HTTPS server."""
+
+_SESSION_FIELDS = frozenset(
+    {"protocol_version", "server_info", "capabilities", "tools", "resources", "prompts", "instructions"}
+)
+"""AuditData fields that come from a server session (vs. probe/transport data).
+A partial audit lacks all of these, so rules depending solely on them are
+skipped rather than failed (see _skipped_for_partial)."""
 
 
 class MCPAuditor:
@@ -42,16 +49,25 @@ class MCPAuditor:
     aspects of MCP compliance and contributes to an overall audit score.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
         """Initialize a new MCPAuditor instance.
+
+        Args:
+            headers: Extra HTTP headers for the sessionless probe phase, e.g.
+                an ``Authorization`` bearer to probe an auth-gated server.
+                Should match the headers passed to the MCPClient. Sensitive —
+                never logged or included in the report (only the boolean
+                ``authenticated`` flag is reported).
 
         Sets up the auditor with:
         - Empty audit data container
         - All registered audit rules
         - Zero initial score
         - Empty results list
+
         """
         super().__init__()
+        self.headers: dict[str, str] | None = headers or None
         self.mcp_client: MCPClient | None = None
         self.audit_data: AuditData = AuditData()
         self.score: int = 0
@@ -142,7 +158,7 @@ class MCPAuditor:
         if not url.startswith(("http://", "https://")):
             return False
 
-        probes = await run_all_probes(url)
+        probes = await run_all_probes(url, headers=self.headers)
         if not has_modern_support(probes):
             return False
 
@@ -162,6 +178,49 @@ class MCPAuditor:
 
         self._populate_from_probe_payloads()
         self.era = detect_era(None, probes)
+        self._run_all_rules()
+        return True
+
+    async def audit_partial(self, url: str, reason: str) -> bool:
+        """Run a partial audit of an HTTP server without a server session.
+
+        For a server that could not be connected to and shows no modern
+        support (typically because it is auth-gated), this still scores the
+        rules observable without a session: the auth-posture, TLS, transport,
+        and discovery rules. Session-dependent rules (server info,
+        capabilities, tools, resources, prompts) are skipped as
+        insufficient-data rather than failed — the report is marked partial and
+        its score is NOT comparable to a full audit's.
+
+        Args:
+            url: The MCP endpoint URL (http:// or https://)
+            reason: Human-readable reason the full audit was not possible
+                (e.g. the connection failure message), recorded in the report.
+
+        Returns:
+            True when the partial audit ran; False for a non-HTTP url.
+
+        """
+        if not url.startswith(("http://", "https://")):
+            return False
+
+        self._reset_run_state()
+        self.audit_data.partial = True
+        self.audit_data.partial_reason = reason
+        self.audit_data.url = url
+        self.audit_data.transport_type = MCPTransportType.STREAMABLE_HTTP
+        self.audit_data.probes = await run_all_probes(url, headers=self.headers)
+        if url.startswith("https://"):
+            # The probes reached the server over HTTPS with certificate
+            # verification (httpx default), so TLS is verified even though no
+            # MCP session was established.
+            self.audit_data.tls_verified = True
+            self.audit_data.tls_version = await self._probe_tls_version(url)
+        else:
+            self.audit_data.tls_verified = False
+            self.audit_data.tls_version = None
+
+        self.era = detect_era(None, self.audit_data.probes)
         self._run_all_rules()
         return True
 
@@ -214,6 +273,24 @@ class MCPAuditor:
             logger.info("Could not parse %s from probe payload: %s", model.__name__, e)
             return None
 
+    def _skipped_for_partial(self, rule: BaseRule) -> bool:
+        """Whether a rule must be skipped in a partial audit (no server session).
+
+        In a partial audit only probe-derived rules can run. A rule is skipped
+        when it depends *solely* on session-derived data (via its @requires_*
+        decorator) and all of that data is absent — so it cannot judge and must
+        not fail the server for a missing observation. Rules needing probe- or
+        transport-derived data (url, tls, probes) or the full AuditData run
+        normally; their own logic/skip_reason handles missing pieces.
+        """
+        if not self.audit_data.partial:
+            return False
+        requires = getattr(rule.check, "_requires", None)
+        names: tuple[str, ...] = (requires,) if isinstance(requires, str) else tuple(requires or ())
+        if not names or not all(name in _SESSION_FIELDS for name in names):
+            return False
+        return all(getattr(self.audit_data, name, None) is None for name in names)
+
     def _run_all_rules(self) -> None:
         """Execute all applicable audit rules and update the audit score.
 
@@ -244,6 +321,8 @@ class MCPAuditor:
             skip_reason: str | None = None
             if not rule.applies_to(self.audit_data.protocol_version):
                 skip_reason = SKIP_REASON_NOT_APPLICABLE
+            elif self._skipped_for_partial(rule):
+                skip_reason = SKIP_REASON_INSUFFICIENT_DATA
             else:
                 skip_reason = rule.skip_reason(self.audit_data)
 
@@ -351,7 +430,7 @@ class MCPAuditor:
             self.audit_data.probes = not_applicable_results(reason="probes require an HTTP(S) transport")
             return
 
-        self.audit_data.probes = await run_all_probes(url)
+        self.audit_data.probes = await run_all_probes(url, headers=self.headers)
 
     async def _collect_init_result(self) -> None:
         """Collect initialization data from the MCP server.
@@ -453,6 +532,15 @@ class MCPAuditor:
         return {
             "score": self.score,
             "max_score": self.max_score,
+            # True when the audit was run with caller-supplied auth headers.
+            # Only the flag is reported — header values are never included.
+            "authenticated": self.headers is not None,
+            # A partial audit ran without a server session (e.g. an auth-gated
+            # server): only probe-derived rules scored; session-dependent rules
+            # were skipped as insufficient-data. The score is NOT comparable to
+            # a full audit's — partial_reason says why.
+            "partial": self.audit_data.partial,
+            "partial_reason": self.audit_data.partial_reason,
             "summary": self.get_audit_summary(),
             "results": [res.to_dict() for res in self.results],
             "skipped_rules": [s.to_dict() for s in self.skipped_rules],

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -29,6 +29,16 @@ TLS_PROBE_TIMEOUT_S = 10
 """Timeout for probing the negotiated TLS version of an HTTPS server."""
 
 
+def has_authorization_credential(headers: dict[str, str] | None) -> bool:
+    """Whether the header set carries an Authorization credential.
+
+    The single predicate behind both the report's ``authenticated`` flag and
+    the CLI's rejected-credentials messaging — other custom headers (tracing,
+    API keys we cannot classify) never count as an auth credential.
+    """
+    return any(name.lower() == "authorization" for name in (headers or {}))
+
+
 class MCPAuditor:
     """Orchestrates the MCP server audit process.
 
@@ -532,7 +542,7 @@ class MCPAuditor:
             # an explicit Authorization --header). Other custom headers (e.g.
             # tracing) do not mark the audit authenticated. Only the flag is
             # reported — header values are never included.
-            "authenticated": any(name.lower() == "authorization" for name in (self.headers or {})),
+            "authenticated": has_authorization_credential(self.headers),
             # A partial audit ran without a server session (e.g. an auth-gated
             # server): only probe-derived rules scored; session-dependent rules
             # were skipped as insufficient-data. The score is NOT comparable to

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -30,13 +30,14 @@ TLS_PROBE_TIMEOUT_S = 10
 
 
 def has_authorization_credential(headers: dict[str, str] | None) -> bool:
-    """Whether the header set carries an Authorization credential.
+    """Whether the header set carries a non-blank Authorization credential.
 
     The single predicate behind both the report's ``authenticated`` flag and
     the CLI's rejected-credentials messaging — other custom headers (tracing,
-    API keys we cannot classify) never count as an auth credential.
+    API keys we cannot classify) never count as an auth credential, and a
+    blank value (e.g. ``--header 'Authorization:'``) is no credential either.
     """
-    return any(name.lower() == "authorization" for name in (headers or {}))
+    return any(name.lower() == "authorization" and value.strip() for name, value in (headers or {}).items())
 
 
 class MCPAuditor:

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
-    from mcp.types import InitializeResult, Prompt, Resource, Tool
+    from mcp_types import InitializeResult, Prompt, Resource, Tool
 
 from pydantic import ValidationError
 
@@ -173,7 +173,7 @@ class MCPAuditor:
         parse stays None — the corresponding rules then report it missing,
         which is accurate from the client's perspective.
         """
-        from mcp.types import Implementation, ServerCapabilities, Tool
+        from mcp_types import Implementation, ServerCapabilities, Tool
 
         probes = self.audit_data.probes or {}
 
@@ -370,8 +370,8 @@ class MCPAuditor:
             logger.error("No Init Result to audit")
             return
         else:
-            self.audit_data.protocol_version = str(init_result.protocolVersion)
-            self.audit_data.server_info = init_result.serverInfo
+            self.audit_data.protocol_version = str(init_result.protocol_version)
+            self.audit_data.server_info = init_result.server_info
             self.audit_data.capabilities = init_result.capabilities
             self.audit_data.instructions = init_result.instructions
 

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -528,9 +528,11 @@ class MCPAuditor:
         return {
             "score": self.score,
             "max_score": self.max_score,
-            # True when the audit was run with caller-supplied auth headers.
-            # Only the flag is reported — header values are never included.
-            "authenticated": self.headers is not None,
+            # True when the audit sent an Authorization credential (--token or
+            # an explicit Authorization --header). Other custom headers (e.g.
+            # tracing) do not mark the audit authenticated. Only the flag is
+            # reported — header values are never included.
+            "authenticated": any(name.lower() == "authorization" for name in (self.headers or {})),
             # A partial audit ran without a server session (e.g. an auth-gated
             # server): only probe-derived rules scored; session-dependent rules
             # were skipped as insufficient-data. The score is NOT comparable to

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -138,11 +138,15 @@ class MCPClient:
     transports, with automatic transport detection.
     """
 
-    def __init__(self, timeout: int | None = None) -> None:
+    def __init__(self, timeout: int | None = None, headers: dict[str, str] | None = None) -> None:
         """Initialize a new MCP client instance.
 
         Args:
             timeout: Connection timeout in seconds (None for no timeout)
+            headers: Extra HTTP headers sent on every request to an HTTP(S)
+                server, e.g. ``{"Authorization": "Bearer …"}`` to audit an
+                auth-gated server. Ignored for stdio transports. Values are
+                sensitive and are never logged or included in the report.
 
         Sets up the client with an empty session and async exit stack for resource management.
 
@@ -151,6 +155,7 @@ class MCPClient:
         self.session: ClientSession | None = None
         self.exit_stack: AsyncExitStack = AsyncExitStack()
         self.timeout: int | None = timeout
+        self.headers: dict[str, str] | None = headers or None
         self._init_result: InitializeResult | None = None
 
         # Transport metadata (populated after connection)
@@ -425,6 +430,7 @@ class MCPClient:
                     pool=5.0,  # Pool timeout: 5 seconds
                 ),
                 follow_redirects=True,
+                headers=self.headers,
                 limits=httpx2.Limits(max_connections=100, max_keepalive_connections=20),
             )
 
@@ -497,6 +503,7 @@ class MCPClient:
                     pool=5.0,  # Pool timeout: 5 seconds
                 ),
                 follow_redirects=True,
+                headers=self.headers,
                 limits=httpx2.Limits(max_connections=100, max_keepalive_connections=20),
             )
 

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -6,7 +6,7 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
-import httpx
+import httpx2
 from mcp import (
     ClientSession,
     InitializeResult,
@@ -18,7 +18,7 @@ from mcp import (
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
-from mcp.types import Prompt, Resource, Tool
+from mcp_types import Prompt, Resource, Tool
 
 from .enums import ConnectionErrorReason, MCPTransportType
 
@@ -104,7 +104,7 @@ def extract_http_status(exc: BaseException) -> int | None:
         if current is None or id(current) in seen:
             continue
         seen.add(id(current))
-        if isinstance(current, httpx.HTTPStatusError):
+        if isinstance(current, httpx2.HTTPStatusError):
             return current.response.status_code
         if isinstance(current, BaseExceptionGroup):
             stack.extend(current.exceptions)
@@ -417,15 +417,15 @@ class MCPClient:
 
         try:
             # Configure HTTP client with timeouts and retries
-            client = httpx.AsyncClient(
-                timeout=httpx.Timeout(
+            client = httpx2.AsyncClient(
+                timeout=httpx2.Timeout(
                     connect=15.0,  # Connection timeout: 15 seconds
                     read=60.0,  # Read timeout: 60 seconds
                     write=30.0,  # Write timeout: 30 seconds
                     pool=5.0,  # Pool timeout: 5 seconds
                 ),
                 follow_redirects=True,
-                limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+                limits=httpx2.Limits(max_connections=100, max_keepalive_connections=20),
             )
 
             # Establish connection and verify the MCP handshake
@@ -438,17 +438,17 @@ class MCPClient:
             logger.info("Successfully connected to MCP server via Streamable HTTP: %s", server_url)
             return True
 
-        except httpx.ConnectError as e:
+        except httpx2.ConnectError as e:
             logger.exception("Connection refused or server unreachable: %s", server_url)
             logger.debug("Error details: %s", e)
             self._record_failure(ConnectionErrorReason.UNREACHABLE)
             return False
-        except httpx.TimeoutException as e:
+        except httpx2.TimeoutException as e:
             logger.exception("Connection timeout for server: %s", server_url)
             logger.debug("Error details: %s", e)
             self._record_failure(ConnectionErrorReason.TIMEOUT)
             return False
-        except httpx.HTTPStatusError as e:
+        except httpx2.HTTPStatusError as e:
             logger.exception("HTTP error %s from server: %s", e.response.status_code, server_url)
             logger.debug("Error details: %s", e)
             self._record_failure(reason_for_status(e.response.status_code), e.response.status_code)
@@ -489,24 +489,24 @@ class MCPClient:
 
         try:
             # Configure HTTP client for SSE with appropriate timeouts
-            client = httpx.AsyncClient(
-                timeout=httpx.Timeout(
+            client = httpx2.AsyncClient(
+                timeout=httpx2.Timeout(
                     connect=15.0,  # Connection timeout: 15 seconds
                     read=None,  # No read timeout for streaming (handled by keepalive)
                     write=30.0,  # Write timeout: 30 seconds
                     pool=5.0,  # Pool timeout: 5 seconds
                 ),
                 follow_redirects=True,
-                limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+                limits=httpx2.Limits(max_connections=100, max_keepalive_connections=20),
             )
 
             # Establish connection using MCP SDK's sse_client
             # Create a factory that ignores extra parameters since we already have a client
             def client_factory(
                 headers: dict[str, str] | None = None,
-                timeout: httpx.Timeout | None = None,
-                auth: httpx.Auth | None = None,
-            ) -> httpx.AsyncClient:
+                timeout: httpx2.Timeout | None = None,
+                auth: httpx2.Auth | None = None,
+            ) -> httpx2.AsyncClient:
                 return client
 
             await self._establish_session(
@@ -518,17 +518,17 @@ class MCPClient:
             logger.info("Successfully connected to MCP server via SSE: %s", server_url)
             return True
 
-        except httpx.ConnectError as e:
+        except httpx2.ConnectError as e:
             logger.exception("Connection refused or server unreachable: %s", server_url)
             logger.debug("Error details: %s", e)
             self._record_failure(ConnectionErrorReason.UNREACHABLE)
             return False
-        except httpx.TimeoutException as e:
+        except httpx2.TimeoutException as e:
             logger.exception("Connection timeout for server: %s", server_url)
             logger.debug("Error details: %s", e)
             self._record_failure(ConnectionErrorReason.TIMEOUT)
             return False
-        except httpx.HTTPStatusError as e:
+        except httpx2.HTTPStatusError as e:
             logger.exception("HTTP error %s from server: %s", e.response.status_code, server_url)
             logger.debug("Error details: %s", e)
             self._record_failure(reason_for_status(e.response.status_code), e.response.status_code)

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -27,7 +27,7 @@ import json
 import logging
 from typing import Any
 
-import httpx
+import httpx2
 
 from mcpscore.spec import DRAFT, LATEST, Era
 
@@ -207,7 +207,7 @@ def _request_headers(protocol_version: str, method: str, name: str | None = None
     return headers
 
 
-def _parse_payload(response: httpx.Response) -> dict[str, Any] | None:
+def _parse_payload(response: httpx2.Response) -> dict[str, Any] | None:
     """Extract the JSON-RPC message from a JSON or SSE response body."""
     content_type = response.headers.get("content-type", "")
     try:
@@ -223,7 +223,7 @@ def _parse_payload(response: httpx.Response) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-async def _post(client: httpx.AsyncClient, url: str, body: dict, headers: dict[str, str]) -> _ProbeResponse:
+async def _post(client: httpx2.AsyncClient, url: str, body: dict, headers: dict[str, str]) -> _ProbeResponse:
     response = await client.post(url, json=body, headers=headers, timeout=PROBE_TIMEOUT_S)
     return _ProbeResponse(
         status_code=response.status_code,
@@ -242,7 +242,7 @@ def _base_details(response: _ProbeResponse) -> dict[str, Any]:
     return details
 
 
-async def _probe_discover(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_discover(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """``server/discover`` — mandatory for modern servers (SEP-2567).
 
     SUPPORTED when the server returns a DiscoverResult carrying
@@ -267,7 +267,7 @@ async def _probe_discover(client: httpx.AsyncClient, url: str) -> ProbeResult:
     return ProbeResult(PROBE_DISCOVER, ProbeOutcome.UNSUPPORTED, details)
 
 
-async def _probe_stateless_list(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_stateless_list(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """Modern ``tools/list`` with required ``_meta``, no prior ``initialize`` (SEP-2575).
 
     SUPPORTED when the server returns a tools result; details record
@@ -290,7 +290,7 @@ async def _probe_stateless_list(client: httpx.AsyncClient, url: str) -> ProbeRes
     return ProbeResult(PROBE_STATELESS_LIST, ProbeOutcome.UNSUPPORTED, details)
 
 
-async def _probe_malformed_meta(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_malformed_meta(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """Send a modern request missing a required ``_meta`` field.
 
     The spec: a request missing any required field MUST be rejected with
@@ -312,7 +312,7 @@ async def _probe_malformed_meta(client: httpx.AsyncClient, url: str) -> ProbeRes
     return ProbeResult(PROBE_MALFORMED_META, outcome, details)
 
 
-async def _probe_header_mismatch(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_header_mismatch(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """Send a request whose ``Mcp-Method`` header contradicts the body method (SEP-2243).
 
     Servers MUST reject header/body mismatches with HTTP 400 and JSON-RPC
@@ -333,7 +333,7 @@ async def _probe_header_mismatch(client: httpx.AsyncClient, url: str) -> ProbeRe
     return ProbeResult(PROBE_HEADER_MISMATCH, outcome, details)
 
 
-async def _probe_unknown_version(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_unknown_version(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """Send a modern request naming a fabricated protocol version.
 
     Modern servers MUST reject it with ``-32022`` (UnsupportedProtocolVersion)
@@ -356,7 +356,7 @@ async def _probe_unknown_version(client: httpx.AsyncClient, url: str) -> ProbeRe
     return ProbeResult(PROBE_UNKNOWN_VERSION, ProbeOutcome.UNSUPPORTED, details)
 
 
-async def _probe_missing_resource(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_missing_resource(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """``resources/read`` for a deliberately nonexistent URI (SEP-2164).
 
     From 2026-07-28 the missing-resource error is standard ``-32602``; the
@@ -377,7 +377,7 @@ async def _probe_missing_resource(client: httpx.AsyncClient, url: str) -> ProbeR
     return ProbeResult(PROBE_MISSING_RESOURCE, outcome, details)
 
 
-async def _probe_unauthenticated(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_unauthenticated(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """One unauthenticated request, recording status and ``WWW-Authenticate``.
 
     This is a pure observation probe (it feeds the auth-posture rules):
@@ -396,7 +396,7 @@ async def _probe_unauthenticated(client: httpx.AsyncClient, url: str) -> ProbeRe
     return ProbeResult(PROBE_UNAUTHENTICATED, ProbeOutcome.SUPPORTED, details)
 
 
-async def _probe_session_id_echo(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_session_id_echo(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """Send a modern request carrying a spurious ``Mcp-Session-Id`` header.
 
     ``Mcp-Session-Id`` is removed in 2026-07-28; servers serving modern
@@ -419,7 +419,7 @@ async def _probe_session_id_echo(client: httpx.AsyncClient, url: str) -> ProbeRe
     return ProbeResult(PROBE_SESSION_ID_ECHO, outcome, details)
 
 
-async def _probe_removed_method(client: httpx.AsyncClient, url: str) -> ProbeResult:
+async def _probe_removed_method(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """Send a modern request for a method removed in the target revision (``ping``).
 
     Removed methods are unknown methods: the server MUST respond with HTTP 404
@@ -509,7 +509,7 @@ def detect_era(session_protocol_version: str | None, probes: dict[str, ProbeResu
     return None
 
 
-async def run_all_probes(url: str, client: httpx.AsyncClient | None = None) -> dict[str, ProbeResult]:
+async def run_all_probes(url: str, client: httpx2.AsyncClient | None = None) -> dict[str, ProbeResult]:
     """Run every probe against an HTTP(S) MCP endpoint.
 
     Probes run concurrently; a probe that fails at the network level yields
@@ -527,18 +527,18 @@ async def run_all_probes(url: str, client: httpx.AsyncClient | None = None) -> d
 
     """
 
-    async def run_one(probe_id: str, http_client: httpx.AsyncClient) -> ProbeResult:
+    async def run_one(probe_id: str, http_client: httpx2.AsyncClient) -> ProbeResult:
         try:
             return await _PROBES[probe_id](http_client, url)
         except Exception as e:  # noqa: BLE001 — a probe failure is data, never an audit abort
             logger.info("Probe %s failed against %s: %s", probe_id, url, e)
             return ProbeResult(probe_id, ProbeOutcome.ERROR, {"exception": type(e).__name__})
 
-    async def run_with(http_client: httpx.AsyncClient) -> dict[str, ProbeResult]:
+    async def run_with(http_client: httpx2.AsyncClient) -> dict[str, ProbeResult]:
         results = await asyncio.gather(*(run_one(probe_id, http_client) for probe_id in PROBE_IDS))
         return {result.probe_id: result for result in results}
 
     if client is not None:
         return await run_with(client)
-    async with httpx.AsyncClient(follow_redirects=True) as own_client:
+    async with httpx2.AsyncClient(follow_redirects=True) as own_client:
         return await run_with(own_client)

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -558,7 +558,11 @@ def detect_era(session_protocol_version: str | None, probes: dict[str, ProbeResu
     return None
 
 
-async def run_all_probes(url: str, client: httpx2.AsyncClient | None = None) -> dict[str, ProbeResult]:
+async def run_all_probes(
+    url: str,
+    client: httpx2.AsyncClient | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict[str, ProbeResult]:
     """Run every probe against an HTTP(S) MCP endpoint.
 
     Probes run concurrently; a probe that fails at the network level yields
@@ -570,6 +574,9 @@ async def run_all_probes(url: str, client: httpx2.AsyncClient | None = None) -> 
         client: Optional preconfigured httpx client (tests inject a
             MockTransport-backed one); a short-lived client is created
             otherwise
+        headers: Extra HTTP headers (e.g. an ``Authorization`` bearer) merged
+            into the short-lived client's defaults. Ignored when ``client`` is
+            supplied (the caller configures it). Sensitive — never logged.
 
     Returns:
         Mapping of probe_id to its ProbeResult, covering all PROBE_IDS
@@ -589,5 +596,5 @@ async def run_all_probes(url: str, client: httpx2.AsyncClient | None = None) -> 
 
     if client is not None:
         return await run_with(client)
-    async with httpx2.AsyncClient(follow_redirects=True) as own_client:
+    async with httpx2.AsyncClient(follow_redirects=True, headers=headers) as own_client:
         return await run_with(own_client)

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -50,6 +50,11 @@ PROBE_TIMEOUT_S = 10.0
 META_PREFIX = "io.modelcontextprotocol/"
 """Prefix of the reserved ``_meta`` keys carrying per-request context (2026-07-28)."""
 
+AUTH_GATED_STATUSES = frozenset({401, 403})
+"""HTTP statuses that mark an access-controlled server whose auth posture the
+auth-posture rules examine. Kept in sync with the CLI's partial-audit trigger
+(ConnectionErrorReason.UNAUTHORIZED / FORBIDDEN)."""
+
 ERROR_HEADER_MISMATCH = -32020
 """JSON-RPC error code for HTTP header/body mismatches (2026-07-28)."""
 
@@ -226,8 +231,24 @@ def _parse_payload(response: httpx2.Response) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-async def _post(client: httpx2.AsyncClient, url: str, body: dict, headers: dict[str, str]) -> _ProbeResponse:
-    response = await client.post(url, json=body, headers=headers, timeout=PROBE_TIMEOUT_S)
+async def _post(
+    client: httpx2.AsyncClient,
+    url: str,
+    body: dict,
+    headers: dict[str, str],
+    *,
+    anonymous: bool = False,
+) -> _ProbeResponse:
+    """POST a probe request, optionally stripping the caller's Authorization.
+
+    When ``anonymous``, remove any caller-supplied ``Authorization`` header so
+    the probe observes the server's unauthenticated behavior even when a token
+    was provided via --token/--header.
+    """
+    request = client.build_request("POST", url, json=body, headers=headers, timeout=PROBE_TIMEOUT_S)
+    if anonymous:
+        request.headers.pop("Authorization", None)
+    response = await client.send(request)
     return _ProbeResponse(
         status_code=response.status_code,
         headers=dict(response.headers),
@@ -393,6 +414,7 @@ async def _probe_unauthenticated(client: httpx2.AsyncClient, url: str) -> ProbeR
         url,
         _request_body("tools/list", 7, _modern_meta(target)),
         _request_headers(target, "tools/list"),
+        anonymous=True,
     )
     details = _base_details(response)
     details["www_authenticate"] = response.headers.get("www-authenticate")
@@ -427,7 +449,13 @@ async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeRes
     details: dict[str, Any] = {"urls_tried": []}
     for candidate in _well_known_urls(url):
         details["urls_tried"].append(candidate)
-        response = await client.get(candidate, headers={"Accept": "application/json"}, timeout=PROBE_TIMEOUT_S)
+        # The protected-resource metadata is a public well-known document;
+        # fetch it without any caller-supplied Authorization header.
+        request = client.build_request(
+            "GET", candidate, headers={"Accept": "application/json"}, timeout=PROBE_TIMEOUT_S
+        )
+        request.headers.pop("Authorization", None)
+        response = await client.send(request)
         details["http_status"] = response.status_code
         if response.status_code != 200:
             continue

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -162,7 +162,14 @@ class _ProbeResponse:
 
     @property
     def error(self) -> dict[str, Any] | None:
-        return self.payload.get("error") if isinstance(self.payload, dict) else None
+        # Only a JSON-RPC error *object* counts. A non-dict "error" (e.g. an
+        # OAuth/RFC 6750 body's string `"error": "invalid_token"` on a 401)
+        # must not be treated as one — error_code/_base_details call .get() on
+        # it, which would raise AttributeError on a string.
+        if not isinstance(self.payload, dict):
+            return None
+        error = self.payload.get("error")
+        return error if isinstance(error, dict) else None
 
     @property
     def error_code(self) -> int | None:
@@ -438,37 +445,93 @@ def _well_known_urls(url: str) -> list[str]:
     return candidates
 
 
+async def _get_json_anonymous(client: httpx2.AsyncClient, url: str) -> tuple[int, dict[str, Any] | None]:
+    """GET a public well-known JSON document, stripping any caller Authorization.
+
+    Returns (http_status, parsed_dict_or_None). Auth-discovery documents (RFC
+    9728, RFC 8414) are public; the caller's bearer must not be sent.
+    """
+    request = client.build_request("GET", url, headers={"Accept": "application/json"}, timeout=PROBE_TIMEOUT_S)
+    request.headers.pop("Authorization", None)
+    response = await client.send(request)
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        parsed = response.json()
+    except (json.JSONDecodeError, ValueError):
+        return response.status_code, None
+    return response.status_code, parsed if isinstance(parsed, dict) else None
+
+
+def _is_http_url(value: object) -> bool:
+    """Whether a value is an http(s) URL string."""
+    return isinstance(value, str) and value.startswith(("https://", "http://"))
+
+
+def _auth_server_metadata_urls(issuer: str) -> list[str]:
+    """RFC 8414 / OIDC well-known locations for an authorization server issuer."""
+    base = issuer.rstrip("/")
+    return [
+        f"{base}/.well-known/oauth-authorization-server",
+        f"{base}/.well-known/openid-configuration",
+    ]
+
+
+async def _fetch_auth_server_metadata(client: httpx2.AsyncClient, issuer: str, details: dict[str, Any]) -> None:
+    """Fetch the authorization server's RFC 8414 metadata; record posture in details.
+
+    Records whether the metadata document was found, whether it advertises the
+    required authorization/token endpoints, and whether it advertises PKCE with
+    S256 (`code_challenge_methods_supported`) — the OAuth security BCP (RFC
+    9700) / MCP-auth requirement.
+    """
+    details["auth_server_issuer"] = issuer
+    details["auth_server_metadata_present"] = False
+    for candidate in _auth_server_metadata_urls(issuer):
+        _status, metadata = await _get_json_anonymous(client, candidate)
+        if metadata is None:
+            continue
+        methods = metadata.get("code_challenge_methods_supported")
+        details["auth_server_metadata_url"] = candidate
+        details["auth_server_metadata_present"] = True
+        details["auth_server_has_endpoints"] = isinstance(metadata.get("authorization_endpoint"), str) and isinstance(
+            metadata.get("token_endpoint"), str
+        )
+        details["auth_server_pkce_s256"] = isinstance(methods, list) and "S256" in methods
+        return
+
+
 async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeResult:
-    """Fetch RFC 9728 protected resource metadata from its well-known locations.
+    """Fetch the auth-discovery chain (RFC 9728 PRM → RFC 8414 AS metadata).
 
     Observation probe feeding the auth-posture rules: SUPPORTED when a
     well-known location returns HTTP 200 with a JSON object carrying the
     REQUIRED ``resource`` field (RFC 9728 §2); details record what was found
-    where. Servers without authentication commonly 404 here — the dependent
-    rules skip unless the endpoint demanded auth in the first place.
+    where, plus the authorization server's endpoint/PKCE posture. Servers
+    without authentication commonly 404 here — the dependent rules skip unless
+    the endpoint demanded auth in the first place.
     """
     details: dict[str, Any] = {"urls_tried": []}
     for candidate in _well_known_urls(url):
         details["urls_tried"].append(candidate)
-        # The protected-resource metadata is a public well-known document;
-        # fetch it without any caller-supplied Authorization header.
-        request = client.build_request(
-            "GET", candidate, headers={"Accept": "application/json"}, timeout=PROBE_TIMEOUT_S
-        )
-        request.headers.pop("Authorization", None)
-        response = await client.send(request)
-        details["http_status"] = response.status_code
-        if response.status_code != 200:
+        status, metadata = await _get_json_anonymous(client, candidate)
+        details["http_status"] = status
+        if metadata is None:
             continue
-        try:
-            metadata = response.json()
-        except (json.JSONDecodeError, ValueError):
-            continue
-        if isinstance(metadata, dict) and isinstance(metadata.get("resource"), str):
+        if isinstance(metadata.get("resource"), str):
             servers = metadata.get("authorization_servers")
+            servers = servers if isinstance(servers, list) else None
             details["metadata_url"] = candidate
             details["resource"] = metadata["resource"]
-            details["authorization_servers"] = servers if isinstance(servers, list) else None
+            details["authorization_servers"] = servers
+            details["scopes_supported"] = metadata.get("scopes_supported")
+            # Walk to the first authorization server's RFC 8414 metadata. The
+            # document is public and fetched anonymously; whether the AS URL is
+            # HTTPS is scored separately by auth_authorization_servers_https, so
+            # observe http too rather than skipping the metadata check entirely.
+            first = next((s for s in (servers or []) if _is_http_url(s)), None)
+            if first is not None:
+                await _fetch_auth_server_metadata(client, first, details)
             return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.SUPPORTED, details, payload=metadata)
     return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.UNSUPPORTED, details)
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -25,7 +25,10 @@ from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, version as package_version
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 from urllib.parse import urlsplit
 
 import httpx2
@@ -108,6 +111,15 @@ PROBE_IDS: tuple[str, ...] = (
     PROBE_AUTH_METADATA,
 )
 """Stable identifiers of all probes."""
+
+_ANONYMOUS_PROBE_IDS = frozenset({PROBE_UNAUTHENTICATED, PROBE_AUTH_METADATA})
+"""Probes that must see the server as an unauthenticated client does.
+
+These run on a client that carries none of the caller's headers: --header may
+hold non-Authorization credentials (API keys, cookies) that would defeat the
+unauthenticated observation, and auth-metadata discovery (RFC 8414) can leave
+the server's origin for the authorization server's.
+"""
 
 
 class ProbeOutcome(StrEnum):
@@ -251,7 +263,10 @@ async def _post(
 
     When ``anonymous``, remove any caller-supplied ``Authorization`` header so
     the probe observes the server's unauthenticated behavior even when a token
-    was provided via --token/--header.
+    was provided via --token/--header. When ``run_all_probes`` created the
+    clients itself, anonymous probes additionally run on a client that carries
+    no caller headers at all (see ``_ANONYMOUS_PROBE_IDS``); the pop here also
+    covers caller-injected clients whose defaults it cannot control.
     """
     request = client.build_request("POST", url, json=body, headers=headers, timeout=PROBE_TIMEOUT_S)
     if anonymous:
@@ -449,7 +464,11 @@ async def _get_json_anonymous(client: httpx2.AsyncClient, url: str) -> tuple[int
     """GET a public well-known JSON document, stripping any caller Authorization.
 
     Returns (http_status, parsed_dict_or_None). Auth-discovery documents (RFC
-    9728, RFC 8414) are public; the caller's bearer must not be sent.
+    9728, RFC 8414) are public — and RFC 8414 discovery can leave the server's
+    origin for the authorization server's — so no caller credential may be
+    sent. When ``run_all_probes`` created the clients, these fetches already
+    run on a header-free client (``_ANONYMOUS_PROBE_IDS``); the pop here also
+    covers caller-injected clients.
     """
     request = client.build_request("GET", url, headers={"Accept": "application/json"}, timeout=PROBE_TIMEOUT_S)
     request.headers.pop("Authorization", None)
@@ -664,11 +683,14 @@ async def run_all_probes(
     Args:
         url: The MCP endpoint URL (http:// or https://)
         client: Optional preconfigured httpx client (tests inject a
-            MockTransport-backed one); a short-lived client is created
-            otherwise
+            MockTransport-backed one); short-lived clients are created
+            otherwise. An injected client is used for every probe, including
+            the anonymous ones — the caller configures its headers.
         headers: Extra HTTP headers (e.g. an ``Authorization`` bearer) merged
-            into the short-lived client's defaults. Ignored when ``client`` is
-            supplied (the caller configures it). Sensitive — never logged.
+            into the short-lived authenticated client's defaults; probes in
+            ``_ANONYMOUS_PROBE_IDS`` run on a separate client that carries
+            none of them. Ignored when ``client`` is supplied. Sensitive —
+            never logged.
 
     Returns:
         Mapping of probe_id to its ProbeResult, covering all PROBE_IDS
@@ -682,11 +704,14 @@ async def run_all_probes(
             logger.info("Probe %s failed against %s: %s", probe_id, url, e)
             return ProbeResult(probe_id, ProbeOutcome.ERROR, {"exception": type(e).__name__})
 
-    async def run_with(http_client: httpx2.AsyncClient) -> dict[str, ProbeResult]:
-        results = await asyncio.gather(*(run_one(probe_id, http_client) for probe_id in PROBE_IDS))
+    async def run_with(select: Callable[[str], httpx2.AsyncClient]) -> dict[str, ProbeResult]:
+        results = await asyncio.gather(*(run_one(probe_id, select(probe_id)) for probe_id in PROBE_IDS))
         return {result.probe_id: result for result in results}
 
     if client is not None:
-        return await run_with(client)
-    async with httpx2.AsyncClient(follow_redirects=True, headers=headers) as own_client:
-        return await run_with(own_client)
+        return await run_with(lambda _probe_id: client)
+    async with (
+        httpx2.AsyncClient(follow_redirects=True, headers=headers) as own_client,
+        httpx2.AsyncClient(follow_redirects=True) as anon_client,
+    ):
+        return await run_with(lambda probe_id: anon_client if probe_id in _ANONYMOUS_PROBE_IDS else own_client)

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -26,6 +26,7 @@ from importlib.metadata import PackageNotFoundError, version as package_version
 import json
 import logging
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx2
 
@@ -86,6 +87,7 @@ PROBE_MISSING_RESOURCE = "probe_missing_resource"
 PROBE_UNAUTHENTICATED = "probe_unauthenticated"
 PROBE_SESSION_ID_ECHO = "probe_session_id_echo"
 PROBE_REMOVED_METHOD = "probe_removed_method"
+PROBE_AUTH_METADATA = "probe_auth_metadata"
 
 PROBE_IDS: tuple[str, ...] = (
     PROBE_DISCOVER,
@@ -97,6 +99,7 @@ PROBE_IDS: tuple[str, ...] = (
     PROBE_UNAUTHENTICATED,
     PROBE_SESSION_ID_ECHO,
     PROBE_REMOVED_METHOD,
+    PROBE_AUTH_METADATA,
 )
 """Stable identifiers of all probes."""
 
@@ -396,6 +399,51 @@ async def _probe_unauthenticated(client: httpx2.AsyncClient, url: str) -> ProbeR
     return ProbeResult(PROBE_UNAUTHENTICATED, ProbeOutcome.SUPPORTED, details)
 
 
+def _well_known_urls(url: str) -> list[str]:
+    """RFC 9728 §3 well-known locations for a protected resource URL.
+
+    For a resource with a path component the path-aware form (path appended
+    after the well-known prefix) is tried first, then the origin-root form.
+    """
+    parts = urlsplit(url)
+    origin = f"{parts.scheme}://{parts.netloc}"
+    path = parts.path.rstrip("/")
+    candidates = []
+    if path:
+        candidates.append(f"{origin}/.well-known/oauth-protected-resource{path}")
+    candidates.append(f"{origin}/.well-known/oauth-protected-resource")
+    return candidates
+
+
+async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeResult:
+    """Fetch RFC 9728 protected resource metadata from its well-known locations.
+
+    Observation probe feeding the auth-posture rules: SUPPORTED when a
+    well-known location returns HTTP 200 with a JSON object carrying the
+    REQUIRED ``resource`` field (RFC 9728 §2); details record what was found
+    where. Servers without authentication commonly 404 here — the dependent
+    rules skip unless the endpoint demanded auth in the first place.
+    """
+    details: dict[str, Any] = {"urls_tried": []}
+    for candidate in _well_known_urls(url):
+        details["urls_tried"].append(candidate)
+        response = await client.get(candidate, headers={"Accept": "application/json"}, timeout=PROBE_TIMEOUT_S)
+        details["http_status"] = response.status_code
+        if response.status_code != 200:
+            continue
+        try:
+            metadata = response.json()
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(metadata, dict) and isinstance(metadata.get("resource"), str):
+            servers = metadata.get("authorization_servers")
+            details["metadata_url"] = candidate
+            details["resource"] = metadata["resource"]
+            details["authorization_servers"] = servers if isinstance(servers, list) else None
+            return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.SUPPORTED, details, payload=metadata)
+    return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.UNSUPPORTED, details)
+
+
 async def _probe_session_id_echo(client: httpx2.AsyncClient, url: str) -> ProbeResult:
     """Send a modern request carrying a spurious ``Mcp-Session-Id`` header.
 
@@ -450,6 +498,7 @@ _PROBES = {
     PROBE_UNAUTHENTICATED: _probe_unauthenticated,
     PROBE_SESSION_ID_ECHO: _probe_session_id_echo,
     PROBE_REMOVED_METHOD: _probe_removed_method,
+    PROBE_AUTH_METADATA: _probe_auth_metadata,
 }
 
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -35,6 +35,7 @@ from mcpscore.spec import DRAFT, LATEST, Era
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "AUTH_GATED_STATUSES",
     "GATEWAY_PROBE_IDS",
     "PROBE_IDS",
     "ProbeOutcome",

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -13,6 +13,11 @@ The rule system is designed to be extensible, allowing easy addition of new
 audit checks by implementing the BaseRule interface.
 """
 
+from .auth import (
+    AuthAuthorizationServersHttpsRule,
+    AuthProtectedResourceMetadataRule,
+    AuthWwwAuthenticateRule,
+)
 from .base import (
     AuditData,
     BaseRule,
@@ -63,15 +68,18 @@ from .security import (
     TLSEnabledRule,
 )
 from .server_info import (
+    ServerIconsPresentRule,
     ServerInstructionsPresentRule,
     ServerNamePresentRule,
     ServerTitlePresentRule,
     ServerVersionPresentRule,
+    ServerWebsiteUrlPresentRule,
 )
 from .tools import (
     ToolsAnnotationsPresentRule,
     ToolsAtLeastOneRule,
     ToolsDescriptionPresentRule,
+    ToolsExecutionConsistentRule,
     ToolsInputSchemaValidRule,
     ToolsNamePresentRule,
     ToolsNamesUniqueRule,
@@ -86,6 +94,9 @@ from .transport import (
 __all__ = (
     "AllowedVersionRule",
     "AuditData",
+    "AuthAuthorizationServersHttpsRule",
+    "AuthProtectedResourceMetadataRule",
+    "AuthWwwAuthenticateRule",
     "BaseRule",
     "CacheMetadataReadinessRule",
     "CapabilityLoggingPresentRule",
@@ -114,10 +125,12 @@ __all__ = (
     "RuleResult",
     "RuleSeverity",
     "ServerDiscoverReadinessRule",
+    "ServerIconsPresentRule",
     "ServerInstructionsPresentRule",
     "ServerNamePresentRule",
     "ServerTitlePresentRule",
     "ServerVersionPresentRule",
+    "ServerWebsiteUrlPresentRule",
     "SkippedRule",
     "StatelessRequestReadinessRule",
     "StreamableHTTPTransportRule",
@@ -126,6 +139,7 @@ __all__ = (
     "ToolsAnnotationsPresentRule",
     "ToolsAtLeastOneRule",
     "ToolsDescriptionPresentRule",
+    "ToolsExecutionConsistentRule",
     "ToolsInputSchemaValidRule",
     "ToolsNamePresentRule",
     "ToolsNamesUniqueRule",

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -15,7 +15,12 @@ audit checks by implementing the BaseRule interface.
 
 from .auth import (
     AuthAuthorizationServersHttpsRule,
+    AuthChallengeReferencesMetadataRule,
+    AuthMetadataHttpsRule,
     AuthProtectedResourceMetadataRule,
+    AuthScopesAdvertisedRule,
+    AuthServerMetadataPresentRule,
+    AuthServerPkceRule,
     AuthWwwAuthenticateRule,
 )
 from .base import (
@@ -95,7 +100,12 @@ __all__ = (
     "AllowedVersionRule",
     "AuditData",
     "AuthAuthorizationServersHttpsRule",
+    "AuthChallengeReferencesMetadataRule",
+    "AuthMetadataHttpsRule",
     "AuthProtectedResourceMetadataRule",
+    "AuthScopesAdvertisedRule",
+    "AuthServerMetadataPresentRule",
+    "AuthServerPkceRule",
     "AuthWwwAuthenticateRule",
     "BaseRule",
     "CacheMetadataReadinessRule",

--- a/mcpscore/rules/auth.py
+++ b/mcpscore/rules/auth.py
@@ -11,10 +11,13 @@ Authorization spec (2025-06-18 and later) makes MCP servers OAuth 2.0
 protected resources — a 401 MUST carry ``WWW-Authenticate`` pointing at the
 resource metadata, the RFC 9728 metadata document MUST exist with its
 ``resource`` value matching the server, and it MUST list at least one
-authorization server.
+authorization server. The deeper rules follow the discovery chain to the
+authorization server's own RFC 8414 metadata and check it advertises PKCE
+(S256), per the OAuth security BCP (RFC 9700).
 """
 
 from typing import ClassVar
+from urllib.parse import urlsplit
 
 from ..probes import AUTH_GATED_STATUSES, PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED, ProbeOutcome, ProbeResult
 from .base import (
@@ -33,6 +36,12 @@ _AUTH_BASIS = "MCP Authorization (2025-06-18+) / RFC 9728"
 def _normalized(url: str) -> str:
     """Normalize a resource URL for comparison (trailing slash only)."""
     return url.rstrip("/")
+
+
+def _origin(url: str) -> str:
+    """Return the scheme://host[:port] origin of a URL, for same-origin comparison."""
+    parts = urlsplit(url)
+    return f"{parts.scheme}://{parts.netloc}"
 
 
 class AuthPostureBaseRule(BaseRule):
@@ -231,4 +240,306 @@ class AuthAuthorizationServersHttpsRule(AuthPostureBaseRule):
             passed=passed,
             message=message,
             details={"basis": _AUTH_BASIS, "authorization_servers": servers, "invalid": invalid},
+        )
+
+
+_RFC_8414 = "RFC 8414 (OAuth 2.0 Authorization Server Metadata) / RFC 9700"
+
+
+class AuthMetadataBaseRule(AuthPostureBaseRule):
+    """Auth-posture rule that needs the RFC 9728 protected-resource metadata.
+
+    Beyond the base 401/403 gate, these rules skip when no metadata document
+    was found — that absence is already the AuthProtectedResourceMetadataRule's
+    finding, so re-failing here would double-count one defect.
+    """
+
+    required_probe_ids = (PROBE_UNAUTHENTICATED, PROBE_AUTH_METADATA)
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        reason = super().skip_reason(audit_data)
+        if reason is not None:
+            return reason
+        if self._probe(audit_data, PROBE_AUTH_METADATA).outcome is not ProbeOutcome.SUPPORTED:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
+
+    def _metadata(self, audit_data: AuditData) -> dict:
+        return self._probe(audit_data, PROBE_AUTH_METADATA).details
+
+
+def _parse_www_authenticate_param(header: str, param: str) -> str | None:
+    """Extract a quoted parameter (e.g. resource_metadata="…") from a challenge."""
+    marker = f'{param}="'
+    start = header.find(marker)
+    if start == -1:
+        return None
+    start += len(marker)
+    end = header.find('"', start)
+    return header[start:end] if end != -1 else None
+
+
+@register_rule
+class AuthChallengeReferencesMetadataRule(AuthPostureBaseRule):
+    """Medium check: the 401 challenge points clients at the resource metadata."""
+
+    rule_id = "auth_challenge_references_metadata"
+    rule_order = 7
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - Challenge References Resource Metadata"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when the challenge header is absent (AuthWwwAuthenticateRule's finding)."""
+        reason = super().skip_reason(audit_data)
+        if reason is not None:
+            return reason
+        challenge = self._probe(audit_data, PROBE_UNAUTHENTICATED).details.get("www_authenticate")
+        if not (isinstance(challenge, str) and challenge.strip()):
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """Medium check: WWW-Authenticate carries resource_metadata (RFC 9728 §5.1).
+
+        Without the ``resource_metadata`` parameter a client cannot discover
+        the protected-resource metadata from the challenge alone.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        challenge = str(self._probe(audit_data, PROBE_UNAUTHENTICATED).details.get("www_authenticate"))
+        referenced = _parse_www_authenticate_param(challenge, "resource_metadata")
+        # RFC 9728 serves the metadata from the resource's own origin; the exact
+        # path (root vs path-aware form) is a legitimate server choice, so we
+        # compare origins, not full URLs — a *different origin* is the real red
+        # flag (it points clients at someone else's metadata).
+        if referenced is None:
+            passed = False
+            message = "❌ The 401 challenge has no resource_metadata parameter for discovering the metadata"
+        elif audit_data.url is not None and _origin(referenced) != _origin(audit_data.url):
+            passed = False
+            message = f"❌ The challenge's resource_metadata '{referenced}' is not on this server's origin"
+        else:
+            passed = True
+            message = f"✅ The 401 challenge references the resource metadata: '{referenced}'"
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"basis": _AUTH_BASIS, "resource_metadata": referenced},
+        )
+
+
+@register_rule
+class AuthMetadataHttpsRule(AuthMetadataBaseRule):
+    """Medium check: the protected-resource metadata is served and named over HTTPS."""
+
+    rule_id = "auth_metadata_https"
+    rule_order = 8
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - Resource Metadata Uses HTTPS"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """Medium check: the metadata URL and its `resource` value are HTTPS.
+
+        RFC 9728 requires the metadata endpoint to use HTTPS; a plain-HTTP
+        metadata document or resource identifier is spoofable in transit.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        details = self._metadata(audit_data)
+        metadata_url = str(details.get("metadata_url", ""))
+        resource = str(details.get("resource", ""))
+        insecure = [u for u in (metadata_url, resource) if not u.startswith("https://")]
+        passed = not insecure
+        message = (
+            "✅ The protected-resource metadata URL and resource identifier use HTTPS"
+            if passed
+            else f"❌ Number of protected-resource metadata URLs not using HTTPS: {len(insecure)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"basis": _AUTH_BASIS, "metadata_url": metadata_url, "resource": resource},
+        )
+
+
+@register_rule
+class AuthScopesAdvertisedRule(AuthMetadataBaseRule):
+    """Low check: the metadata advertises scopes so clients can request least privilege."""
+
+    rule_id = "auth_scopes_advertised"
+    rule_order = 9
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - Scopes Advertised"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """Low check: `scopes_supported` is present and non-empty (RFC 9728).
+
+        Advertised scopes let clients request only the access they need; their
+        absence pushes clients toward over-broad authorization.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        scopes = self._metadata(audit_data).get("scopes_supported")
+        count = len(scopes) if isinstance(scopes, list) else 0
+        passed = count > 0
+        message = (
+            f"✅ The protected-resource metadata advertises {count} scope(s)"
+            if passed
+            else "❌ The protected-resource metadata advertises no scopes_supported for least-privilege requests"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"basis": _AUTH_BASIS, "scopes_supported": scopes},
+        )
+
+
+@register_rule
+class AuthServerMetadataPresentRule(AuthMetadataBaseRule):
+    """High check: the authorization server publishes RFC 8414 metadata with endpoints."""
+
+    rule_id = "auth_server_metadata_present"
+    rule_order = 10
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - Authorization Server Metadata Present"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when the metadata lists no HTTPS authorization server to discover."""
+        reason = super().skip_reason(audit_data)
+        if reason is not None:
+            return reason
+        if self._metadata(audit_data).get("auth_server_issuer") is None:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """High check: the authorization server's RFC 8414 metadata is reachable.
+
+        It must advertise the authorization and token endpoints; clients
+        discover how to authorize and exchange tokens from this
+        document; without it the flow is undiscoverable.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        details = self._metadata(audit_data)
+        issuer = details.get("auth_server_issuer")
+        present = details.get("auth_server_metadata_present") is True
+        has_endpoints = details.get("auth_server_has_endpoints") is True
+        passed = present and has_endpoints
+        if not present:
+            message = f"❌ Authorization server '{issuer}' publishes no RFC 8414 metadata document"
+        elif not has_endpoints:
+            message = f"❌ Authorization server '{issuer}' metadata omits the authorization or token endpoint"
+        else:
+            message = f"✅ Authorization server '{issuer}' publishes RFC 8414 metadata with the required endpoints"
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"basis": _RFC_8414, "issuer": issuer, "present": present, "has_endpoints": has_endpoints},
+        )
+
+
+@register_rule
+class AuthServerPkceRule(AuthMetadataBaseRule):
+    """High check: the authorization server advertises PKCE with S256."""
+
+    rule_id = "auth_server_metadata_pkce"
+    rule_order = 11
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - Authorization Server Enforces PKCE (S256)"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when there is no reachable AS metadata to inspect (that rule's finding)."""
+        reason = super().skip_reason(audit_data)
+        if reason is not None:
+            return reason
+        if self._metadata(audit_data).get("auth_server_metadata_present") is not True:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """High check: `code_challenge_methods_supported` includes S256.
+
+        PKCE with S256 is required by the OAuth security BCP (RFC 9700) and the
+        MCP authorization spec; without it the authorization-code flow is open
+        to code-interception attacks.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        details = self._metadata(audit_data)
+        passed = details.get("auth_server_pkce_s256") is True
+        message = (
+            "✅ The authorization server advertises PKCE with S256"
+            if passed
+            else "❌ The authorization server does not advertise PKCE with S256 (code_challenge_methods_supported)"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"basis": _RFC_8414, "issuer": details.get("auth_server_issuer")},
         )

--- a/mcpscore/rules/auth.py
+++ b/mcpscore/rules/auth.py
@@ -16,7 +16,7 @@ authorization server.
 
 from typing import ClassVar
 
-from ..probes import PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED, ProbeOutcome, ProbeResult
+from ..probes import AUTH_GATED_STATUSES, PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED, ProbeOutcome, ProbeResult
 from .base import (
     SKIP_REASON_INSUFFICIENT_DATA,
     SKIP_REASON_NOT_APPLICABLE,
@@ -46,13 +46,17 @@ class AuthPostureBaseRule(BaseRule):
     """Probes whose observations this rule needs; unavailable → skip."""
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
-        """Skip unless an unauthenticated request was actually challenged with 401."""
+        """Skip unless an unauthenticated request was challenged (HTTP 401/403).
+
+        A server that serves anonymous requests (any other status) has no auth
+        posture to grade, so the rules skip as not-applicable.
+        """
         probes = audit_data.probes or {}
         for probe_id in self.required_probe_ids:
             result = probes.get(probe_id)
             if result is None or result.outcome in (ProbeOutcome.ERROR, ProbeOutcome.NOT_APPLICABLE):
                 return SKIP_REASON_INSUFFICIENT_DATA
-        if probes[PROBE_UNAUTHENTICATED].details.get("http_status") != 401:
+        if probes[PROBE_UNAUTHENTICATED].details.get("http_status") not in AUTH_GATED_STATUSES:
             return SKIP_REASON_NOT_APPLICABLE
         return None
 

--- a/mcpscore/rules/auth.py
+++ b/mcpscore/rules/auth.py
@@ -2,9 +2,9 @@
 
 These rules score how an auth-gated server presents its authorization
 surface — the one part of an authenticated server mcpscore can audit without
-credentials. They gate on the unauthenticated probe observing HTTP 401: a
-server that serves anonymous requests has no auth posture to grade, and the
-rules skip as not-applicable rather than handing out free points.
+credentials. They gate on the unauthenticated probe observing HTTP 401 or
+403: a server that serves anonymous requests has no auth posture to grade,
+and the rules skip as not-applicable rather than handing out free points.
 
 Normative basis (cited per rule, re-verify at spec-final): the MCP
 Authorization spec (2025-06-18 and later) makes MCP servers OAuth 2.0
@@ -77,25 +77,26 @@ class AuthPostureBaseRule(BaseRule):
 
 @register_rule
 class AuthWwwAuthenticateRule(AuthPostureBaseRule):
-    """High check: a 401 response carries a ``WWW-Authenticate`` challenge."""
+    """High check: a gated (401/403) response carries a ``WWW-Authenticate`` challenge."""
 
     rule_id = "auth_www_authenticate"
     rule_order = 4
 
     @property
     def rule_name(self) -> str:
-        return "Auth - 401 Carries WWW-Authenticate"
+        return "Auth - WWW-Authenticate Challenge"
 
     @property
     def severity(self) -> RuleSeverity:
         return RuleSeverity.HIGH
 
     def check(self, audit_data: AuditData) -> RuleResult:
-        """High check: the 401 challenge includes a WWW-Authenticate header.
+        """High check: the auth challenge includes a WWW-Authenticate header.
 
         The Authorization spec requires servers to use ``WWW-Authenticate`` on
         401 responses to point clients at the resource metadata; without it a
-        client cannot discover how to authenticate.
+        client cannot discover how to authenticate. The rule also runs for
+        403-gated servers, so messages report the observed status.
 
         Args:
             audit_data: The collected server data for this audit
@@ -104,12 +105,14 @@ class AuthWwwAuthenticateRule(AuthPostureBaseRule):
             RuleResult with the check outcome
 
         """
-        challenge = self._probe(audit_data, PROBE_UNAUTHENTICATED).details.get("www_authenticate")
+        probe = self._probe(audit_data, PROBE_UNAUTHENTICATED)
+        status = probe.details.get("http_status")
+        challenge = probe.details.get("www_authenticate")
         passed = isinstance(challenge, str) and bool(challenge.strip())
         message = (
-            f"✅ 401 responses carry a WWW-Authenticate challenge: '{challenge}'"
+            f"✅ HTTP {status} responses carry a WWW-Authenticate challenge: '{challenge}'"
             if passed
-            else "❌ 401 responses lack the WWW-Authenticate header clients need to discover how to authenticate"
+            else f"❌ HTTP {status} responses lack the WWW-Authenticate header needed to discover how to authenticate"
         )
         return RuleResult(
             rule_name=self.rule_name,
@@ -281,7 +284,7 @@ def _parse_www_authenticate_param(header: str, param: str) -> str | None:
 
 @register_rule
 class AuthChallengeReferencesMetadataRule(AuthPostureBaseRule):
-    """Medium check: the 401 challenge points clients at the resource metadata."""
+    """Medium check: the auth challenge points clients at the resource metadata."""
 
     rule_id = "auth_challenge_references_metadata"
     rule_order = 7
@@ -317,7 +320,9 @@ class AuthChallengeReferencesMetadataRule(AuthPostureBaseRule):
             RuleResult with the check outcome
 
         """
-        challenge = str(self._probe(audit_data, PROBE_UNAUTHENTICATED).details.get("www_authenticate"))
+        probe = self._probe(audit_data, PROBE_UNAUTHENTICATED)
+        status = probe.details.get("http_status")
+        challenge = str(probe.details.get("www_authenticate"))
         referenced = _parse_www_authenticate_param(challenge, "resource_metadata")
         # RFC 9728 serves the metadata from the resource's own origin; the exact
         # path (root vs path-aware form) is a legitimate server choice, so we
@@ -325,13 +330,13 @@ class AuthChallengeReferencesMetadataRule(AuthPostureBaseRule):
         # flag (it points clients at someone else's metadata).
         if referenced is None:
             passed = False
-            message = "❌ The 401 challenge has no resource_metadata parameter for discovering the metadata"
+            message = f"❌ The HTTP {status} challenge has no resource_metadata parameter for discovering the metadata"
         elif audit_data.url is not None and _origin(referenced) != _origin(audit_data.url):
             passed = False
             message = f"❌ The challenge's resource_metadata '{referenced}' is not on this server's origin"
         else:
             passed = True
-            message = f"✅ The 401 challenge references the resource metadata: '{referenced}'"
+            message = f"✅ The HTTP {status} challenge references the resource metadata: '{referenced}'"
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,

--- a/mcpscore/rules/auth.py
+++ b/mcpscore/rules/auth.py
@@ -1,0 +1,228 @@
+"""Authorization-posture rules (RFC 9728 protected resource metadata).
+
+These rules score how an auth-gated server presents its authorization
+surface — the one part of an authenticated server mcpscore can audit without
+credentials. They gate on the unauthenticated probe observing HTTP 401: a
+server that serves anonymous requests has no auth posture to grade, and the
+rules skip as not-applicable rather than handing out free points.
+
+Normative basis (cited per rule, re-verify at spec-final): the MCP
+Authorization spec (2025-06-18 and later) makes MCP servers OAuth 2.0
+protected resources — a 401 MUST carry ``WWW-Authenticate`` pointing at the
+resource metadata, the RFC 9728 metadata document MUST exist with its
+``resource`` value matching the server, and it MUST list at least one
+authorization server.
+"""
+
+from typing import ClassVar
+
+from ..probes import PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED, ProbeOutcome, ProbeResult
+from .base import (
+    SKIP_REASON_INSUFFICIENT_DATA,
+    SKIP_REASON_NOT_APPLICABLE,
+    AuditData,
+    BaseRule,
+    RuleResult,
+    RuleSeverity,
+)
+from .registry import register_rule
+
+_AUTH_BASIS = "MCP Authorization (2025-06-18+) / RFC 9728"
+
+
+def _normalized(url: str) -> str:
+    """Normalize a resource URL for comparison (trailing slash only)."""
+    return url.rstrip("/")
+
+
+class AuthPostureBaseRule(BaseRule):
+    """Base class for auth-posture rules: security group, auth-gated servers only."""
+
+    group_name = "security"
+    group_order = 3
+    min_spec_version = "2025-06-18"
+
+    required_probe_ids: ClassVar[tuple[str, ...]] = (PROBE_UNAUTHENTICATED,)
+    """Probes whose observations this rule needs; unavailable → skip."""
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip unless an unauthenticated request was actually challenged with 401."""
+        probes = audit_data.probes or {}
+        for probe_id in self.required_probe_ids:
+            result = probes.get(probe_id)
+            if result is None or result.outcome in (ProbeOutcome.ERROR, ProbeOutcome.NOT_APPLICABLE):
+                return SKIP_REASON_INSUFFICIENT_DATA
+        if probes[PROBE_UNAUTHENTICATED].details.get("http_status") != 401:
+            return SKIP_REASON_NOT_APPLICABLE
+        return None
+
+    def _probe(self, audit_data: AuditData, probe_id: str) -> ProbeResult:
+        """Return a required probe's result (skip_reason guarantees presence)."""
+        assert audit_data.probes is not None  # noqa: S101 — guaranteed by skip_reason
+        return audit_data.probes[probe_id]
+
+
+@register_rule
+class AuthWwwAuthenticateRule(AuthPostureBaseRule):
+    """High check: a 401 response carries a ``WWW-Authenticate`` challenge."""
+
+    rule_id = "auth_www_authenticate"
+    rule_order = 4
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - 401 Carries WWW-Authenticate"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """High check: the 401 challenge includes a WWW-Authenticate header.
+
+        The Authorization spec requires servers to use ``WWW-Authenticate`` on
+        401 responses to point clients at the resource metadata; without it a
+        client cannot discover how to authenticate.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        challenge = self._probe(audit_data, PROBE_UNAUTHENTICATED).details.get("www_authenticate")
+        passed = isinstance(challenge, str) and bool(challenge.strip())
+        message = (
+            f"✅ 401 responses carry a WWW-Authenticate challenge: '{challenge}'"
+            if passed
+            else "❌ 401 responses lack the WWW-Authenticate header clients need to discover how to authenticate"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"basis": _AUTH_BASIS, "www_authenticate": challenge},
+        )
+
+
+@register_rule
+class AuthProtectedResourceMetadataRule(AuthPostureBaseRule):
+    """High check: RFC 9728 protected resource metadata exists and names this server."""
+
+    rule_id = "auth_protected_resource_metadata"
+    rule_order = 5
+    required_probe_ids = (PROBE_UNAUTHENTICATED, PROBE_AUTH_METADATA)
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - Protected Resource Metadata"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """High check: the well-known metadata document exists and matches.
+
+        RFC 9728 requires the metadata's ``resource`` value to identify the
+        protected resource; a mismatched value sends clients to authenticate
+        for a different resource than the one they connected to.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        probe = self._probe(audit_data, PROBE_AUTH_METADATA)
+        details = {"basis": _AUTH_BASIS, **probe.details}
+        if probe.outcome is not ProbeOutcome.SUPPORTED:
+            return RuleResult(
+                rule_name=self.rule_name,
+                severity=self.severity,
+                passed=False,
+                message="❌ No RFC 9728 protected resource metadata found at the well-known locations",
+                details=details,
+            )
+
+        resource = str(probe.details.get("resource"))
+        matches = audit_data.url is not None and _normalized(resource) == _normalized(audit_data.url)
+        details["resource_matches"] = matches
+        message = (
+            f"✅ Protected resource metadata found at '{probe.details.get('metadata_url')}'"
+            if matches
+            else f"❌ Protected resource metadata 'resource' is '{resource}', which does not match this server"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=matches,
+            message=message,
+            details=details,
+        )
+
+
+@register_rule
+class AuthAuthorizationServersHttpsRule(AuthPostureBaseRule):
+    """High check: the metadata lists authorization servers, all on HTTPS."""
+
+    rule_id = "auth_authorization_servers_https"
+    rule_order = 6
+    required_probe_ids = (PROBE_UNAUTHENTICATED, PROBE_AUTH_METADATA)
+
+    @property
+    def rule_name(self) -> str:
+        return "Auth - Authorization Servers Present and HTTPS"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Additionally skip when there is no metadata document to inspect.
+
+        The metadata rule already grades absence; failing here too would
+        double-count one defect.
+        """
+        reason = super().skip_reason(audit_data)
+        if reason is not None:
+            return reason
+        if self._probe(audit_data, PROBE_AUTH_METADATA).outcome is not ProbeOutcome.SUPPORTED:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """High check: at least one authorization server, every entry HTTPS.
+
+        Clients authenticate against the listed authorization servers; an
+        empty list leaves them nowhere to go, and a plain-HTTP entry exposes
+        the token exchange.
+
+        Args:
+            audit_data: The collected server data for this audit
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        servers = self._probe(audit_data, PROBE_AUTH_METADATA).details.get("authorization_servers") or []
+        insecure = [server for server in servers if isinstance(server, str) and not server.startswith("https://")]
+        if not servers:
+            passed = False
+            message = "❌ Protected resource metadata lists no authorization servers to authenticate against"
+        elif insecure:
+            passed = False
+            message = f"❌ Number of authorization servers not using HTTPS: {len(insecure)}"
+        else:
+            passed = True
+            message = f"✅ All {len(servers)} authorization server(s) use HTTPS"
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"basis": _AUTH_BASIS, "authorization_servers": servers, "insecure": insecure},
+        )

--- a/mcpscore/rules/auth.py
+++ b/mcpscore/rules/auth.py
@@ -30,8 +30,6 @@ from .base import (
 )
 from .registry import register_rule
 
-_AUTH_BASIS = "MCP Authorization (2025-06-18+) / RFC 9728"
-
 
 def _normalized(url: str) -> str:
     """Normalize a resource URL for comparison (trailing slash only)."""
@@ -119,7 +117,7 @@ class AuthWwwAuthenticateRule(AuthPostureBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _AUTH_BASIS, "www_authenticate": challenge},
+            details={"basis": "MCP Authorization (2025-06-18+); RFC 9728 §5.1", "www_authenticate": challenge},
         )
 
 
@@ -154,7 +152,7 @@ class AuthProtectedResourceMetadataRule(AuthPostureBaseRule):
 
         """
         probe = self._probe(audit_data, PROBE_AUTH_METADATA)
-        details = {"basis": _AUTH_BASIS, **probe.details}
+        details = {"basis": "RFC 9728 §3 (well-known location), §2 (resource)", **probe.details}
         if probe.outcome is not ProbeOutcome.SUPPORTED:
             return RuleResult(
                 rule_name=self.rule_name,
@@ -242,11 +240,12 @@ class AuthAuthorizationServersHttpsRule(AuthPostureBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _AUTH_BASIS, "authorization_servers": servers, "invalid": invalid},
+            details={
+                "basis": "RFC 9728 §2 (authorization_servers)",
+                "authorization_servers": servers,
+                "invalid": invalid,
+            },
         )
-
-
-_RFC_8414 = "RFC 8414 (OAuth 2.0 Authorization Server Metadata) / RFC 9700"
 
 
 class AuthMetadataBaseRule(AuthPostureBaseRule):
@@ -342,7 +341,7 @@ class AuthChallengeReferencesMetadataRule(AuthPostureBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _AUTH_BASIS, "resource_metadata": referenced},
+            details={"basis": "RFC 9728 §5.1 (resource_metadata parameter)", "resource_metadata": referenced},
         )
 
 
@@ -389,7 +388,11 @@ class AuthMetadataHttpsRule(AuthMetadataBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _AUTH_BASIS, "metadata_url": metadata_url, "resource": resource},
+            details={
+                "basis": "RFC 9728 §2 (resource), §3 (HTTPS well-known)",
+                "metadata_url": metadata_url,
+                "resource": resource,
+            },
         )
 
 
@@ -434,7 +437,7 @@ class AuthScopesAdvertisedRule(AuthMetadataBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _AUTH_BASIS, "scopes_supported": scopes},
+            details={"basis": "RFC 9728 §2 (scopes_supported)", "scopes_supported": scopes},
         )
 
 
@@ -492,7 +495,12 @@ class AuthServerMetadataPresentRule(AuthMetadataBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _RFC_8414, "issuer": issuer, "present": present, "has_endpoints": has_endpoints},
+            details={
+                "basis": "RFC 8414 §3 (well-known location), §2 (endpoints)",
+                "issuer": issuer,
+                "present": present,
+                "has_endpoints": has_endpoints,
+            },
         )
 
 
@@ -546,5 +554,8 @@ class AuthServerPkceRule(AuthMetadataBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _RFC_8414, "issuer": details.get("auth_server_issuer")},
+            details={
+                "basis": "RFC 9700 §2.1.1 (PKCE); RFC 8414 §2 (code_challenge_methods_supported)",
+                "issuer": details.get("auth_server_issuer"),
+            },
         )

--- a/mcpscore/rules/auth.py
+++ b/mcpscore/rules/auth.py
@@ -209,13 +209,15 @@ class AuthAuthorizationServersHttpsRule(AuthPostureBaseRule):
 
         """
         servers = self._probe(audit_data, PROBE_AUTH_METADATA).details.get("authorization_servers") or []
-        insecure = [server for server in servers if isinstance(server, str) and not server.startswith("https://")]
+        # An entry is valid only if it is a string on HTTPS; anything else
+        # (plain HTTP, null, a number) is a malformed entry, not a pass.
+        invalid = [server for server in servers if not (isinstance(server, str) and server.startswith("https://"))]
         if not servers:
             passed = False
             message = "❌ Protected resource metadata lists no authorization servers to authenticate against"
-        elif insecure:
+        elif invalid:
             passed = False
-            message = f"❌ Number of authorization servers not using HTTPS: {len(insecure)}"
+            message = f"❌ Number of authorization servers not on HTTPS or malformed: {len(invalid)}"
         else:
             passed = True
             message = f"✅ All {len(servers)} authorization server(s) use HTTPS"
@@ -224,5 +226,5 @@ class AuthAuthorizationServersHttpsRule(AuthPostureBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"basis": _AUTH_BASIS, "authorization_servers": servers, "insecure": insecure},
+            details={"basis": _AUTH_BASIS, "authorization_servers": servers, "invalid": invalid},
         )

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -11,7 +11,7 @@ from mcpscore.spec import compare
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from mcp.types import Implementation, Prompt, Resource, ServerCapabilities, Tool
+    from mcp_types import Implementation, Prompt, Resource, ServerCapabilities, Tool
 
     from ..enums import MCPTransportType
     from ..probes import ProbeResult

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -131,6 +131,12 @@ class AuditData:
     # None until the auditor's probe-collection phase has run.
     probes: dict[str, ProbeResult] | None = None
 
+    # Partial audit: no server session was available (e.g. an auth-gated
+    # server), so only probe-derived rules were scored and session-dependent
+    # rules skipped as insufficient-data. False for a normal full audit.
+    partial: bool = False
+    partial_reason: str | None = None
+
 
 # Decorators to specify what data a rule needs
 def requires_protocol_version(func: Callable) -> Callable:

--- a/mcpscore/rules/capabilities.py
+++ b/mcpscore/rules/capabilities.py
@@ -1,9 +1,22 @@
 from abc import abstractmethod
 
-from mcp.types import ServerCapabilities
+from mcp_types import ServerCapabilities
+from pydantic import BaseModel
 
 from .base import BaseRule, RuleResult, RuleSeverity, requires_capabilities
 from .registry import register_rule
+
+
+def _wire_str(capability: object | None) -> str | None:
+    """Render a capability model using MCP wire field names (spec casing).
+
+    Report messages and details are public output and must show the spec's
+    field names (e.g. ``listChanged``), not the SDK's Python attribute names.
+    """
+    if not isinstance(capability, BaseModel):
+        return None if capability is None else str(capability)
+    fields = type(capability).model_fields
+    return " ".join(f"{field.alias or name}={getattr(capability, name)}" for name, field in fields.items())
 
 
 class CapabilityBaseRule(BaseRule):
@@ -95,7 +108,7 @@ class CapabilityToolsPresentRule(CapabilityBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_tools": getattr(capabilities, "tools", None)},
+            details={"capability_tools": _wire_str(getattr(capabilities, "tools", None))},
         )
 
 
@@ -127,19 +140,19 @@ class CapabilityToolsListChangedRule(CapabilityBaseRule):
         if not hasattr(capabilities, "tools") or not capabilities.tools:
             passed = False
             message = "❌ Tools is not present in capabilities"
-        elif not capabilities.tools.listChanged:
+        elif not capabilities.tools.list_changed:
             passed = False
             message = "❌ listChanged is not supported by Tools"
         else:
             passed = True
-            message = f"✅ Tools support listChanged: '{capabilities.tools}'"
+            message = f"✅ Tools support listChanged: '{_wire_str(capabilities.tools)}'"
 
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_tools": getattr(capabilities, "tools", None)},
+            details={"capability_tools": _wire_str(getattr(capabilities, "tools", None))},
         )
 
 
@@ -180,7 +193,7 @@ class CapabilityPromptsPresentRule(CapabilityBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_prompts": getattr(capabilities, "prompts", None)},
+            details={"capability_prompts": _wire_str(getattr(capabilities, "prompts", None))},
         )
 
 
@@ -212,19 +225,19 @@ class CapabilityPromptsListChangedRule(CapabilityBaseRule):
         if not hasattr(capabilities, "prompts") or not capabilities.prompts:
             passed = False
             message = "❌ Prompts is not present in capabilities"
-        elif not capabilities.prompts.listChanged:
+        elif not capabilities.prompts.list_changed:
             passed = False
             message = "❌ listChanged is not supported by Prompts"
         else:
             passed = True
-            message = f"✅ Prompts support listChanged: '{capabilities.prompts}'"
+            message = f"✅ Prompts support listChanged: '{_wire_str(capabilities.prompts)}'"
 
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_prompts": getattr(capabilities, "prompts", None)},
+            details={"capability_prompts": _wire_str(getattr(capabilities, "prompts", None))},
         )
 
 
@@ -265,7 +278,7 @@ class CapabilityResourcesPresentRule(CapabilityBaseRule):
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_resources": getattr(capabilities, "resources", None)},
+            details={"capability_resources": _wire_str(getattr(capabilities, "resources", None))},
         )
 
 
@@ -297,19 +310,19 @@ class CapabilityResourcesListChangedRule(CapabilityBaseRule):
         if not hasattr(capabilities, "resources") or not capabilities.resources:
             passed = False
             message = "❌ Resources is not present in capabilities"
-        elif not capabilities.resources.listChanged:
+        elif not capabilities.resources.list_changed:
             passed = False
             message = "❌ listChanged is not supported by Resources"
         else:
             passed = True
-            message = f"✅ Resources support listChanged: '{capabilities.resources}'"
+            message = f"✅ Resources support listChanged: '{_wire_str(capabilities.resources)}'"
 
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_resources": getattr(capabilities, "resources", None)},
+            details={"capability_resources": _wire_str(getattr(capabilities, "resources", None))},
         )
 
 
@@ -346,14 +359,14 @@ class CapabilityResourcesSubscribeRule(CapabilityBaseRule):
             message = "❌ subscribe is not supported by Resources"
         else:
             passed = True
-            message = f"✅ Resources support subscribe: '{capabilities.resources}'"
+            message = f"✅ Resources support subscribe: '{_wire_str(capabilities.resources)}'"
 
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_resources": getattr(capabilities, "resources", None)},
+            details={"capability_resources": _wire_str(getattr(capabilities, "resources", None))},
         )
 
 
@@ -387,12 +400,12 @@ class CapabilityLoggingPresentRule(CapabilityBaseRule):
             message = "❌ Logging is not present in capabilities"
         else:
             passed = True
-            message = f"✅ Logging capability is present: '{capabilities.logging}'"
+            message = f"✅ Logging capability is present: '{_wire_str(capabilities.logging)}'"
 
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_logging": getattr(capabilities, "logging", None)},
+            details={"capability_logging": _wire_str(getattr(capabilities, "logging", None))},
         )

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from mcp.types import Prompt
+from mcp_types import Prompt
 
 from .base import BaseRule, RuleResult, RuleSeverity, requires_fields
 from .registry import register_rule

--- a/mcpscore/rules/readiness.py
+++ b/mcpscore/rules/readiness.py
@@ -536,10 +536,10 @@ class ToolSchemaDialectReadinessRule(ReadinessBaseRule):
         offending: dict[str, list[str]] = {}
         for tool in audit_data.tools or []:
             problems: list[str] = []
-            input_schema = getattr(tool, "inputSchema", None)
+            input_schema = getattr(tool, "input_schema", None)
             if isinstance(input_schema, dict):
                 problems.extend(self._schema_problems(input_schema))
-            output_schema = getattr(tool, "outputSchema", None)
+            output_schema = getattr(tool, "output_schema", None)
             if isinstance(output_schema, dict):
                 problems.extend(self._schema_problems(output_schema))
             if problems:

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from mcp.types import Resource
+from mcp_types import Resource
 
 from .base import BaseRule, RuleResult, RuleSeverity, requires_fields
 from .registry import register_rule

--- a/mcpscore/rules/server_info.py
+++ b/mcpscore/rules/server_info.py
@@ -227,3 +227,105 @@ class ServerInstructionsPresentRule(BaseRule):
             message=message,
             details={"has_instructions": passed},
         )
+
+
+@register_rule
+class ServerWebsiteUrlPresentRule(ServerInfoBaseRule):
+    """Low check: Verify that serverInfo.websiteUrl is present.
+
+    The ``websiteUrl`` field (2025-11-25) gives clients and registries a
+    human-facing home for the server; a missing one is a completeness gap.
+    """
+
+    rule_id = "server_websiteurl_present"
+    rule_order = 5
+    min_spec_version = "2025-11-25"
+
+    @property
+    def rule_name(self) -> str:
+        return "Server Info - Website URL Present"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def _check_server_info(self, server_info: Implementation) -> RuleResult:
+        """Low check: Verify that serverInfo.websiteUrl is present.
+
+        Args:
+            server_info: Server implementation info to check
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        website_url = getattr(server_info, "website_url", None)
+        if website_url:
+            passed = True
+            message = f"✅ Server website URL is present: '{website_url}'"
+        else:
+            passed = False
+            message = "❌ Server website URL (websiteUrl) is not present in server info"
+
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"website_url": website_url},
+        )
+
+
+@register_rule
+class ServerIconsPresentRule(ServerInfoBaseRule):
+    """Low check: Verify that serverInfo declares valid icons.
+
+    Icons (2025-11-25) are what registries and client directories render next
+    to the server's name; each declared icon must carry a usable ``src``
+    (an https:// or data: URI) — declaring none, or declaring broken ones,
+    lists the server worse than its peers.
+    """
+
+    rule_id = "server_icons_present"
+    rule_order = 6
+    min_spec_version = "2025-11-25"
+
+    @property
+    def rule_name(self) -> str:
+        return "Server Info - Icons Present and Valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def _check_server_info(self, server_info: Implementation) -> RuleResult:
+        """Low check: Verify that serverInfo declares icons with valid sources.
+
+        Args:
+            server_info: Server implementation info to check
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        icons = getattr(server_info, "icons", None) or []
+        invalid = [
+            icon.src for icon in icons if not (isinstance(icon.src, str) and icon.src.startswith(("https://", "data:")))
+        ]
+        if not icons:
+            passed = False
+            message = "❌ Server declares no icons in server info"
+        elif invalid:
+            passed = False
+            message = f"❌ Number of icons without a valid https/data src: {len(invalid)}"
+        else:
+            passed = True
+            message = f"✅ Server declares {len(icons)} icon(s) with valid sources"
+
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"icon_count": len(icons), "invalid_srcs": invalid},
+        )

--- a/mcpscore/rules/server_info.py
+++ b/mcpscore/rules/server_info.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from mcp.types import Implementation
+from mcp_types import Implementation
 
 from .base import BaseRule, RuleResult, RuleSeverity, requires_fields, requires_server_info
 from .registry import register_rule

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -3,7 +3,7 @@ from collections import Counter
 import re
 from typing import Any
 
-from mcp.types import Tool
+from mcp_types import Tool
 
 from .base import BaseRule, RuleResult, RuleSeverity, requires_tools
 from .registry import register_rule
@@ -408,7 +408,7 @@ class ToolsInputSchemaValidRule(ToolsBaseRule):
 
         """
         tools_with_invalid_input_schema: list[str] = [
-            tool.name for tool in tools if not is_valid_schema(tool.inputSchema)
+            tool.name for tool in tools if not is_valid_schema(tool.input_schema)
         ]
 
         passed = len(tools_with_invalid_input_schema) == 0
@@ -457,7 +457,7 @@ class ToolsOutputSchemaValidRule(ToolsBaseRule):
 
         """
         tools_with_invalid_output_schema: list[str] = [
-            tool.name for tool in tools if tool.outputSchema is not None and not is_valid_schema(tool.outputSchema)
+            tool.name for tool in tools if tool.output_schema is not None and not is_valid_schema(tool.output_schema)
         ]
 
         passed = len(tools_with_invalid_output_schema) == 0
@@ -479,7 +479,7 @@ class ToolsOutputSchemaValidRule(ToolsBaseRule):
 # The behavior-describing hints from the MCP tool `annotations` object. The
 # display-only `title` hint is excluded: it conveys no execution semantics, so
 # it does not count as "annotated" for this rule.
-_TOOL_BEHAVIOR_HINTS = ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint")
+_TOOL_BEHAVIOR_HINTS = ("read_only_hint", "destructive_hint", "idempotent_hint", "open_world_hint")
 
 
 def _has_behavior_annotation(tool: Tool) -> bool:

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from mcp_types import Tool
 
-from .base import BaseRule, RuleResult, RuleSeverity, requires_tools
+from .base import BaseRule, RuleResult, RuleSeverity, requires_fields, requires_tools
 from .registry import register_rule
 
 
@@ -536,4 +536,66 @@ class ToolsAnnotationsPresentRule(ToolsBaseRule):
             passed=passed,
             message=message,
             details={"tools_without_annotations": tools_without_annotations},
+        )
+
+
+@register_rule
+class ToolsExecutionConsistentRule(BaseRule):
+    """Medium check: task-augmented tools require the ``tasks`` capability.
+
+    A tool whose ``execution.taskSupport`` is ``optional`` or ``required``
+    (2025-11-25 experimental tasks) promises task-augmented execution — a
+    server making that promise without declaring the ``tasks`` capability
+    gives clients contradictory metadata.
+    """
+
+    group_name = "tools"
+    group_order = 4
+    rule_id = "tools_execution_consistent"
+    rule_order = 10
+    min_spec_version = "2025-11-25"
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools - Task Execution Backed by Tasks Capability"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    @requires_fields("tools", "capabilities")
+    def check(self, tools: list[Tool] | None, capabilities: Any | None) -> RuleResult:  # type: ignore[override]
+        """Medium check: tools declaring task execution align with capabilities.
+
+        Args:
+            tools: The server's declared tools
+            capabilities: The server's declared capabilities
+
+        Returns:
+            RuleResult with the check outcome
+
+        """
+        task_tools = [
+            tool.name
+            for tool in (tools or [])
+            if tool.execution is not None and tool.execution.task_support in ("optional", "required")
+        ]
+        has_tasks_capability = getattr(capabilities, "tasks", None) is not None
+
+        if not task_tools:
+            passed = True
+            message = "✅ No tools declare task-augmented execution"
+        elif has_tasks_capability:
+            passed = True
+            message = f"✅ All {len(task_tools)} task-augmented tool(s) are backed by the tasks capability"
+        else:
+            passed = False
+            message = f"❌ Number of tools declaring task execution without a tasks capability: {len(task_tools)}"
+
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"task_tools": task_tools, "tasks_capability": has_tasks_capability},
         )

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -5,7 +5,15 @@ from typing import Any
 
 from mcp_types import Tool
 
-from .base import BaseRule, RuleResult, RuleSeverity, requires_fields, requires_tools
+from .base import (
+    SKIP_REASON_INSUFFICIENT_DATA,
+    AuditData,
+    BaseRule,
+    RuleResult,
+    RuleSeverity,
+    requires_fields,
+    requires_tools,
+)
 from .registry import register_rule
 
 
@@ -554,6 +562,19 @@ class ToolsExecutionConsistentRule(BaseRule):
     rule_id = "tools_execution_consistent"
     rule_order = 10
     min_spec_version = "2025-11-25"
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when the tools list is unavailable despite a declared tools capability.
+
+        A failed ``tools/list`` (tools is None while the server declared the
+        tools capability) means this rule cannot judge consistency — the peer
+        tools rules already report the missing list, so re-passing here on an
+        empty fallback would be a false green.
+        """
+        declares_tools = getattr(audit_data.capabilities, "tools", None) is not None
+        if declares_tools and audit_data.tools is None:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
 
     @property
     def rule_name(self) -> str:

--- a/mcpscore/rules/transport.py
+++ b/mcpscore/rules/transport.py
@@ -1,5 +1,5 @@
 from ..enums import MCPTransportType
-from .base import BaseRule, RuleResult, RuleSeverity, requires_fields
+from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
 from .registry import register_rule
 
 
@@ -18,6 +18,17 @@ class StreamableHTTPTransportRule(BaseRule):
     group_name = "transport"
     group_order = 5
     rule_order = 1
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip in a partial audit where no transport was established.
+
+        A partial audit reaches the server only over raw probe requests; it
+        never confirms which MCP transport the server speaks, so the rule
+        cannot judge (transport_type is None) and must not claim a pass.
+        """
+        if audit_data.partial and audit_data.transport_type is None:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
 
     @property
     def rule_name(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.1.0b2"
+version = "1.1.0b3"
 description = "CLI tool to analyze your MCP server and get a comprehensive report on its quality"
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.1.0b1"
+version = "1.1.0b2"
 description = "CLI tool to analyze your MCP server and get a comprehensive report on its quality"
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "0.8.0"
+version = "1.1.0b1"
 description = "CLI tool to analyze your MCP server and get a comprehensive report on its quality"
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"
@@ -57,9 +57,8 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
-    "mcp>=1.28.1,<2",
-    "httpx>=0.28.1,<1",
-    "httpx-sse>=0.4.3",
+    "mcp==2.0.0b2",
+    "httpx2>=2.5.0",
     "jsonschema>=4.21",
 ]
 
@@ -81,6 +80,11 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15.20",
 ]
+
+[tool.uv]
+# mcp 2.0.0b2 pins the transitive mcp-types==2.0.0b2; uv only auto-allows
+# pre-releases for direct dependencies, so transitive betas need this.
+prerelease = "allow"
 
 [tool.pyright]
 reportMissingImports = true

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -263,7 +263,10 @@ def wait_for_publish(version: str) -> None:
     wait_for_registry("PyPI", f"https://pypi.org/pypi/mcpscore/{version}/json", "publish.yml")
     if is_prerelease(version):
         ok("npm skipped (pre-release publishes to PyPI only)")
-        print(f"\nSmoke test:\n  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp")
+        # --prerelease=allow: uv's pre-release exception covers only direct
+        # requirements, and this package's SDK pin (mcp==2.0.0bN) is transitive
+        # from uvx's point of view.
+        print(f"\nSmoke test:\n  uvx --prerelease=allow mcpscore=={version} https://mcp.deepwiki.com/mcp")
         return
     # npm requires the scope slash URL-encoded (%2F) — canonical registry form.
     npm_path = NPM_PACKAGE.replace("/", "%2F")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -171,6 +171,12 @@ def check_tag_absent(version: str) -> None:
     ok(f"tag v{version} is unused")
 
 
+REVIEW_BOT_CHECKS = frozenset({"copilot-pull-request-reviewer", "Cursor Bugbot"})
+"""Check runs registered by code-review bots. They are reviews, not CI gates —
+they re-enter in_progress on every push, so counting them would make a release
+racy against the bots' review latency."""
+
+
 def check_ci_green(sha: str) -> None:
     raw = run(
         "gh",
@@ -179,7 +185,7 @@ def check_ci_green(sha: str) -> None:
         "--jq",
         "[.check_runs[] | {name, status, conclusion, started_at, completed_at}]",
     )
-    runs = json.loads(raw)
+    runs = [r for r in json.loads(raw) if r["name"] not in REVIEW_BOT_CHECKS]
     if not runs:
         fail("no CI check runs found for HEAD — has CI finished?")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,6 +113,10 @@ def check_git_state(prerelease: bool = False) -> str:
 def check_changelog(version: str) -> str:
     """Verify the CHANGELOG section and link block, and return the section body."""
     changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    # A half-resolved merge ships raw conflict text in a release-facing file,
+    # and the section/link greps below can still pass around it.
+    if re.search(r"^(<{7} |={7}$|>{7} )", changelog, flags=re.MULTILINE):
+        fail("CHANGELOG.md contains unresolved merge conflict markers")
     match = re.search(
         rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
         changelog,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -98,6 +98,8 @@ def check_git_state(prerelease: bool = False) -> str:
     pushed, and in sync with its origin counterpart.
     """
     branch = run("git", "branch", "--show-current")
+    if not branch:
+        fail("detached HEAD — check out a branch to release from")
     if branch != "main" and not prerelease:
         fail(f"must release from main (currently on '{branch}')")
     if run("git", "status", "--porcelain"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ class FakeServerCapabilities:
     prompts: FakePromptsCaps | None = None
     resources: FakeResourcesCaps | None = None
     logging: FakeLoggingCaps | None = None
+    tasks: Any | None = None
 
 
 @dataclass
@@ -40,6 +41,8 @@ class FakeImplementation:
     name: str | None = None
     title: str | None = None
     version: str | None = None
+    website_url: str | None = None
+    icons: list[Any] | None = None
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,17 +8,17 @@ import pytest
 
 @dataclass
 class FakeToolsCaps:
-    listChanged: bool = False  # noqa: N815
+    list_changed: bool = False
 
 
 @dataclass
 class FakePromptsCaps:
-    listChanged: bool = False  # noqa: N815
+    list_changed: bool = False
 
 
 @dataclass
 class FakeResourcesCaps:
-    listChanged: bool = False  # noqa: N815
+    list_changed: bool = False
     subscribe: bool = False
 
 
@@ -45,9 +45,9 @@ class FakeImplementation:
 @pytest.fixture
 def capabilities_full() -> FakeServerCapabilities:
     return FakeServerCapabilities(
-        tools=FakeToolsCaps(listChanged=True),
-        prompts=FakePromptsCaps(listChanged=True),
-        resources=FakeResourcesCaps(listChanged=True, subscribe=True),
+        tools=FakeToolsCaps(list_changed=True),
+        prompts=FakePromptsCaps(list_changed=True),
+        resources=FakeResourcesCaps(list_changed=True, subscribe=True),
         logging=FakeLoggingCaps(enabled=True),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def _no_network_probes(monkeypatch: pytest.MonkeyPatch) -> None:
     from mcpscore import mcp_auditor
     from mcpscore.probes import not_applicable_results
 
-    async def stubbed_run_all_probes(url: str, client: Any = None) -> dict:
+    async def stubbed_run_all_probes(url: str, client: Any = None, headers: Any = None) -> dict:
         return not_applicable_results(reason="stubbed in unit tests")
 
     monkeypatch.setattr(mcp_auditor, "run_all_probes", stubbed_run_all_probes)

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -82,8 +82,8 @@ async def test_auditor_collects_data_and_scores():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             self.capabilities = type(
                 "Caps",
                 (),
@@ -120,8 +120,8 @@ async def test_auditor_with_tools_capability():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             # Tools capability is present (empty dict signals capability exists)
             self.capabilities = type(
                 "Caps",
@@ -156,8 +156,8 @@ async def test_auditor_with_resources_capability():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             # Resources capability is present
             self.capabilities = type(
                 "Caps",
@@ -192,8 +192,8 @@ async def test_auditor_with_prompts_capability():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             # Prompts capability is present
             self.capabilities = type(
                 "Caps",
@@ -228,8 +228,8 @@ async def test_auditor_with_all_capabilities():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             # All capabilities present
             self.capabilities = type(
                 "Caps",
@@ -279,8 +279,8 @@ async def test_auditor_with_no_capabilities():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             self.capabilities = None  # No capabilities
             self.instructions = None
 
@@ -309,8 +309,8 @@ async def test_auditor_https_tls_detection():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             self.capabilities = None
             self.instructions = None
 
@@ -337,8 +337,8 @@ async def test_auditor_http_no_tls():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             self.capabilities = None
             self.instructions = None
 
@@ -362,8 +362,8 @@ async def test_auditor_stdio_no_tls_detection():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             self.capabilities = None
             self.instructions = None
 
@@ -617,8 +617,8 @@ async def test_auditor_transport_metadata_collection():
     class InitResult:
         def __init__(self) -> None:
             super().__init__()
-            self.protocolVersion = "2025-06-18"
-            self.serverInfo = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
+            self.protocol_version = "2025-06-18"
+            self.server_info = type("Impl", (), {"name": "n", "title": "t", "version": "1"})()
             self.capabilities = None
             self.instructions = None
 

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -3,7 +3,20 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from mcpscore import MCPAuditor, MCPClient
+from mcpscore.mcp_auditor import has_authorization_credential
 from mcpscore.rules import AuditData, BaseRule, RuleResult, RuleSeverity
+
+
+def test_has_authorization_credential():
+    """Only a non-blank Authorization value counts as a credential."""
+    assert has_authorization_credential({"Authorization": "Bearer tok"}) is True
+    assert has_authorization_credential({"authorization": "Basic abc"}) is True
+    # Blank or whitespace values are not credentials (e.g. --header 'Authorization:').
+    assert has_authorization_credential({"Authorization": ""}) is False
+    assert has_authorization_credential({"Authorization": "   "}) is False
+    assert has_authorization_credential({"X-Trace-Id": "abc"}) is False
+    assert has_authorization_credential({}) is False
+    assert has_authorization_credential(None) is False
 
 
 class DummyClient(MCPClient):

--- a/tests/test_auth_rules.py
+++ b/tests/test_auth_rules.py
@@ -66,6 +66,11 @@ class TestSkipGating:
         for rule_cls in ALL_RULES:
             assert rule_cls().skip_reason(_data(_unauth(), _metadata())) is None
 
+    def test_rules_run_for_403_gated_servers(self):
+        """A 403 challenge is an access-controlled server too — rules run (matches partial trigger)."""
+        for rule_cls in ALL_RULES:
+            assert rule_cls().skip_reason(_data(_unauth(status=403), _metadata())) is None
+
     def test_metadata_rules_skip_without_the_metadata_probe(self):
         data = _data(_unauth())
         assert AuthProtectedResourceMetadataRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA

--- a/tests/test_auth_rules.py
+++ b/tests/test_auth_rules.py
@@ -1,0 +1,136 @@
+"""Tests for the auth-posture rules (RFC 9728 protected resource metadata)."""
+
+from mcpscore.probes import PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED, ProbeOutcome, ProbeResult
+from mcpscore.rules import AuditData
+from mcpscore.rules.auth import (
+    AuthAuthorizationServersHttpsRule,
+    AuthProtectedResourceMetadataRule,
+    AuthWwwAuthenticateRule,
+)
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
+
+URL = "https://server.example/mcp"
+METADATA_URL = "https://server.example/.well-known/oauth-protected-resource/mcp"
+
+ALL_RULES = (AuthWwwAuthenticateRule, AuthProtectedResourceMetadataRule, AuthAuthorizationServersHttpsRule)
+
+
+def _unauth(status: int = 401, www_authenticate: str | None = 'Bearer resource_metadata="..."') -> ProbeResult:
+    return ProbeResult(
+        PROBE_UNAUTHENTICATED,
+        ProbeOutcome.SUPPORTED,
+        {"http_status": status, "www_authenticate": www_authenticate},
+    )
+
+
+def _metadata(
+    outcome: ProbeOutcome = ProbeOutcome.SUPPORTED,
+    resource: str = URL,
+    servers: list[str] | None = None,
+) -> ProbeResult:
+    details = {"urls_tried": [METADATA_URL], "http_status": 200}
+    if outcome is ProbeOutcome.SUPPORTED:
+        details |= {
+            "metadata_url": METADATA_URL,
+            "resource": resource,
+            "authorization_servers": servers,
+        }
+    return ProbeResult(PROBE_AUTH_METADATA, outcome, details)
+
+
+def _data(unauth: ProbeResult | None, metadata: ProbeResult | None = None) -> AuditData:
+    probes = {}
+    if unauth is not None:
+        probes[PROBE_UNAUTHENTICATED] = unauth
+    if metadata is not None:
+        probes[PROBE_AUTH_METADATA] = metadata
+    return AuditData(url=URL, probes=probes or None)
+
+
+class TestSkipGating:
+    def test_all_rules_skip_without_probes(self):
+        for rule_cls in ALL_RULES:
+            assert rule_cls().skip_reason(AuditData()) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_all_rules_skip_when_probe_errored(self):
+        errored = ProbeResult(PROBE_UNAUTHENTICATED, ProbeOutcome.ERROR, {"exception": "ConnectError"})
+        for rule_cls in ALL_RULES:
+            assert rule_cls().skip_reason(_data(errored, _metadata())) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_all_rules_skip_for_open_servers(self):
+        """A server serving anonymous requests (HTTP 200) has no auth posture to grade."""
+        for rule_cls in ALL_RULES:
+            assert rule_cls().skip_reason(_data(_unauth(status=200), _metadata())) == SKIP_REASON_NOT_APPLICABLE
+
+    def test_rules_run_for_auth_gated_servers(self):
+        for rule_cls in ALL_RULES:
+            assert rule_cls().skip_reason(_data(_unauth(), _metadata())) is None
+
+    def test_metadata_rules_skip_without_the_metadata_probe(self):
+        data = _data(_unauth())
+        assert AuthProtectedResourceMetadataRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+        assert AuthAuthorizationServersHttpsRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_servers_rule_skips_when_metadata_absent(self):
+        """Absent metadata is the metadata rule's finding — no double-counting."""
+        data = _data(_unauth(), _metadata(outcome=ProbeOutcome.UNSUPPORTED))
+        assert AuthAuthorizationServersHttpsRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+        assert AuthProtectedResourceMetadataRule().skip_reason(data) is None
+
+
+class TestWwwAuthenticate:
+    def test_challenge_present_passes(self):
+        result = AuthWwwAuthenticateRule().check(_data(_unauth()))
+        assert result.passed is True
+        assert "WWW-Authenticate" in result.message
+
+    def test_missing_challenge_fails(self):
+        result = AuthWwwAuthenticateRule().check(_data(_unauth(www_authenticate=None)))
+        assert result.passed is False
+
+    def test_blank_challenge_fails(self):
+        result = AuthWwwAuthenticateRule().check(_data(_unauth(www_authenticate="  ")))
+        assert result.passed is False
+
+
+class TestProtectedResourceMetadata:
+    def test_matching_metadata_passes(self):
+        result = AuthProtectedResourceMetadataRule().check(_data(_unauth(), _metadata()))
+        assert result.passed is True
+        assert result.details is not None
+        assert result.details["resource_matches"] is True
+
+    def test_trailing_slash_difference_still_matches(self):
+        result = AuthProtectedResourceMetadataRule().check(_data(_unauth(), _metadata(resource=URL + "/")))
+        assert result.passed is True
+
+    def test_absent_metadata_fails(self):
+        data = _data(_unauth(), _metadata(outcome=ProbeOutcome.UNSUPPORTED))
+        result = AuthProtectedResourceMetadataRule().check(data)
+        assert result.passed is False
+        assert "No RFC 9728" in result.message
+
+    def test_mismatched_resource_fails(self):
+        data = _data(_unauth(), _metadata(resource="https://other.example/mcp"))
+        result = AuthProtectedResourceMetadataRule().check(data)
+        assert result.passed is False
+        assert "does not match" in result.message
+
+
+class TestAuthorizationServersHttps:
+    def test_all_https_passes(self):
+        data = _data(_unauth(), _metadata(servers=["https://auth.example", "https://sso.example"]))
+        result = AuthAuthorizationServersHttpsRule().check(data)
+        assert result.passed is True
+
+    def test_empty_list_fails(self):
+        result = AuthAuthorizationServersHttpsRule().check(_data(_unauth(), _metadata(servers=[])))
+        assert result.passed is False
+        assert "no authorization servers" in result.message
+
+    def test_plain_http_entry_fails(self):
+        data = _data(_unauth(), _metadata(servers=["https://auth.example", "http://insecure.example"]))
+        result = AuthAuthorizationServersHttpsRule().check(data)
+        assert result.passed is False
+        assert result.details is not None
+        assert result.details["insecure"] == ["http://insecure.example"]

--- a/tests/test_auth_rules.py
+++ b/tests/test_auth_rules.py
@@ -4,7 +4,12 @@ from mcpscore.probes import PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED, ProbeOut
 from mcpscore.rules import AuditData
 from mcpscore.rules.auth import (
     AuthAuthorizationServersHttpsRule,
+    AuthChallengeReferencesMetadataRule,
+    AuthMetadataHttpsRule,
     AuthProtectedResourceMetadataRule,
+    AuthScopesAdvertisedRule,
+    AuthServerMetadataPresentRule,
+    AuthServerPkceRule,
     AuthWwwAuthenticateRule,
 )
 from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
@@ -27,15 +32,31 @@ def _metadata(
     outcome: ProbeOutcome = ProbeOutcome.SUPPORTED,
     resource: str = URL,
     servers: list | None = None,
+    **extra: object,
 ) -> ProbeResult:
-    details = {"urls_tried": [METADATA_URL], "http_status": 200}
+    details: dict = {"urls_tried": [METADATA_URL], "http_status": 200}
     if outcome is ProbeOutcome.SUPPORTED:
         details |= {
             "metadata_url": METADATA_URL,
             "resource": resource,
             "authorization_servers": servers,
         }
+        details |= extra
     return ProbeResult(PROBE_AUTH_METADATA, outcome, details)
+
+
+def _full_metadata(**extra: object) -> ProbeResult:
+    """Build a good-posture metadata probe: HTTPS servers, AS metadata, scopes, PKCE."""
+    base: dict = {
+        "servers": ["https://auth.example"],
+        "scopes_supported": ["read", "write"],
+        "auth_server_issuer": "https://auth.example",
+        "auth_server_metadata_present": True,
+        "auth_server_has_endpoints": True,
+        "auth_server_pkce_s256": True,
+    }
+    base |= extra
+    return _metadata(**base)
 
 
 def _data(unauth: ProbeResult | None, metadata: ProbeResult | None = None) -> AuditData:
@@ -147,3 +168,91 @@ class TestAuthorizationServersHttps:
         assert result.passed is False
         assert result.details is not None
         assert result.details["invalid"] == [None, 123]
+
+
+class TestChallengeReferencesMetadata:
+    def test_passes_when_challenge_points_at_metadata(self):
+        unauth = _unauth(www_authenticate=f'Bearer resource_metadata="{METADATA_URL}"')
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is True
+
+    def test_fails_without_resource_metadata_param(self):
+        unauth = _unauth(www_authenticate='Bearer realm="mcp"')
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is False
+
+    def test_fails_on_cross_origin_reference(self):
+        unauth = _unauth(www_authenticate='Bearer resource_metadata="https://evil.example/.well-known/x"')
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is False
+        assert "not on this server's origin" in result.message
+
+    def test_passes_on_same_origin_different_path(self):
+        # Root PRM form in the header while the probe discovered the path-aware
+        # form — both valid RFC 9728 locations on the same origin.
+        unauth = _unauth(
+            www_authenticate='Bearer resource_metadata="https://server.example/.well-known/oauth-protected-resource"'
+        )
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is True
+
+    def test_skips_when_no_challenge_header(self):
+        # No metadata probe needed: this rule requires only the unauthenticated probe.
+        data = _data(_unauth(www_authenticate=None))
+        assert AuthChallengeReferencesMetadataRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+
+class TestMetadataHttps:
+    def test_passes_for_https(self):
+        result = AuthMetadataHttpsRule().check(_data(_unauth(), _full_metadata()))
+        assert result.passed is True
+
+    def test_fails_for_http_resource(self):
+        meta = _full_metadata(resource="http://server.example/mcp")
+        result = AuthMetadataHttpsRule().check(_data(_unauth(), meta))
+        assert result.passed is False
+
+
+class TestScopesAdvertised:
+    def test_passes_with_scopes(self):
+        result = AuthScopesAdvertisedRule().check(_data(_unauth(), _full_metadata()))
+        assert result.passed is True
+
+    def test_fails_without_scopes(self):
+        result = AuthScopesAdvertisedRule().check(_data(_unauth(), _full_metadata(scopes_supported=None)))
+        assert result.passed is False
+
+
+class TestAuthServerMetadataPresent:
+    def test_passes_with_endpoints(self):
+        result = AuthServerMetadataPresentRule().check(_data(_unauth(), _full_metadata()))
+        assert result.passed is True
+
+    def test_fails_when_absent(self):
+        meta = _full_metadata(auth_server_metadata_present=False, auth_server_has_endpoints=False)
+        result = AuthServerMetadataPresentRule().check(_data(_unauth(), meta))
+        assert result.passed is False
+
+    def test_fails_without_endpoints(self):
+        meta = _full_metadata(auth_server_has_endpoints=False)
+        result = AuthServerMetadataPresentRule().check(_data(_unauth(), meta))
+        assert result.passed is False
+        assert "endpoint" in result.message
+
+    def test_skips_when_no_authorization_server(self):
+        meta = _full_metadata(servers=[], auth_server_issuer=None)
+        assert AuthServerMetadataPresentRule().skip_reason(_data(_unauth(), meta)) == SKIP_REASON_INSUFFICIENT_DATA
+
+
+class TestAuthServerPkce:
+    def test_passes_with_s256(self):
+        result = AuthServerPkceRule().check(_data(_unauth(), _full_metadata()))
+        assert result.passed is True
+
+    def test_fails_without_s256(self):
+        result = AuthServerPkceRule().check(_data(_unauth(), _full_metadata(auth_server_pkce_s256=False)))
+        assert result.passed is False
+
+    def test_skips_when_no_as_metadata(self):
+        meta = _full_metadata(auth_server_metadata_present=False)
+        assert AuthServerPkceRule().skip_reason(_data(_unauth(), meta)) == SKIP_REASON_INSUFFICIENT_DATA

--- a/tests/test_auth_rules.py
+++ b/tests/test_auth_rules.py
@@ -26,7 +26,7 @@ def _unauth(status: int = 401, www_authenticate: str | None = 'Bearer resource_m
 def _metadata(
     outcome: ProbeOutcome = ProbeOutcome.SUPPORTED,
     resource: str = URL,
-    servers: list[str] | None = None,
+    servers: list | None = None,
 ) -> ProbeResult:
     details = {"urls_tried": [METADATA_URL], "http_status": 200}
     if outcome is ProbeOutcome.SUPPORTED:
@@ -133,4 +133,12 @@ class TestAuthorizationServersHttps:
         result = AuthAuthorizationServersHttpsRule().check(data)
         assert result.passed is False
         assert result.details is not None
-        assert result.details["insecure"] == ["http://insecure.example"]
+        assert result.details["invalid"] == ["http://insecure.example"]
+
+    def test_non_string_entries_fail(self):
+        """A non-empty list with no valid HTTPS strings must not pass (regression: it did)."""
+        data = _data(_unauth(), _metadata(servers=[None, 123]))
+        result = AuthAuthorizationServersHttpsRule().check(data)
+        assert result.passed is False
+        assert result.details is not None
+        assert result.details["invalid"] == [None, 123]

--- a/tests/test_auth_rules.py
+++ b/tests/test_auth_rules.py
@@ -125,6 +125,26 @@ class TestSkipGating:
         assert AuthServerPkceRule().skip_reason(data) is None
 
 
+class TestCitations:
+    def test_every_rule_cites_a_specific_section(self):
+        """details["basis"] is a per-rule, section-level citation (report contract)."""
+        data = _data(_unauth(), _full_metadata())
+        for rule_cls in (
+            AuthWwwAuthenticateRule,
+            AuthProtectedResourceMetadataRule,
+            AuthAuthorizationServersHttpsRule,
+            AuthChallengeReferencesMetadataRule,
+            AuthMetadataHttpsRule,
+            AuthScopesAdvertisedRule,
+            AuthServerMetadataPresentRule,
+            AuthServerPkceRule,
+        ):
+            details = rule_cls().check(data).details
+            assert details is not None
+            basis = details["basis"]
+            assert "§" in basis, f"{rule_cls.rule_id} basis lacks a section-level citation: {basis!r}"
+
+
 class TestWwwAuthenticate:
     def test_challenge_present_passes(self):
         result = AuthWwwAuthenticateRule().check(_data(_unauth()))

--- a/tests/test_auth_rules.py
+++ b/tests/test_auth_rules.py
@@ -103,6 +103,27 @@ class TestSkipGating:
         assert AuthAuthorizationServersHttpsRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
         assert AuthProtectedResourceMetadataRule().skip_reason(data) is None
 
+    def test_metadata_detail_rules_skip_when_metadata_unsupported(self):
+        """The deeper metadata rules have nothing to inspect without the document."""
+        data = _data(_unauth(), _metadata(outcome=ProbeOutcome.UNSUPPORTED))
+        assert AuthMetadataHttpsRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+        assert AuthScopesAdvertisedRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_as_metadata_rule_skips_without_an_issuer(self):
+        """No authorization server listed → the servers rule's finding, not this one's."""
+        data = _data(_unauth(), _full_metadata(auth_server_issuer=None))
+        assert AuthServerMetadataPresentRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_pkce_rule_skips_when_as_metadata_unreachable(self):
+        """Unreachable RFC 8414 metadata is the presence rule's finding — no double-counting."""
+        data = _data(_unauth(), _full_metadata(auth_server_metadata_present=False))
+        assert AuthServerPkceRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_deep_as_rules_run_with_full_metadata(self):
+        data = _data(_unauth(), _full_metadata())
+        assert AuthServerMetadataPresentRule().skip_reason(data) is None
+        assert AuthServerPkceRule().skip_reason(data) is None
+
 
 class TestWwwAuthenticate:
     def test_challenge_present_passes(self):

--- a/tests/test_capabilities_rules.py
+++ b/tests/test_capabilities_rules.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from mcp_types import ResourcesCapability
 from pydantic import BaseModel
 
@@ -73,3 +75,28 @@ def test_capabilities_feature_rules(capabilities_full, capabilities_missing):
     for rule in feature_rules:
         assert rule.check(AuditData(capabilities=capabilities_full)).passed
         assert not rule.check(AuditData(capabilities=capabilities_missing)).passed
+
+
+def test_capabilities_feature_rules_declared_but_disabled(capabilities_full):
+    """A capability that is declared but has the feature flag off must fail with 'not supported'.
+
+    Distinct from the capability being absent: this exercises the middle arm
+    (present, flag false) of each feature rule.
+    """
+    caps = replace(
+        capabilities_full,
+        tools=replace(capabilities_full.tools, list_changed=False),
+        prompts=replace(capabilities_full.prompts, list_changed=False),
+        resources=replace(capabilities_full.resources, list_changed=False, subscribe=False),
+    )
+    feature_rules = [
+        CapabilityToolsListChangedRule(),
+        CapabilityPromptsListChangedRule(),
+        CapabilityResourcesListChangedRule(),
+        CapabilityResourcesSubscribeRule(),
+    ]
+
+    for rule in feature_rules:
+        result = rule.check(AuditData(capabilities=caps))
+        assert result.passed is False
+        assert "not supported" in result.message

--- a/tests/test_capabilities_rules.py
+++ b/tests/test_capabilities_rules.py
@@ -35,7 +35,7 @@ def test_capabilities_presence_rules(capabilities_full, capabilities_missing):
 def test_capabilities_feature_rules(capabilities_full, capabilities_missing):
     """Test that capability feature rules correctly validate advanced capabilities.
 
-    This test verifies that rules for listChanged and subscribe features
+    This test verifies that rules for list_changed and subscribe features
     properly detect when these advanced capabilities are supported or missing
     in the server's capability declaration.
     """

--- a/tests/test_capabilities_rules.py
+++ b/tests/test_capabilities_rules.py
@@ -1,3 +1,6 @@
+from mcp_types import ResourcesCapability
+from pydantic import BaseModel
+
 from mcpscore.rules import (
     AuditData,
     CapabilityLoggingPresentRule,
@@ -10,7 +13,28 @@ from mcpscore.rules.capabilities import (
     CapabilityResourcesSubscribeRule,
     CapabilityToolsListChangedRule,
     CapabilityToolsPresentRule,
+    _wire_str,
 )
+
+
+class TestWireStr:
+    """The report must always show MCP wire field names, never SDK attribute names."""
+
+    def test_none_stays_none(self):
+        assert _wire_str(None) is None
+
+    def test_non_model_falls_back_to_str(self):
+        assert _wire_str("already a string") == "already a string"
+
+    def test_model_renders_wire_aliases(self):
+        capability = ResourcesCapability(subscribe=False, list_changed=True)
+        assert _wire_str(capability) == "subscribe=False listChanged=True"
+
+    def test_field_without_alias_uses_python_name(self):
+        class Plain(BaseModel):
+            flag: bool = True
+
+        assert _wire_str(Plain()) == "flag=True"
 
 
 def test_capabilities_presence_rules(capabilities_full, capabilities_missing):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -960,6 +960,41 @@ class TestAuthCliFlow:
         assert "HTTP 401" in reason
         assert "Partial audit" in caplog.text
 
+    async def test_rejected_credentials_get_verify_guidance(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+        caplog: LogCaptureFixture,
+    ) -> None:
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://gated.example/mcp", "--token", "expired"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.last_connection_error = ConnectionFailure(reason=ConnectionErrorReason.UNAUTHORIZED)
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+        mock_auditor.audit_partial = AsyncMock(return_value=True)
+        mock_auditor.get_audit_report = MagicMock(
+            return_value=_report_payload(score=19, max_score=19, partial=True, partial_reason="rejected")
+        )
+        mock_auditor.audit_data = MagicMock(transport_type=MCPTransportType.STREAMABLE_HTTP)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            caplog.at_level(logging.INFO),
+        ):
+            await async_main()
+
+        # Credentials were supplied and refused: the guidance must say so
+        # instead of advising the user to pass a token they already passed.
+        reason = mock_auditor.audit_partial.await_args.kwargs["reason"]
+        assert "rejected the provided credentials" in reason
+        assert "HTTP 401" in reason
+        assert "pass a token" not in reason
+        assert "rejected the provided credentials" in caplog.text
+
     async def test_non_auth_failure_still_exits_2(
         self,
         monkeypatch: MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -865,6 +865,17 @@ class TestCollectHeaders:
         with pytest.raises(ValueError, match="invalid header"):
             parse_header("nocolon")
 
+    def test_header_error_never_echoes_the_value(self) -> None:
+        from mcpscore.cli import build_parser, collect_headers
+
+        # A missing colon can mean the whole argument is a mistyped secret
+        # (e.g. "Authorization Bearer <token>"); the error text is logged, so
+        # it must identify the bad argument by position, never by content.
+        args = build_parser().parse_args(["https://x", "--header", "X-A: 1", "--header", "Authorization supersecret"])
+        with pytest.raises(ValueError, match="--header #2") as exc:
+            collect_headers(args)
+        assert "supersecret" not in str(exc.value)
+
     def test_collect_headers_empty(self) -> None:
         from mcpscore.cli import build_parser, collect_headers
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -259,7 +259,8 @@ class TestAsyncMain:
         assert exc_info.value.code == 2
         assert "Error connecting to the MCP server: /path/to/server.py" in caplog.text
         mock_auditor.audit.assert_not_called()
-        mock_client.cleanup.assert_not_called()
+        # Even a failed connection can leave resources on the exit stack.
+        mock_client.cleanup.assert_awaited_once()
 
     async def test_async_main_with_different_server_path(
         self,
@@ -486,7 +487,8 @@ class TestErrorHandling:
         assert exc_info.value.code == 2
         assert "Error connecting to the MCP server: https://example.com/mcp" in caplog.text
         mock_auditor.audit.assert_not_called()
-        mock_client.cleanup.assert_not_called()
+        # Even a failed connection can leave resources on the exit stack.
+        mock_client.cleanup.assert_awaited_once()
 
 
 class TestMainGuard:
@@ -970,6 +972,47 @@ class TestAuthCliFlow:
         assert "requires authentication" in reason
         assert "HTTP 401" in reason
         assert "Partial audit" in caplog.text
+
+    async def test_client_cleanup_runs_on_every_exit_path(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        """Early returns (modern-only, partial) and exit-2 must still close the client.
+
+        Failed detection attempts can leave resources on the client's exit
+        stack, so cleanup() has to run no matter how async_main() exits.
+        """
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.cleanup = AsyncMock()
+        mock_auditor.audit_partial = AsyncMock(return_value=True)
+        mock_auditor.get_audit_report = MagicMock(return_value=_report_payload(score=1, max_score=1))
+        mock_auditor.audit_data = MagicMock(transport_type=None)
+
+        scenarios = [
+            # (audit_modern_only result, connection failure, expects SystemExit)
+            (True, None, False),  # modern-only early return
+            (False, ConnectionFailure(reason=ConnectionErrorReason.UNAUTHORIZED), False),  # partial early return
+            (False, ConnectionFailure(reason=ConnectionErrorReason.UNREACHABLE), True),  # exit 2
+        ]
+        for modern, failure, exits in scenarios:
+            mock_client.cleanup.reset_mock()
+            mock_client.last_connection_error = failure
+            mock_auditor.audit_modern_only = AsyncMock(return_value=modern)
+            monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x.example/mcp"])
+            with (
+                patch("mcpscore.cli.MCPClient", return_value=mock_client),
+                patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            ):
+                if exits:
+                    with pytest.raises(SystemExit):
+                        await async_main()
+                else:
+                    await async_main()
+            mock_client.cleanup.assert_awaited_once()
 
     async def test_partial_audit_emits_json_report(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -954,6 +954,10 @@ class TestAuthCliFlow:
             await async_main()
 
         mock_auditor.audit_partial.assert_awaited_once()
+        # The reason describes the completed partial audit, not a hard failure.
+        reason = mock_auditor.audit_partial.await_args.kwargs["reason"]
+        assert "requires authentication" in reason
+        assert "HTTP 401" in reason
         assert "Partial audit" in caplog.text
 
     async def test_non_auth_failure_still_exits_2(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1079,6 +1079,44 @@ class TestAuthCliFlow:
         assert "pass a token" not in reason
         assert "rejected the provided credentials" in caplog.text
 
+    async def test_non_auth_headers_get_missing_credential_guidance(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+        caplog: LogCaptureFixture,
+    ) -> None:
+        """A tracing header is not a credential — a 401 means auth is missing, not rejected.
+
+        Keys off the same predicate as the report's authenticated flag, so the
+        log and the report never contradict each other.
+        """
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://gated.example/mcp", "--header", "X-Trace-Id: abc"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.last_connection_error = ConnectionFailure(reason=ConnectionErrorReason.UNAUTHORIZED)
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+        mock_auditor.audit_partial = AsyncMock(return_value=True)
+        mock_auditor.get_audit_report = MagicMock(
+            return_value=_report_payload(score=19, max_score=19, partial=True, partial_reason="requires auth")
+        )
+        mock_auditor.audit_data = MagicMock(transport_type=MCPTransportType.STREAMABLE_HTTP)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            caplog.at_level(logging.INFO),
+        ):
+            await async_main()
+
+        reason = mock_auditor.audit_partial.await_args.kwargs["reason"]
+        assert "requires authentication" in reason
+        assert "pass a token" in reason
+        assert "rejected" not in reason
+        assert "rejected" not in caplog.text
+
     async def test_non_auth_failure_still_exits_2(
         self,
         monkeypatch: MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,9 @@ def mock_client() -> MagicMock:
     client = MagicMock(spec=MCPClient)
     client.detect_and_connect = AsyncMock(return_value=(True, MCPTransportType.STDIO))
     client.cleanup = AsyncMock()
+    # Instance attribute (set in __init__) — spec'd mocks don't expose it, so
+    # assign explicitly; the partial-audit branch reads it on connect failure.
+    client.last_connection_error = None
     return client
 
 
@@ -62,6 +65,9 @@ def _report_payload(**overrides) -> dict:
     report = {
         "score": 85,
         "max_score": 100,
+        "authenticated": False,
+        "partial": False,
+        "partial_reason": None,
         "summary": {"total": 2, "passed": 1, "failed": 1, "skipped": 0, "by_severity": {}},
         "results": [],
         "skipped_rules": [],
@@ -842,3 +848,133 @@ class TestLogAuditOutcome:
             await async_main()
 
         assert "not assessed" in caplog.text
+
+
+class TestCollectHeaders:
+    """Tests for --header / --token / MCPSCORE_TOKEN parsing."""
+
+    def test_parse_header_splits_on_first_colon(self) -> None:
+        from mcpscore.cli import parse_header
+
+        assert parse_header("Authorization: Bearer abc") == ("Authorization", "Bearer abc")
+        assert parse_header("X-Trace: a:b:c") == ("X-Trace", "a:b:c")
+
+    def test_parse_header_rejects_missing_colon(self) -> None:
+        from mcpscore.cli import parse_header
+
+        with pytest.raises(ValueError, match="invalid header"):
+            parse_header("nocolon")
+
+    def test_collect_headers_empty(self) -> None:
+        from mcpscore.cli import build_parser, collect_headers
+
+        args = build_parser().parse_args(["https://x"])
+        assert collect_headers(args) == {}
+
+    def test_collect_headers_repeatable_and_token(self, monkeypatch: MonkeyPatch) -> None:
+        from mcpscore.cli import build_parser, collect_headers
+
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        args = build_parser().parse_args(["https://x", "--header", "X-A: 1", "--header", "X-B: 2", "--token", "tok"])
+        assert collect_headers(args) == {"X-A": "1", "X-B": "2", "Authorization": "Bearer tok"}
+
+    def test_explicit_authorization_header_wins_over_token(self, monkeypatch: MonkeyPatch) -> None:
+        from mcpscore.cli import build_parser, collect_headers
+
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        args = build_parser().parse_args(["https://x", "--header", "Authorization: Custom z", "--token", "tok"])
+        assert collect_headers(args) == {"Authorization": "Custom z"}
+
+    def test_token_falls_back_to_env(self, monkeypatch: MonkeyPatch) -> None:
+        from mcpscore.cli import build_parser, collect_headers
+
+        monkeypatch.setenv("MCPSCORE_TOKEN", "envtok")
+        args = build_parser().parse_args(["https://x"])
+        assert collect_headers(args) == {"Authorization": "Bearer envtok"}
+
+
+class TestAuthCliFlow:
+    """Tests for the auth-header and partial-audit CLI wiring."""
+
+    async def test_headers_passed_to_client_and_auditor(
+        self, monkeypatch: MonkeyPatch, mock_client: MagicMock, mock_auditor: MagicMock
+    ) -> None:
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--token", "secret"])
+        captured = {}
+
+        def capture_client(**kwargs):
+            captured["client_headers"] = kwargs.get("headers")
+            return mock_client
+
+        def capture_auditor(**kwargs):
+            captured["auditor_headers"] = kwargs.get("headers")
+            return mock_auditor
+
+        mock_client.detect_and_connect = AsyncMock(return_value=(True, MCPTransportType.STREAMABLE_HTTP))
+        with (
+            patch("mcpscore.cli.MCPClient", side_effect=capture_client),
+            patch("mcpscore.cli.MCPAuditor", side_effect=capture_auditor),
+        ):
+            await async_main()
+
+        assert captured["client_headers"] == {"Authorization": "Bearer secret"}
+        assert captured["auditor_headers"] == {"Authorization": "Bearer secret"}
+
+    async def test_bad_header_exits_1(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--header", "nocolon"])
+        with pytest.raises(SystemExit) as exc:
+            await async_main()
+        assert exc.value.code == 1
+
+    async def test_401_triggers_partial_audit(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+        caplog: LogCaptureFixture,
+    ) -> None:
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://gated.example/mcp"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.last_connection_error = ConnectionFailure(reason=ConnectionErrorReason.UNAUTHORIZED)
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+        mock_auditor.audit_partial = AsyncMock(return_value=True)
+        mock_auditor.get_audit_report = MagicMock(
+            return_value=_report_payload(score=19, max_score=19, partial=True, partial_reason="requires auth")
+        )
+        mock_auditor.audit_data = MagicMock(transport_type=MCPTransportType.STREAMABLE_HTTP)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            caplog.at_level(logging.INFO),
+        ):
+            await async_main()
+
+        mock_auditor.audit_partial.assert_awaited_once()
+        assert "Partial audit" in caplog.text
+
+    async def test_non_auth_failure_still_exits_2(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://down.example/mcp"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.last_connection_error = ConnectionFailure(reason=ConnectionErrorReason.UNREACHABLE)
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            pytest.raises(SystemExit) as exc,
+        ):
+            await async_main()
+
+        assert exc.value.code == 2
+        mock_auditor.audit_partial.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -971,6 +971,36 @@ class TestAuthCliFlow:
         assert "HTTP 401" in reason
         assert "Partial audit" in caplog.text
 
+    async def test_partial_audit_emits_json_report(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+        capsys,
+    ) -> None:
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://gated.example/mcp", "--json"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.last_connection_error = ConnectionFailure(reason=ConnectionErrorReason.UNAUTHORIZED)
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+        mock_auditor.audit_partial = AsyncMock(return_value=True)
+        mock_auditor.get_audit_report = MagicMock(
+            return_value=_report_payload(score=19, max_score=19, partial=True, partial_reason="requires auth")
+        )
+        mock_auditor.audit_data = MagicMock(transport_type=None)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        report = json.loads(capsys.readouterr().out)
+        assert report["target"] == "https://gated.example/mcp"
+        assert report["partial"] is True
+        assert report["partial_reason"] == "requires auth"
+
     async def test_rejected_credentials_get_verify_guidance(
         self,
         monkeypatch: MonkeyPatch,

--- a/tests/test_mcp_client_connection_error.py
+++ b/tests/test_mcp_client_connection_error.py
@@ -8,7 +8,7 @@ message instead of a flat "could not connect".
 from contextlib import AsyncExitStack
 from unittest.mock import MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from mcpscore.enums import ConnectionErrorReason, MCPTransportType
@@ -21,10 +21,10 @@ from mcpscore.mcp_client import (
 )
 
 
-def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+def _http_status_error(status_code: int) -> httpx2.HTTPStatusError:
     response = MagicMock()
     response.status_code = status_code
-    return httpx.HTTPStatusError("boom", request=MagicMock(), response=response)
+    return httpx2.HTTPStatusError("boom", request=MagicMock(), response=response)
 
 
 class TestReasonForStatus:
@@ -110,7 +110,7 @@ class TestConnectRecordsFailure:
 
     async def test_connect_error_is_unreachable(self, mcp_client):
         with patch("mcpscore.mcp_client.streamable_http_client") as mock_client:
-            mock_client.return_value.__aenter__.side_effect = httpx.ConnectError("refused")
+            mock_client.return_value.__aenter__.side_effect = httpx2.ConnectError("refused")
 
             result = await mcp_client.connect_to_server(MCPTransportType.STREAMABLE_HTTP, "https://example.com/mcp")
 

--- a/tests/test_mcp_client_http.py
+++ b/tests/test_mcp_client_http.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from mcpscore.enums import MCPTransportType
@@ -64,7 +64,7 @@ class TestMCPClientHTTP:
 
         with patch("mcpscore.mcp_client.streamable_http_client") as mock_client:
             # Simulate connection error
-            mock_client.return_value.__aenter__.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.return_value.__aenter__.side_effect = httpx2.ConnectError("Connection refused")
 
             result = await mcp_client.connect_to_server(MCPTransportType.STREAMABLE_HTTP, server_url)
 
@@ -76,7 +76,7 @@ class TestMCPClientHTTP:
 
         with patch("mcpscore.mcp_client.streamable_http_client") as mock_client:
             # Simulate timeout
-            mock_client.return_value.__aenter__.side_effect = httpx.TimeoutException("Request timed out")
+            mock_client.return_value.__aenter__.side_effect = httpx2.TimeoutException("Request timed out")
 
             result = await mcp_client.connect_to_server(MCPTransportType.STREAMABLE_HTTP, server_url)
 
@@ -90,7 +90,7 @@ class TestMCPClientHTTP:
             # Simulate 404 error
             mock_response = MagicMock()
             mock_response.status_code = 404
-            http_error = httpx.HTTPStatusError("Not Found", request=MagicMock(), response=mock_response)
+            http_error = httpx2.HTTPStatusError("Not Found", request=MagicMock(), response=mock_response)
             mock_client.return_value.__aenter__.side_effect = http_error
 
             result = await mcp_client.connect_to_server(MCPTransportType.STREAMABLE_HTTP, server_url)
@@ -136,7 +136,7 @@ class TestMCPClientHTTP:
             patch("mcpscore.mcp_client.ClientSession", return_value=mock_session),
         ):
             # HTTP fails
-            mock_http_client.return_value.__aenter__.side_effect = httpx.ConnectError("Connection refused")
+            mock_http_client.return_value.__aenter__.side_effect = httpx2.ConnectError("Connection refused")
 
             # SSE succeeds
             mock_sse_client.return_value.__aenter__.return_value = (mock_read_stream, mock_write_stream)
@@ -173,8 +173,8 @@ class TestMCPClientHTTP:
             patch("mcpscore.mcp_client.sse_client") as mock_sse_client,
         ):
             # Both fail
-            mock_http_client.return_value.__aenter__.side_effect = httpx.ConnectError("Connection refused")
-            mock_sse_client.return_value.__aenter__.side_effect = httpx.ConnectError("Connection refused")
+            mock_http_client.return_value.__aenter__.side_effect = httpx2.ConnectError("Connection refused")
+            mock_sse_client.return_value.__aenter__.side_effect = httpx2.ConnectError("Connection refused")
 
             success, transport = await mcp_client.detect_and_connect(server_url)
 

--- a/tests/test_mcp_client_session.py
+++ b/tests/test_mcp_client_session.py
@@ -3,8 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from mcp import InitializeResult, ListPromptsResult, ListResourcesResult, ListToolsResult
-from mcp.types import Prompt, Resource, Tool
-from pydantic import AnyUrl
+from mcp_types import Prompt, Resource, Tool
 import pytest
 
 from mcpscore.mcp_client import ERROR_NO_ACTIVE_SESSION, MCPClient
@@ -71,8 +70,8 @@ class TestMCPClientSessionOperations:
     async def test_list_tools_success(self, mock_connected_client):
         """Test successful list_tools."""
         mock_tools = [
-            Tool(name="tool1", description="Test tool 1", inputSchema={"type": "object"}),
-            Tool(name="tool2", description="Test tool 2", inputSchema={"type": "object"}),
+            Tool(name="tool1", description="Test tool 1", input_schema={"type": "object"}),
+            Tool(name="tool2", description="Test tool 2", input_schema={"type": "object"}),
         ]
         mock_result = ListToolsResult(tools=mock_tools)
         mock_connected_client.session.list_tools.return_value = mock_result
@@ -103,8 +102,8 @@ class TestMCPClientSessionOperations:
     async def test_list_resources_success(self, mock_connected_client):
         """Test successful list_resources."""
         mock_resources = [
-            Resource(uri=AnyUrl("file:///test1.txt"), name="Test Resource 1", mimeType="text/plain"),
-            Resource(uri=AnyUrl("file:///test2.txt"), name="Test Resource 2", mimeType="text/plain"),
+            Resource(uri="file:///test1.txt", name="Test Resource 1", mime_type="text/plain"),
+            Resource(uri="file:///test2.txt", name="Test Resource 2", mime_type="text/plain"),
         ]
         mock_result = ListResourcesResult(resources=mock_resources)
         mock_connected_client.session.list_resources.return_value = mock_result

--- a/tests/test_mcp_client_sse.py
+++ b/tests/test_mcp_client_sse.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from mcpscore.enums import MCPTransportType
@@ -59,7 +59,7 @@ class TestMCPClientSSE:
 
         with patch("mcpscore.mcp_client.sse_client") as mock_client:
             # Simulate connection error
-            mock_client.return_value.__aenter__.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.return_value.__aenter__.side_effect = httpx2.ConnectError("Connection refused")
 
             result = await mcp_client.connect_to_server(MCPTransportType.SSE, server_url)
 
@@ -71,7 +71,7 @@ class TestMCPClientSSE:
 
         with patch("mcpscore.mcp_client.sse_client") as mock_client:
             # Simulate timeout
-            mock_client.return_value.__aenter__.side_effect = httpx.TimeoutException("Request timed out")
+            mock_client.return_value.__aenter__.side_effect = httpx2.TimeoutException("Request timed out")
 
             result = await mcp_client.connect_to_server(MCPTransportType.SSE, server_url)
 
@@ -85,7 +85,7 @@ class TestMCPClientSSE:
             # Simulate 500 error
             mock_response = MagicMock()
             mock_response.status_code = 500
-            http_error = httpx.HTTPStatusError("Internal Server Error", request=MagicMock(), response=mock_response)
+            http_error = httpx2.HTTPStatusError("Internal Server Error", request=MagicMock(), response=mock_response)
             mock_client.return_value.__aenter__.side_effect = http_error
 
             result = await mcp_client.connect_to_server(MCPTransportType.SSE, server_url)
@@ -158,7 +158,7 @@ class TestMCPClientSSE:
                 # Verify that httpx_client_factory parameter is passed
                 assert "httpx_client_factory" in kwargs
                 client_factory = kwargs["httpx_client_factory"]
-                # Test the factory returns an httpx.AsyncClient
+                # Test the factory returns an httpx2.AsyncClient
                 client = client_factory()
                 assert client is not None
                 mock_context = MagicMock()

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -336,3 +336,23 @@ async def test_audit_partial_threads_headers_to_probes(monkeypatch: pytest.Monke
     await auditor.audit_partial(GATED_URL, reason="auth")
     assert captured["headers"] == {"Authorization": "Bearer tok"}
     assert auditor.get_audit_report()["authenticated"] is True
+
+
+async def test_non_authorization_headers_do_not_mark_authenticated(stub_probes, monkeypatch: pytest.MonkeyPatch):
+    """A tracing/custom header is not a credential — the report must not claim auth."""
+    stub_probes(_auth_gated_probe_results())
+    monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+    auditor = MCPAuditor(headers={"X-Trace-Id": "abc123"})
+    await auditor.audit_partial(GATED_URL, reason="auth")
+    assert auditor.get_audit_report()["authenticated"] is False
+
+
+async def test_audit_partial_over_http_records_unverified_tls(stub_probes):
+    """A plain-http target cannot verify TLS; the report must not claim it did."""
+    stub_probes(_auth_gated_probe_results())
+
+    auditor = MCPAuditor()
+    assert await auditor.audit_partial("http://server.example/mcp", reason="auth") is True
+    assert auditor.audit_data.tls_verified is False
+    assert auditor.audit_data.tls_version is None

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -301,7 +301,7 @@ async def test_audit_partial_scores_auth_and_skips_session(stub_probes, monkeypa
     assert report["partial_reason"] == "requires auth (HTTP 401)"
 
     scored = {r["rule_id"] for r in report["results"]}
-    # Auth-posture + TLS + transport rules run on probe/transport data.
+    # Auth-posture and TLS rules run on probe/transport data.
     assert "auth_www_authenticate" in scored
     assert "auth_protected_resource_metadata" in scored
     assert "security_tls_enabled" in scored
@@ -310,6 +310,16 @@ async def test_audit_partial_scores_auth_and_skips_session(stub_probes, monkeypa
     assert skipped.get("tools_at_least_one") == "insufficient-data"
     assert skipped.get("server_name_present") == "insufficient-data"
     assert skipped.get("capability_tools_present") == "insufficient-data"
+    # No transport was established, so the transport rule cannot claim a pass.
+    assert "transport_streamable_http" not in scored
+    assert skipped.get("transport_streamable_http") == "insufficient-data"
+    # error_response is never collected, so its rules must not auto-pass here.
+    assert "security_malformed_request_handling" not in scored
+    assert "security_error_data_leak" not in scored
+    assert skipped.get("security_malformed_request_handling") == "insufficient-data"
+    assert skipped.get("security_error_data_leak") == "insufficient-data"
+    # Transport left unverified in the audit data.
+    assert auditor.audit_data.transport_type is None
 
 
 async def test_audit_partial_threads_headers_to_probes(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -56,7 +56,7 @@ def stub_probes(monkeypatch: pytest.MonkeyPatch):
     """Point the auditor's probe runner at canned results."""
 
     def install(results: dict[str, ProbeResult]) -> None:
-        async def fake_run_all_probes(url: str, client=None) -> dict[str, ProbeResult]:
+        async def fake_run_all_probes(url: str, client=None, headers=None) -> dict[str, ProbeResult]:
             return results
 
         monkeypatch.setattr(mcp_auditor, "run_all_probes", fake_run_all_probes)
@@ -254,3 +254,75 @@ class TestAuditorReuseDoesNotLeakState:
         assert await auditor.audit_modern_only(URL) is False
 
         assert len(auditor.results) == results_before
+
+
+# --- Partial audit (auth-gated servers) --------------------------------------
+
+from mcpscore.probes import PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED  # noqa: E402
+
+
+def _auth_gated_probe_results() -> dict[str, ProbeResult]:
+    """Probe results for a well-behaved auth-gated server: 401 + RFC 9728 metadata."""
+    results = not_applicable_results(reason="unset")
+    results[PROBE_UNAUTHENTICATED] = ProbeResult(
+        PROBE_UNAUTHENTICATED,
+        ProbeOutcome.SUPPORTED,
+        {"http_status": 401, "www_authenticate": 'Bearer resource_metadata="..."'},
+    )
+    results[PROBE_AUTH_METADATA] = ProbeResult(
+        PROBE_AUTH_METADATA,
+        ProbeOutcome.SUPPORTED,
+        {
+            "urls_tried": ["https://gated.example/.well-known/oauth-protected-resource/mcp"],
+            "metadata_url": "https://gated.example/.well-known/oauth-protected-resource/mcp",
+            "resource": "https://gated.example/mcp",
+            "authorization_servers": ["https://auth.example"],
+        },
+    )
+    return results
+
+
+GATED_URL = "https://gated.example/mcp"
+
+
+async def test_audit_partial_returns_false_for_non_url():
+    assert await MCPAuditor().audit_partial("/path/to/server.py", reason="x") is False
+
+
+async def test_audit_partial_scores_auth_and_skips_session(stub_probes, monkeypatch: pytest.MonkeyPatch):
+    stub_probes(_auth_gated_probe_results())
+    monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+    auditor = MCPAuditor()
+    assert await auditor.audit_partial(GATED_URL, reason="requires auth (HTTP 401)") is True
+
+    report = auditor.get_audit_report()
+    assert report["partial"] is True
+    assert report["partial_reason"] == "requires auth (HTTP 401)"
+
+    scored = {r["rule_id"] for r in report["results"]}
+    # Auth-posture + TLS + transport rules run on probe/transport data.
+    assert "auth_www_authenticate" in scored
+    assert "auth_protected_resource_metadata" in scored
+    assert "security_tls_enabled" in scored
+    # Session-dependent rules skip as insufficient-data, never fail.
+    skipped = {s["rule_id"]: s["reason"] for s in report["skipped_rules"]}
+    assert skipped.get("tools_at_least_one") == "insufficient-data"
+    assert skipped.get("server_name_present") == "insufficient-data"
+    assert skipped.get("capability_tools_present") == "insufficient-data"
+
+
+async def test_audit_partial_threads_headers_to_probes(monkeypatch: pytest.MonkeyPatch):
+    captured = {}
+
+    async def fake_run_all_probes(url: str, client=None, headers=None) -> dict[str, ProbeResult]:
+        captured["headers"] = headers
+        return _auth_gated_probe_results()
+
+    monkeypatch.setattr(mcp_auditor, "run_all_probes", fake_run_all_probes)
+    monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+    auditor = MCPAuditor(headers={"Authorization": "Bearer tok"})
+    await auditor.audit_partial(GATED_URL, reason="auth")
+    assert captured["headers"] == {"Authorization": "Bearer tok"}
+    assert auditor.get_audit_report()["authenticated"] is True

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -514,6 +514,45 @@ async def test_run_all_probes_creates_its_own_client_when_none_given(monkeypatch
 class TestAnonymousProbes:
     """The unauthenticated and metadata probes must not send a caller's bearer."""
 
+    async def test_own_client_path_keeps_all_caller_headers_off_anonymous_probes(self, monkeypatch):
+        """Anonymous probes run on a client with no caller headers at all.
+
+        --header can carry non-Authorization credentials (API keys, cookies);
+        they must not reach the unauthenticated probe or the auth-discovery
+        fetches — the latter can leave the server's origin entirely.
+        """
+        requests_log: list[httpx2.Request] = []
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            requests_log.append(request)
+            if request.url.path.startswith("/.well-known/"):
+                return httpx2.Response(200, json={"resource": URL, "authorization_servers": ["https://as.example"]})
+            return httpx2.Response(401, headers={"WWW-Authenticate": "Bearer"}, json={})
+
+        transport = httpx2.MockTransport(handler)
+        real_async_client = httpx2.AsyncClient
+
+        def patched_client(**kwargs):
+            kwargs.setdefault("transport", transport)
+            return real_async_client(**kwargs)
+
+        monkeypatch.setattr(httpx2, "AsyncClient", patched_client)
+
+        await run_all_probes(URL, headers={"X-Api-Key": "sekret", "Authorization": "Bearer tok"})
+
+        wellknown = [r for r in requests_log if r.url.path.startswith("/.well-known/")]
+        assert wellknown, "auth-metadata discovery should have run"
+        for request in wellknown:
+            assert "X-Api-Key" not in request.headers
+            assert "Authorization" not in request.headers
+        # The unauthenticated probe's request reached the server with neither header.
+        assert any(
+            r.url.path == "/mcp" and "X-Api-Key" not in r.headers and "Authorization" not in r.headers
+            for r in requests_log
+        )
+        # Authenticated probes still carry the caller's headers.
+        assert any(r.headers.get("X-Api-Key") == "sekret" for r in requests_log)
+
     async def test_unauthenticated_probe_strips_authorization(self):
         from mcpscore.probes import _probe_unauthenticated
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -343,7 +343,7 @@ async def test_auditor_runs_probes_for_http_url(monkeypatch):
 
     seen: dict = {}
 
-    async def fake_run_all_probes(url: str, client=None):
+    async def fake_run_all_probes(url: str, client=None, headers=None):
         seen["url"] = url
         return {PROBE_DISCOVER: ProbeResult(PROBE_DISCOVER, ProbeOutcome.SUPPORTED, {})}
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -454,3 +454,44 @@ async def test_run_all_probes_creates_its_own_client_when_none_given(monkeypatch
     results = await run_all_probes(URL)  # no client injected -> own-client branch
 
     assert set(results) == set(PROBE_IDS)
+
+
+class TestAnonymousProbes:
+    """The unauthenticated and metadata probes must not send a caller's bearer."""
+
+    async def test_unauthenticated_probe_strips_authorization(self):
+        from mcpscore.probes import _probe_unauthenticated
+
+        seen_auth: dict[str, str | None] = {}
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            seen_auth["post"] = request.headers.get("Authorization")
+            return httpx2.Response(401, headers={"WWW-Authenticate": "Bearer"}, json={})
+
+        # Client carries a default bearer, as if --token was passed.
+        async with httpx2.AsyncClient(
+            transport=httpx2.MockTransport(handler), headers={"Authorization": "Bearer secret"}
+        ) as client:
+            result = await _probe_unauthenticated(client, URL)
+
+        # The probe reached the server without the bearer, so it saw the 401 challenge.
+        assert seen_auth["post"] is None
+        assert result.details["http_status"] == 401
+        assert result.details["www_authenticate"] == "Bearer"
+
+    async def test_auth_metadata_probe_strips_authorization(self):
+        seen_auth: dict[str, str | None] = {}
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method == "GET":
+                seen_auth["get"] = request.headers.get("Authorization")
+                return httpx2.Response(200, json={"resource": URL})
+            return httpx2.Response(401)
+
+        async with httpx2.AsyncClient(
+            transport=httpx2.MockTransport(handler), headers={"Authorization": "Bearer secret"}
+        ) as client:
+            results = await run_all_probes(URL, client=client)
+
+        assert seen_auth["get"] is None
+        assert results[PROBE_AUTH_METADATA].outcome is ProbeOutcome.SUPPORTED

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -10,6 +10,7 @@ from mcpscore.probes import (
     ERROR_LEGACY_RESOURCE_NOT_FOUND,
     ERROR_UNSUPPORTED_PROTOCOL_VERSION,
     META_PREFIX,
+    PROBE_AUTH_METADATA,
     PROBE_DISCOVER,
     PROBE_HEADER_MISMATCH,
     PROBE_IDS,
@@ -22,6 +23,7 @@ from mcpscore.probes import (
     PROBE_UNKNOWN_VERSION,
     ProbeOutcome,
     ProbeResult,
+    _well_known_urls,
     not_applicable_results,
     run_all_probes,
 )
@@ -43,8 +45,16 @@ def _rpc_result(request_id, result: dict):
     return httpx2.Response(200, json={"jsonrpc": "2.0", "id": request_id, "result": result})
 
 
+AUTH_SERVERS = ["https://auth.example"]
+
+
 def _modern_server_handler(request: httpx2.Request) -> httpx2.Response:
     """Simulate a server implementing the 2026-07-28 behaviors the probes check."""
+    if request.method == "GET":
+        # RFC 9728 path-aware well-known location for URL's /mcp path.
+        if request.url.path == "/.well-known/oauth-protected-resource/mcp":
+            return httpx2.Response(200, json={"resource": URL, "authorization_servers": AUTH_SERVERS})
+        return httpx2.Response(404)
     body = json.loads(request.content)
     request_id = body.get("id")
     method = body["method"]
@@ -92,6 +102,8 @@ def _modern_server_handler(request: httpx2.Request) -> httpx2.Response:
 
 def _legacy_server_handler(request: httpx2.Request) -> httpx2.Response:
     """Simulate a stateful 2025-11-25 server: no session → everything is an error."""
+    if request.method == "GET":
+        return httpx2.Response(404)
     body = json.loads(request.content)
     if body["method"] == "resources/read":
         return _rpc_error(body.get("id"), ERROR_LEGACY_RESOURCE_NOT_FOUND, "Resource not found", http_status=200)
@@ -154,6 +166,73 @@ async def test_legacy_server_is_unsupported_but_observed():
     # The legacy resource-not-found code is recorded for the migration rule.
     assert results[PROBE_MISSING_RESOURCE].details["error_code"] == ERROR_LEGACY_RESOURCE_NOT_FOUND
     assert results[PROBE_MISSING_RESOURCE].details["legacy_code_emitted"] is True
+
+    # No well-known metadata anywhere → UNSUPPORTED, with both locations tried.
+    auth = results[PROBE_AUTH_METADATA]
+    assert auth.outcome is ProbeOutcome.UNSUPPORTED
+    assert len(auth.details["urls_tried"]) == 2
+
+
+class TestWellKnownUrls:
+    def test_path_aware_form_first_then_root(self):
+        assert _well_known_urls("https://server.example/mcp") == [
+            "https://server.example/.well-known/oauth-protected-resource/mcp",
+            "https://server.example/.well-known/oauth-protected-resource",
+        ]
+
+    def test_root_resource_has_single_location(self):
+        assert _well_known_urls("https://server.example") == [
+            "https://server.example/.well-known/oauth-protected-resource",
+        ]
+
+    def test_trailing_slash_is_normalized(self):
+        assert _well_known_urls("https://server.example/mcp/") == [
+            "https://server.example/.well-known/oauth-protected-resource/mcp",
+            "https://server.example/.well-known/oauth-protected-resource",
+        ]
+
+
+class TestAuthMetadataProbe:
+    async def test_modern_server_serves_path_aware_metadata(self):
+        results = await _run(_modern_server_handler)
+        auth = results[PROBE_AUTH_METADATA]
+        assert auth.outcome is ProbeOutcome.SUPPORTED
+        assert auth.details["metadata_url"].endswith("/oauth-protected-resource/mcp")
+        assert auth.details["resource"] == URL
+        assert auth.details["authorization_servers"] == AUTH_SERVERS
+        assert auth.payload == {"resource": URL, "authorization_servers": AUTH_SERVERS}
+
+    async def test_falls_back_to_origin_root_location(self):
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method == "GET" and request.url.path == "/.well-known/oauth-protected-resource":
+                return httpx2.Response(200, json={"resource": URL})
+            if request.method == "GET":
+                return httpx2.Response(404)
+            return _modern_server_handler(request)
+
+        results = await _run(handler)
+        auth = results[PROBE_AUTH_METADATA]
+        assert auth.outcome is ProbeOutcome.SUPPORTED
+        assert auth.details["metadata_url"] == "https://server.example/.well-known/oauth-protected-resource"
+        assert auth.details["authorization_servers"] is None
+
+    async def test_invalid_json_is_unsupported(self):
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method == "GET":
+                return httpx2.Response(200, text="<html>not metadata</html>")
+            return _modern_server_handler(request)
+
+        results = await _run(handler)
+        assert results[PROBE_AUTH_METADATA].outcome is ProbeOutcome.UNSUPPORTED
+
+    async def test_metadata_without_resource_field_is_unsupported(self):
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method == "GET":
+                return httpx2.Response(200, json={"authorization_servers": AUTH_SERVERS})
+            return _modern_server_handler(request)
+
+        results = await _run(handler)
+        assert results[PROBE_AUTH_METADATA].outcome is ProbeOutcome.UNSUPPORTED
 
 
 async def test_network_failure_yields_error_outcomes_not_exceptions():

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 
 from mcpscore.probes import (
     ERROR_HEADER_MISMATCH,
@@ -33,17 +33,17 @@ def _rpc_error(request_id, code: int, message: str, data: dict | None = None, ht
     error: dict = {"code": code, "message": message}
     if data is not None:
         error["data"] = data
-    return httpx.Response(
+    return httpx2.Response(
         http_status,
         json={"jsonrpc": "2.0", "id": request_id, "error": error},
     )
 
 
 def _rpc_result(request_id, result: dict):
-    return httpx.Response(200, json={"jsonrpc": "2.0", "id": request_id, "result": result})
+    return httpx2.Response(200, json={"jsonrpc": "2.0", "id": request_id, "result": result})
 
 
-def _modern_server_handler(request: httpx.Request) -> httpx.Response:
+def _modern_server_handler(request: httpx2.Request) -> httpx2.Response:
     """Simulate a server implementing the 2026-07-28 behaviors the probes check."""
     body = json.loads(request.content)
     request_id = body.get("id")
@@ -90,19 +90,19 @@ def _modern_server_handler(request: httpx.Request) -> httpx.Response:
     return _rpc_error(request_id, -32601, "Method not found", http_status=404)
 
 
-def _legacy_server_handler(request: httpx.Request) -> httpx.Response:
+def _legacy_server_handler(request: httpx2.Request) -> httpx2.Response:
     """Simulate a stateful 2025-11-25 server: no session → everything is an error."""
     body = json.loads(request.content)
     if body["method"] == "resources/read":
         return _rpc_error(body.get("id"), ERROR_LEGACY_RESOURCE_NOT_FOUND, "Resource not found", http_status=200)
-    return httpx.Response(
+    return httpx2.Response(
         400,
         json={"jsonrpc": "2.0", "id": body.get("id"), "error": {"code": -32600, "message": "Bad Request: no session"}},
     )
 
 
-def _client(handler) -> httpx.AsyncClient:
-    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+def _client(handler) -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(transport=httpx2.MockTransport(handler))
 
 
 async def _run(handler) -> dict[str, ProbeResult]:
@@ -157,8 +157,8 @@ async def test_legacy_server_is_unsupported_but_observed():
 
 
 async def test_network_failure_yields_error_outcomes_not_exceptions():
-    def handler(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("connection refused")
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("connection refused")
 
     results = await _run(handler)
 
@@ -168,8 +168,8 @@ async def test_network_failure_yields_error_outcomes_not_exceptions():
 
 
 async def test_non_mcp_endpoint_is_unsupported():
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text="<html>not an MCP server</html>")
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, text="<html>not an MCP server</html>")
 
     results = await _run(handler)
 
@@ -178,10 +178,10 @@ async def test_non_mcp_endpoint_is_unsupported():
 
 
 async def test_sse_response_body_is_parsed():
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         body = json.loads(request.content)
         if body["method"] != "server/discover" or request.headers.get("Mcp-Method") != "server/discover":
-            return httpx.Response(
+            return httpx2.Response(
                 400, json={"jsonrpc": "2.0", "id": body.get("id"), "error": {"code": -32600, "message": "bad"}}
             )
         message = {
@@ -194,7 +194,7 @@ async def test_sse_response_body_is_parsed():
                 "cacheScope": "private",
             },
         }
-        return httpx.Response(
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             text=f"event: message\ndata: {json.dumps(message)}\n\n",
@@ -208,8 +208,8 @@ async def test_sse_response_body_is_parsed():
 
 
 async def test_unauthenticated_probe_records_challenge():
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
             401,
             headers={
                 "WWW-Authenticate": 'Bearer resource_metadata="https://server.example/.well-known/oauth-protected-resource"'
@@ -282,7 +282,7 @@ async def test_auditor_runs_probes_for_http_url(monkeypatch):
 async def test_leaky_modern_server_is_detected():
     """A server speaking the modern lifecycle but leaking legacy artifacts."""
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         body = json.loads(request.content)
         request_id = body.get("id")
         method = body["method"]
@@ -326,16 +326,16 @@ async def test_probe_payloads_are_captured_for_data_extraction():
 
 
 async def test_sse_response_without_data_line_is_unsupported():
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, headers={"content-type": "text/event-stream"}, text="event: ping\n\n")
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, text="event: ping\n\n")
 
     results = await _run(handler)
     assert results[PROBE_DISCOVER].outcome is ProbeOutcome.UNSUPPORTED
 
 
 async def test_error_without_message_field_is_handled():
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(400, json={"jsonrpc": "2.0", "id": 1, "error": {"code": -32600}})
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(400, json={"jsonrpc": "2.0", "id": 1, "error": {"code": -32600}})
 
     results = await _run(handler)
     details = results[PROBE_DISCOVER].details
@@ -344,9 +344,9 @@ async def test_error_without_message_field_is_handled():
 
 
 async def test_unknown_version_error_with_non_dict_data():
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         body = json.loads(request.content)
-        return httpx.Response(
+        return httpx2.Response(
             400,
             json={
                 "jsonrpc": "2.0",
@@ -365,7 +365,7 @@ async def test_run_all_probes_creates_its_own_client_when_none_given(monkeypatch
     from mcpscore import probes as probes_module
 
     def make_stub(probe_id: str):
-        async def stub(client: httpx.AsyncClient, url: str) -> ProbeResult:
+        async def stub(client: httpx2.AsyncClient, url: str) -> ProbeResult:
             return ProbeResult(probe_id, ProbeOutcome.SUPPORTED, {"stubbed": True})
 
         return stub

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -216,6 +216,61 @@ class TestAuthMetadataProbe:
         assert auth.details["metadata_url"] == "https://server.example/.well-known/oauth-protected-resource"
         assert auth.details["authorization_servers"] is None
 
+    async def test_walks_to_authorization_server_metadata(self):
+        """PRM → first authorization server's RFC 8414 metadata (endpoints + PKCE)."""
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            path = request.url.path
+            if path == "/.well-known/oauth-protected-resource/mcp":
+                return httpx2.Response(200, json={"resource": URL, "authorization_servers": ["https://auth.example"]})
+            if request.url.host == "auth.example" and path == "/.well-known/oauth-authorization-server":
+                return httpx2.Response(
+                    200,
+                    json={
+                        "issuer": "https://auth.example",
+                        "authorization_endpoint": "https://auth.example/authorize",
+                        "token_endpoint": "https://auth.example/token",
+                        "code_challenge_methods_supported": ["S256"],
+                    },
+                )
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        d = results[PROBE_AUTH_METADATA].details
+        assert d["auth_server_metadata_present"] is True
+        assert d["auth_server_has_endpoints"] is True
+        assert d["auth_server_pkce_s256"] is True
+        assert d["auth_server_issuer"] == "https://auth.example"
+
+    async def test_authorization_server_without_pkce(self):
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            path = request.url.path
+            if path == "/.well-known/oauth-protected-resource/mcp":
+                return httpx2.Response(200, json={"resource": URL, "authorization_servers": ["https://auth.example"]})
+            if request.url.host == "auth.example":
+                # OIDC fallback path, no PKCE advertised.
+                if path == "/.well-known/openid-configuration":
+                    return httpx2.Response(
+                        200,
+                        json={
+                            "issuer": "https://auth.example",
+                            "authorization_endpoint": "https://auth.example/authorize",
+                            "token_endpoint": "https://auth.example/token",
+                        },
+                    )
+                return httpx2.Response(404)
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        d = results[PROBE_AUTH_METADATA].details
+        assert d["auth_server_metadata_present"] is True  # found via OIDC fallback
+        assert d["auth_server_has_endpoints"] is True
+        assert d["auth_server_pkce_s256"] is False
+
     async def test_invalid_json_is_unsupported(self):
         def handler(request: httpx2.Request) -> httpx2.Response:
             if request.method == "GET":
@@ -478,6 +533,30 @@ class TestAnonymousProbes:
         assert seen_auth["post"] is None
         assert result.details["http_status"] == 401
         assert result.details["www_authenticate"] == "Bearer"
+
+    async def test_unauthenticated_probe_survives_oauth_error_body(self):
+        """An RFC 6750 401 body must not crash the probe.
+
+        Its ``error`` field is a string (``"invalid_token"``), not a JSON-RPC
+        error object.
+        """
+        from mcpscore.probes import _probe_unauthenticated
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(
+                401,
+                headers={"WWW-Authenticate": "Bearer"},
+                json={"error": "invalid_token", "error_description": "Authentication required"},
+            )
+
+        async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
+            result = await _probe_unauthenticated(client, URL)
+
+        assert result.outcome is ProbeOutcome.SUPPORTED
+        assert result.details["http_status"] == 401
+        assert result.details["www_authenticate"] == "Bearer"
+        # The string "error" is not a JSON-RPC error object, so no error_code.
+        assert "error_code" not in result.details
 
     async def test_auth_metadata_probe_strips_authorization(self):
         seen_auth: dict[str, str | None] = {}

--- a/tests/test_prompts_rules.py
+++ b/tests/test_prompts_rules.py
@@ -1,6 +1,6 @@
 """Tests for prompt-quality rules."""
 
-from mcp.types import Prompt, PromptArgument
+from mcp_types import Prompt, PromptArgument
 
 from mcpscore.rules import (
     AuditData,

--- a/tests/test_readiness_rules.py
+++ b/tests/test_readiness_rules.py
@@ -227,8 +227,8 @@ class TestDeprecatedFeaturesRule:
 def _tool(name: str = "tool", input_schema: dict | None = None, output_schema: dict | None = None):
     return SimpleNamespace(
         name=name,
-        inputSchema=input_schema if input_schema is not None else {"type": "object", "properties": {}},
-        outputSchema=output_schema,
+        input_schema=input_schema if input_schema is not None else {"type": "object", "properties": {}},
+        output_schema=output_schema,
     )
 
 

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -91,6 +91,12 @@ class TestCheckGitState:
         with pytest.raises(SystemExit):
             release.check_git_state()
 
+    def test_fails_on_detached_head_even_for_prereleases(self, monkeypatch: pytest.MonkeyPatch):
+        """No branch name (detached HEAD) → fail fast, not a malformed gh api call."""
+        self._stub_run(monkeypatch, {"git branch --show-current": ""})
+        with pytest.raises(SystemExit):
+            release.check_git_state(prerelease=True)
+
     def test_prerelease_allowed_off_main(self, monkeypatch: pytest.MonkeyPatch):
         """A pre-release may run from a feature branch, synced against its own origin ref."""
         self._stub_run(

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -54,6 +54,14 @@ class TestCheckChangelog:
         with pytest.raises(SystemExit):
             release.check_changelog("1.2.3")
 
+    def test_fails_on_unresolved_conflict_markers(self, repo: Path):
+        """A half-resolved merge must not pass preflight even when section and link greps succeed."""
+        changelog = repo / "CHANGELOG.md"
+        conflict = "<<<<<<< HEAD\n[a]: https://x/compare/a...b\n=======\n[b]: https://x\n>>>>>>> origin/main\n"
+        changelog.write_text(changelog.read_text() + conflict)
+        with pytest.raises(SystemExit):
+            release.check_changelog("1.2.3")
+
 
 class TestCheckGitState:
     def _stub_run(self, monkeypatch: pytest.MonkeyPatch, responses: dict[str, str]) -> None:

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -19,17 +19,18 @@ import release
 @pytest.fixture
 def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point the script at a temporary repo root with a valid CHANGELOG and npm wrapper."""
-    (tmp_path / "pyproject.toml").write_text('[project]\nname = "mcpscore"\nversion = "1.2.3"\n')
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "mcpscore"\nversion = "1.2.3"\n', encoding="utf-8")
     (tmp_path / "CHANGELOG.md").write_text(
         "# Changelog\n\n"
         "## [1.2.3] - 2026-07-10\n\nThe notes body.\n\n"
         "## [1.2.2] - 2026-07-01\n\nOlder notes.\n\n"
         "[1.2.3]: https://github.com/mcp-box/mcpscore/compare/v1.2.2...v1.2.3\n"
-        "[1.2.2]: https://github.com/mcp-box/mcpscore/releases/tag/v1.2.2\n"
+        "[1.2.2]: https://github.com/mcp-box/mcpscore/releases/tag/v1.2.2\n",
+        encoding="utf-8",
     )
     (tmp_path / "npm").mkdir()
     (tmp_path / "npm" / "package.json").write_text(
-        '{"name": "@mcp-box/mcpscore", "version": "1.2.3", "mcpscore": {"pythonVersion": "1.2.3"}}'
+        '{"name": "@mcp-box/mcpscore", "version": "1.2.3", "mcpscore": {"pythonVersion": "1.2.3"}}', encoding="utf-8"
     )
     monkeypatch.setattr(release, "ROOT", tmp_path)
     return tmp_path
@@ -50,7 +51,10 @@ class TestCheckChangelog:
 
     def test_fails_without_the_compare_link(self, repo: Path):
         changelog = repo / "CHANGELOG.md"
-        changelog.write_text(changelog.read_text().replace("[1.2.3]: https://", "[nope]: https://"))
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace("[1.2.3]: https://", "[nope]: https://"),
+            encoding="utf-8",
+        )
         with pytest.raises(SystemExit):
             release.check_changelog("1.2.3")
 
@@ -58,7 +62,7 @@ class TestCheckChangelog:
         """A half-resolved merge must not pass preflight even when section and link greps succeed."""
         changelog = repo / "CHANGELOG.md"
         conflict = "<<<<<<< HEAD\n[a]: https://x/compare/a...b\n=======\n[b]: https://x\n>>>>>>> origin/main\n"
-        changelog.write_text(changelog.read_text() + conflict)
+        changelog.write_text(changelog.read_text(encoding="utf-8") + conflict, encoding="utf-8")
         with pytest.raises(SystemExit):
             release.check_changelog("1.2.3")
 
@@ -237,14 +241,16 @@ class TestCheckNpmVersionSync:
 
     def test_fails_on_wrapper_version_drift(self, repo: Path):
         (repo / "npm" / "package.json").write_text(
-            '{"name": "@mcp-box/mcpscore", "version": "1.2.2", "mcpscore": {"pythonVersion": "1.2.3"}}'
+            '{"name": "@mcp-box/mcpscore", "version": "1.2.2", "mcpscore": {"pythonVersion": "1.2.3"}}',
+            encoding="utf-8",
         )
         with pytest.raises(SystemExit):
             release.check_npm_version_sync("1.2.3")
 
     def test_fails_on_python_pin_drift(self, repo: Path):
         (repo / "npm" / "package.json").write_text(
-            '{"name": "@mcp-box/mcpscore", "version": "1.2.3", "mcpscore": {"pythonVersion": "1.2.2"}}'
+            '{"name": "@mcp-box/mcpscore", "version": "1.2.3", "mcpscore": {"pythonVersion": "1.2.2"}}',
+            encoding="utf-8",
         )
         with pytest.raises(SystemExit):
             release.check_npm_version_sync("1.2.3")
@@ -255,7 +261,7 @@ class TestCheckNpmVersionSync:
             release.check_npm_version_sync("1.2.3")
 
     def test_fails_on_invalid_json(self, repo: Path):
-        (repo / "npm" / "package.json").write_text("{ not valid json")
+        (repo / "npm" / "package.json").write_text("{ not valid json", encoding="utf-8")
         with pytest.raises(SystemExit):
             release.check_npm_version_sync("1.2.3")
 

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -209,6 +209,27 @@ class TestCheckCiGreen:
         with pytest.raises(SystemExit):
             release.check_ci_green("abc123")
 
+    def test_review_bots_are_not_ci_gates(self, monkeypatch: pytest.MonkeyPatch):
+        """An in-progress Copilot/Bugbot review must not block a release."""
+        copilot = {
+            "name": "copilot-pull-request-reviewer",
+            "status": "in_progress",
+            "conclusion": None,
+            "started_at": "2026-07-10T10:00:00Z",
+            "completed_at": None,
+        }
+        self._stub_checks(
+            monkeypatch,
+            [self._run("lint", "success", "2026-07-10T10:00:00Z"), copilot],
+        )
+        release.check_ci_green("abc123")  # must not raise
+
+    def test_only_review_bot_checks_counts_as_no_ci(self, monkeypatch: pytest.MonkeyPatch):
+        """With nothing but bot reviews on the commit, real CI has not run."""
+        self._stub_checks(monkeypatch, [self._run("Cursor Bugbot", "neutral", "2026-07-10T10:00:00Z")])
+        with pytest.raises(SystemExit):
+            release.check_ci_green("abc123")
+
 
 class TestCreateRelease:
     def test_passes_validated_target_and_cleans_up_notes_file(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_resources_rules.py
+++ b/tests/test_resources_rules.py
@@ -1,6 +1,6 @@
 """Tests for resource-quality rules."""
 
-from mcp.types import Resource
+from mcp_types import Resource
 
 from mcpscore.rules import AuditData, ResourcesDescriptionPresentRule, RuleSeverity
 

--- a/tests/test_server_info_rules.py
+++ b/tests/test_server_info_rules.py
@@ -1,10 +1,14 @@
+from dataclasses import replace
+
 from mcpscore.rules import (
     AuditData,
     RuleSeverity,
+    ServerIconsPresentRule,
     ServerInstructionsPresentRule,
     ServerNamePresentRule,
     ServerTitlePresentRule,
     ServerVersionPresentRule,
+    ServerWebsiteUrlPresentRule,
 )
 
 
@@ -35,3 +39,39 @@ def test_server_instructions_present_rule():
     assert not rule.check(AuditData(instructions=None)).passed
     assert not rule.check(AuditData(instructions="")).passed
     assert not rule.check(AuditData(instructions="   ")).passed
+
+
+def test_server_websiteurl_present_rule(implementation_full, implementation_missing):
+    rule = ServerWebsiteUrlPresentRule()
+    assert rule.rule_id == "server_websiteurl_present"
+    assert rule.min_spec_version == "2025-11-25"
+    with_url = replace(implementation_full, website_url="https://server.example")
+    assert rule.check(AuditData(server_info=with_url)).passed
+    assert not rule.check(AuditData(server_info=implementation_full)).passed
+    assert not rule.check(AuditData(server_info=implementation_missing)).passed
+
+
+def test_server_icons_present_rule(implementation_full, implementation_missing):
+    from mcp_types import Icon
+
+    rule = ServerIconsPresentRule()
+    assert rule.rule_id == "server_icons_present"
+    assert rule.min_spec_version == "2025-11-25"
+
+    valid = replace(implementation_full, icons=[Icon(src="https://server.example/icon.png")])
+    assert rule.check(AuditData(server_info=valid)).passed
+
+    data_uri = replace(implementation_full, icons=[Icon(src="data:image/png;base64,AAAA")])
+    assert rule.check(AuditData(server_info=data_uri)).passed
+
+    # No icons at all fails.
+    no_icons = rule.check(AuditData(server_info=implementation_missing))
+    assert not no_icons.passed
+    assert "no icons" in no_icons.message
+
+    # A plain-http src is not a valid icon source.
+    invalid = replace(implementation_full, icons=[Icon(src="http://server.example/icon.png")])
+    result = rule.check(AuditData(server_info=invalid))
+    assert not result.passed
+    assert result.details is not None
+    assert result.details["invalid_srcs"] == ["http://server.example/icon.png"]

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -16,7 +16,7 @@ And the is_valid_schema() helper function.
 
 from typing import Any
 
-from mcp_types import Tool, ToolAnnotations
+from mcp_types import Tool, ToolAnnotations, ToolExecution
 import pytest
 
 from mcpscore.rules import AuditData, RuleSeverity
@@ -25,6 +25,7 @@ from mcpscore.rules.tools import (
     ToolsAtLeastOneRule,
     ToolsBaseRule,
     ToolsDescriptionPresentRule,
+    ToolsExecutionConsistentRule,
     ToolsInputSchemaValidRule,
     ToolsNamePresentRule,
     ToolsNamesUniqueRule,
@@ -887,3 +888,36 @@ class TestToolsOutputSchemaValidRule:
         assert result.passed is False
         assert result.details is not None
         assert len(result.details["tools_with_invalid_output_schema"]) == 1
+
+
+class TestToolsExecutionConsistentRule:
+    def _tool(self, name: str, task_support: str | None) -> Tool:
+        execution = ToolExecution(task_support=task_support) if task_support is not None else None
+        return Tool(name=name, input_schema={"type": "object"}, execution=execution)
+
+    def test_no_task_tools_passes(self):
+        rule = ToolsExecutionConsistentRule()
+        tools = [self._tool("plain", None), self._tool("forbidden", "forbidden")]
+        result = rule.check(AuditData(tools=tools))
+        assert result.passed is True
+
+    def test_task_tools_with_tasks_capability_pass(self, capabilities_full):
+        from dataclasses import replace
+
+        rule = ToolsExecutionConsistentRule()
+        tools = [self._tool("runner", "optional"), self._tool("batch", "required")]
+        caps = replace(capabilities_full, tasks=object())
+        result = rule.check(AuditData(tools=tools, capabilities=caps))
+        assert result.passed is True
+
+    def test_task_tools_without_tasks_capability_fail(self, capabilities_full):
+        rule = ToolsExecutionConsistentRule()
+        tools = [self._tool("runner", "optional")]
+        result = rule.check(AuditData(tools=tools, capabilities=capabilities_full))
+        assert result.passed is False
+        assert result.details is not None
+        assert result.details["task_tools"] == ["runner"]
+
+    def test_no_tools_at_all_passes(self):
+        result = ToolsExecutionConsistentRule().check(AuditData())
+        assert result.passed is True

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -20,6 +20,7 @@ from mcp_types import Tool, ToolAnnotations, ToolExecution
 import pytest
 
 from mcpscore.rules import AuditData, RuleSeverity
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
 from mcpscore.rules.tools import (
     ToolsAnnotationsPresentRule,
     ToolsAtLeastOneRule,
@@ -919,5 +920,13 @@ class TestToolsExecutionConsistentRule:
         assert result.details["task_tools"] == ["runner"]
 
     def test_no_tools_at_all_passes(self):
-        result = ToolsExecutionConsistentRule().check(AuditData())
-        assert result.passed is True
+        """No tools capability declared → nothing to check → runs and passes."""
+        rule = ToolsExecutionConsistentRule()
+        assert rule.skip_reason(AuditData()) is None
+        assert rule.check(AuditData()).passed is True
+
+    def test_skips_when_tools_unavailable_despite_capability(self, capabilities_full):
+        """A failed tools/list (tools None, capability declared) skips rather than false-passing."""
+        rule = ToolsExecutionConsistentRule()
+        data = AuditData(tools=None, capabilities=capabilities_full)
+        assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -16,7 +16,7 @@ And the is_valid_schema() helper function.
 
 from typing import Any
 
-from mcp.types import Tool, ToolAnnotations
+from mcp_types import Tool, ToolAnnotations
 import pytest
 
 from mcpscore.rules import AuditData, RuleSeverity
@@ -61,7 +61,7 @@ def valid_tool() -> Tool:
         name="test_tool",
         title="Test Tool",
         description="A test tool for validation",
-        inputSchema={
+        input_schema={
             "type": "object",
             "title": "Input Schema",
             "properties": {
@@ -69,7 +69,7 @@ def valid_tool() -> Tool:
             },
             "required": ["param1"],
         },
-        outputSchema={
+        output_schema={
             "type": "object",
             "title": "Output Schema",
             "properties": {
@@ -87,7 +87,7 @@ def tool_with_empty_name() -> Tool:
         name="",
         title="Empty Name Tool",
         description="Tool with empty name",
-        inputSchema={
+        input_schema={
             "type": "object",
             "title": "Input",
             "properties": {},
@@ -103,7 +103,7 @@ def tool_with_invalid_name() -> Tool:
         name="invalid@name#with$special%chars",
         title="Invalid Name Tool",
         description="Tool with invalid name format",
-        inputSchema={
+        input_schema={
             "type": "object",
             "title": "Input",
             "properties": {},
@@ -119,7 +119,7 @@ def tool_with_long_name() -> Tool:
         name="a" * 129,  # 129 characters
         title="Long Name Tool",
         description="Tool with too long name",
-        inputSchema={
+        input_schema={
             "type": "object",
             "title": "Input",
             "properties": {},
@@ -135,7 +135,7 @@ def tool_with_empty_title() -> Tool:
         name="valid_name",
         title="",
         description="Tool with empty title",
-        inputSchema={
+        input_schema={
             "type": "object",
             "title": "Input",
             "properties": {},
@@ -151,7 +151,7 @@ def tool_with_empty_description() -> Tool:
         name="valid_name",
         title="Valid Title",
         description="",
-        inputSchema={
+        input_schema={
             "type": "object",
             "title": "Input",
             "properties": {},
@@ -167,7 +167,7 @@ def tool_with_invalid_input_schema() -> Tool:
         name="valid_name",
         title="Valid Title",
         description="Valid Description",
-        inputSchema={
+        input_schema={
             "type": "string",  # Wrong type - should be "object"
             "title": "Invalid",
             "properties": {},
@@ -183,13 +183,13 @@ def tool_with_invalid_output_schema() -> Tool:
         name="valid_name",
         title="Valid Title",
         description="Valid Description",
-        inputSchema={
+        input_schema={
             "type": "object",
             "title": "Valid Input",
             "properties": {},
             "required": [],
         },
-        outputSchema={
+        output_schema={
             "type": "array",  # Wrong type
             "title": "Invalid Output",
         },
@@ -507,8 +507,8 @@ class TestToolsNamesUniqueRule:
     def test_with_unique_names(self, valid_tool: Tool) -> None:
         """Pass: All tool names are unique."""
         rule = ToolsNamesUniqueRule()
-        tool1 = Tool(name="tool1", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
-        tool2 = Tool(name="tool2", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool1 = Tool(name="tool1", input_schema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool2 = Tool(name="tool2", input_schema={"type": "object", "title": "T", "properties": {}, "required": []})
         result = rule.check(AuditData(tools=[tool1, tool2]))
         assert result.passed is True
         assert result.details is not None
@@ -517,8 +517,8 @@ class TestToolsNamesUniqueRule:
     def test_with_duplicate_names(self, valid_tool: Tool) -> None:
         """Fail: Tools have duplicate names."""
         rule = ToolsNamesUniqueRule()
-        tool1 = Tool(name="duplicate", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
-        tool2 = Tool(name="duplicate", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool1 = Tool(name="duplicate", input_schema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool2 = Tool(name="duplicate", input_schema={"type": "object", "title": "T", "properties": {}, "required": []})
         result = rule.check(AuditData(tools=[tool1, tool2]))
         assert result.passed is False
         assert result.details is not None
@@ -529,11 +529,11 @@ class TestToolsNamesUniqueRule:
         """Fail: Multiple sets of duplicate names."""
         rule = ToolsNamesUniqueRule()
         tools = [
-            Tool(name="dup1", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []}),
-            Tool(name="dup1", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []}),
-            Tool(name="dup2", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []}),
-            Tool(name="dup2", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []}),
-            Tool(name="unique", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []}),
+            Tool(name="dup1", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}),
+            Tool(name="dup1", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}),
+            Tool(name="dup2", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}),
+            Tool(name="dup2", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}),
+            Tool(name="unique", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}),
         ]
         result = rule.check(AuditData(tools=tools))
         assert result.passed is False
@@ -570,35 +570,41 @@ class TestToolsNamesValidFormatRule:
     def test_with_alphanumeric_name(self) -> None:
         """Pass: Tool name with alphanumeric characters."""
         rule = ToolsNamesValidFormatRule()
-        tool = Tool(name="tool123", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool = Tool(name="tool123", input_schema={"type": "object", "title": "T", "properties": {}, "required": []})
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is True
 
     def test_with_underscore_name(self) -> None:
         """Pass: Tool name with underscores."""
         rule = ToolsNamesValidFormatRule()
-        tool = Tool(name="my_tool_name", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool = Tool(
+            name="my_tool_name", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}
+        )
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is True
 
     def test_with_dash_name(self) -> None:
         """Pass: Tool name with dashes."""
         rule = ToolsNamesValidFormatRule()
-        tool = Tool(name="my-tool-name", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool = Tool(
+            name="my-tool-name", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}
+        )
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is True
 
     def test_with_dot_name(self) -> None:
         """Pass: Tool name with dots."""
         rule = ToolsNamesValidFormatRule()
-        tool = Tool(name="my.tool.name", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool = Tool(
+            name="my.tool.name", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}
+        )
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is True
 
     def test_with_max_length_name(self) -> None:
         """Pass: Tool name with 128 characters (max allowed)."""
         rule = ToolsNamesValidFormatRule()
-        tool = Tool(name="a" * 128, inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool = Tool(name="a" * 128, input_schema={"type": "object", "title": "T", "properties": {}, "required": []})
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is True
 
@@ -621,7 +627,9 @@ class TestToolsNamesValidFormatRule:
     def test_with_space_in_name(self) -> None:
         """Fail: Tool name contains spaces."""
         rule = ToolsNamesValidFormatRule()
-        tool = Tool(name="my tool name", inputSchema={"type": "object", "title": "T", "properties": {}, "required": []})
+        tool = Tool(
+            name="my tool name", input_schema={"type": "object", "title": "T", "properties": {}, "required": []}
+        )
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is False
         assert result.details is not None
@@ -714,7 +722,7 @@ class TestToolsAnnotationsPresentRule:
     """Test ToolsAnnotationsPresentRule."""
 
     def _tool(self, name: str, annotations: ToolAnnotations | None) -> Tool:
-        return Tool(name=name, inputSchema={"type": "object"}, annotations=annotations)
+        return Tool(name=name, input_schema={"type": "object"}, annotations=annotations)
 
     def test_rule_properties(self) -> None:
         """Test rule metadata properties."""
@@ -806,7 +814,7 @@ class TestToolsInputSchemaValidRule:
         rule = ToolsInputSchemaValidRule()
         tool = Tool(
             name="test",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {"name": "not-a-mapping"},  # property def must be a dict
             },
@@ -817,7 +825,7 @@ class TestToolsInputSchemaValidRule:
     def test_zero_argument_tool_passes(self) -> None:
         """Pass: a zero-argument tool with a minimal schema is valid."""
         rule = ToolsInputSchemaValidRule()
-        tool = Tool(name="test", inputSchema={"type": "object", "properties": {}})
+        tool = Tool(name="test", input_schema={"type": "object", "properties": {}})
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is True
 
@@ -859,13 +867,13 @@ class TestToolsOutputSchemaValidRule:
         rule = ToolsOutputSchemaValidRule()
         tool = Tool(
             name="test",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "title": "Input",
                 "properties": {},
                 "required": [],
             },
-            outputSchema=None,
+            output_schema=None,
         )
         result = rule.check(AuditData(tools=[tool]))
         assert result.passed is True

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.1.0b1"
+version = "1.1.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
+[options]
+prerelease-mode = "allow"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -37,15 +40,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "certifi"
-version = "2026.6.17"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -309,40 +303,32 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
 ]
 
 [[package]]
@@ -392,13 +378,14 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -410,18 +397,30 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/aa/c5d38e0199304494be6370667d04d93d8681d9bdc864d56678250dbd3f3b/mcp-2.0.0b2.tar.gz", hash = "sha256:0528d0d38ae798fbff251616ec687faaaa8f5309571e0b2bc553c530fa10b8b1", size = 1590650, upload-time = "2026-07-14T16:47:57.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/90/187d6283a304acc6954987992ef17e2515739a649f148dc8b67b302e1bbd/mcp-2.0.0b2-py3-none-any.whl", hash = "sha256:9c50ae5afa08960ab76d50aa3adab3184952d9bea7ef87f4a4a5ba68bdefcf0a", size = 334286, upload-time = "2026-07-14T16:47:54.768Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/21/db529130ac8edd1d844fc322862afeceaf2b7f610a591fa528002b022e07/mcp_types-2.0.0b2.tar.gz", hash = "sha256:094fa7160106819ab39a1586179c3a9f070bfd833d0a6f8fcb30a54a986cc402", size = 65877, upload-time = "2026-07-14T16:47:59.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/e1/c466ceacdaa929396d35ad45176398acd0c416fead0970d3ad22618a19d7/mcp_types-2.0.0b2-py3-none-any.whl", hash = "sha256:35c9c33abb90a77dc6ad1daecaa6407c788c2f32d14d52dad8f843c4f008eae2", size = 68944, upload-time = "2026-07-14T16:47:56.493Z" },
 ]
 
 [[package]]
 name = "mcpscore"
-version = "0.8.0"
+version = "1.1.0b1"
 source = { editable = "." }
 dependencies = [
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
     { name = "mcp" },
 ]
@@ -437,10 +436,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "httpx-sse", specifier = ">=0.4.3" },
+    { name = "httpx2", specifier = ">=2.5.0" },
     { name = "jsonschema", specifier = ">=4.21" },
-    { name = "mcp", specifier = ">=1.28.1,<2" },
+    { name = "mcp", specifier = "==2.0.0b2" },
 ]
 
 [package.metadata.requires-dev]
@@ -459,6 +457,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -992,6 +1002,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.1.0b2"
+version = "1.1.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large migration to MCP SDK v2 and httpx2 touches connection, probing, and all rule data paths; auth and partial-audit behavior changes how gated servers are scored and reported.
> 
> **Overview**
> **Ships the 1.1.0b3 pre-release** on the MCP Python SDK **2.0.0b2** line: runtime moves from `httpx`/`mcp` v1 to **`httpx2`** and **`mcp_types`**, with rule and report code updated for SDK snake_case while **wire names** (e.g. `listChanged`) stay in audit output.
> 
> **Auth-gated servers** are first-class: **`--token`**, repeatable **`--header`**, and **`MCPSCORE_TOKEN`** feed the HTTP client and probes. On **401/403** without a session, the CLI runs a **partial audit** (auth/TLS/probe surface only) instead of exiting; reports add **`authenticated`**, **`partial`**, and **`partial_reason`**. Anonymous probes use a **header-free client** so caller credentials do not skew unauthenticated checks.
> 
> **New scoring** includes RFC 9728/8414 **auth-posture rules** (via `probe_auth_metadata` and extended unauthenticated probing), plus **2025-11-25** rules for `websiteUrl`, icons, and task execution vs `tasks` capability. Docs, rules reference, CHANGELOG, and **`pyproject.toml`** version/deps align; CI checkout comments and **`scripts/release.py`** pre-release/CI tweaks are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71e993d1499e257861be2a91f7c6b0f38e406ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->