### PR TITLE
Enable Dependabot (weekly, grouped minor/patch)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Engine + CLI dependencies (uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # npm wrapper package
+  - package-ecosystem: "npm"
+    directory: "/npm"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Pinned action SHAs in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only automation; no application runtime or auth/data paths change—only how dependency update PRs are proposed.
> 
> **Overview**
> Adds **Dependabot** via `.github/dependabot.yml` so dependency PRs open automatically on a **weekly** cadence.
> 
> **uv** (repo root / `uv.lock`) and **npm** (`/npm`) updates are **grouped** so minor and patch bumps land in a single PR per ecosystem. **GitHub Actions** pinned SHAs in workflows are also checked weekly (no grouping configured for that ecosystem).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 080aea5f547876bed5cc87b7e10df74ee1f3108e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->