### PR TITLE
Added citations everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Every rule now cites its primary source.** All 34 rules that predated the
+  citation policy carry a `basis` in their result `details` — the MCP
+  2025-11-25 spec section (or, where the spec is silent, the best-practice
+  basis, labeled as such) verified against the published spec text. The
+  readiness rules keep their `sep` citations and the auth rules their RFC
+  sections, so every one of the 55 checks now names what it enforces.
+  Enforced by a registry test so future rules cannot ship uncited.
+
 ## [1.1.0b3] - 2026-07-22
 
 **Pre-release: deeper auth-posture rules on the SDK v2 line.** Published as a

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -347,6 +347,8 @@ class MCPAuditor:
 
             res: RuleResult = rule.check(self.audit_data)
             res.rule_id = rule.rule_id
+            if rule.basis and (res.details is None or "basis" not in res.details):
+                res.details = {**(res.details or {}), "basis": rule.basis}
             logger.info(res.message)
 
             if rule.group_name == READINESS_GROUP:

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -249,10 +249,13 @@ class BaseRule(ABC):
     """Unique identifier for this rule. Must be set by subclasses."""
 
     basis: str | None = None
-    """Primary-source citation for the requirement this rule enforces (MCP
-    spec section, SEP, or RFC section). Injected into every result's
-    ``details["basis"]`` by the auditor unless the rule's check already set
-    one. Readiness rules cite via their ``details["sep"]`` key instead."""
+    """Primary-source citation for the requirement this rule enforces, e.g.
+    an MCP spec section or a labeled best practice. The auditor injects it
+    into every result's ``details["basis"]`` unless the check already set
+    that key itself. Two rule families cite differently and leave this
+    attribute unset: auth-posture rules build ``details["basis"]`` inline
+    (per-result RFC sections), and readiness rules cite SEPs via their
+    ``details["sep"]`` key."""
 
     group_name: str = "default"
     """Group name for organizing related rules. Rules in the same group

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -248,6 +248,12 @@ class BaseRule(ABC):
     rule_id: str = ""
     """Unique identifier for this rule. Must be set by subclasses."""
 
+    basis: str | None = None
+    """Primary-source citation for the requirement this rule enforces (MCP
+    spec section, SEP, or RFC section). Injected into every result's
+    ``details["basis"]`` by the auditor unless the rule's check already set
+    one. Readiness rules cite via their ``details["sep"]`` key instead."""
+
     group_name: str = "default"
     """Group name for organizing related rules. Rules in the same group
     are executed together. Groups are executed in alphabetical order

--- a/mcpscore/rules/capabilities.py
+++ b/mcpscore/rules/capabilities.py
@@ -76,6 +76,7 @@ class CapabilityToolsPresentRule(CapabilityBaseRule):
     """Critical check: Verify that capabilities.tools is present."""
 
     rule_id = "capability_tools_present"
+    basis = "MCP 2025-11-25 Tools §Capabilities (servers supporting tools MUST declare the capability)"
     rule_order = 1
 
     @property
@@ -117,6 +118,7 @@ class CapabilityToolsListChangedRule(CapabilityBaseRule):
     """High check: Verify that capabilities.tools has listChanged implemented."""
 
     rule_id = "capability_tools_list_changed"
+    basis = "MCP 2025-11-25 Tools §Capabilities (listChanged)"
     rule_order = 2
 
     @property
@@ -161,6 +163,7 @@ class CapabilityPromptsPresentRule(CapabilityBaseRule):
     """Critical check: Verify that capabilities.prompts is present."""
 
     rule_id = "capability_prompts_present"
+    basis = "MCP 2025-11-25 Prompts §Capabilities (servers supporting prompts MUST declare the capability)"
     rule_order = 3
 
     @property
@@ -202,6 +205,7 @@ class CapabilityPromptsListChangedRule(CapabilityBaseRule):
     """High check: Verify that capabilities.prompts has listChanged implemented."""
 
     rule_id = "capability_prompts_list_changed"
+    basis = "MCP 2025-11-25 Prompts §Capabilities (listChanged)"
     rule_order = 4
 
     @property
@@ -246,6 +250,7 @@ class CapabilityResourcesPresentRule(CapabilityBaseRule):
     """Critical check: Verify that capabilities.resources is present."""
 
     rule_id = "capability_resources_present"
+    basis = "MCP 2025-11-25 Resources §Capabilities (servers supporting resources MUST declare the capability)"
     rule_order = 5
 
     @property
@@ -287,6 +292,7 @@ class CapabilityResourcesListChangedRule(CapabilityBaseRule):
     """High check: Verify that capabilities.resources has listChanged implemented."""
 
     rule_id = "capability_resources_list_changed"
+    basis = "MCP 2025-11-25 Resources §Capabilities (listChanged)"
     rule_order = 6
 
     @property
@@ -331,6 +337,7 @@ class CapabilityResourcesSubscribeRule(CapabilityBaseRule):
     """High check: Verify that capabilities.resources has subscribe implemented."""
 
     rule_id = "capability_resources_subscribe"
+    basis = "MCP 2025-11-25 Resources §Capabilities (subscribe)"
     rule_order = 7
 
     @property
@@ -375,6 +382,7 @@ class CapabilityLoggingPresentRule(CapabilityBaseRule):
     """Medium check: Verify that capabilities.logging is present."""
 
     rule_id = "capability_logging_present"
+    basis = "MCP 2025-11-25 Lifecycle §Capability Negotiation (logging)"
     rule_order = 8
 
     @property

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -59,6 +59,7 @@ class PromptsDescriptionPresentRule(PromptsBaseRule):
     """Medium check: Verify that all declared prompts have a description."""
 
     rule_id = "prompts_description_present"
+    basis = "MCP 2025-11-25 Prompts §Prompt (description)"
     rule_order = 1
 
     @property
@@ -109,6 +110,7 @@ class PromptsArgumentsDocumentedRule(PromptsBaseRule):
     """
 
     rule_id = "prompts_arguments_documented"
+    basis = "MCP 2025-11-25 Prompts §Prompt (arguments: name, description, required)"
     rule_order = 2
 
     @property

--- a/mcpscore/rules/protocol_version.py
+++ b/mcpscore/rules/protocol_version.py
@@ -64,6 +64,7 @@ class AllowedVersionRule(ProtocolVersionBaseRule):
     """Critical check: Verify the MCP protocol version is one of the allowed versions."""
 
     rule_id = "protocol_version_allowed"
+    basis = "MCP 2025-11-25 Lifecycle §Version Negotiation (server MUST respond with a version it supports)"
     rule_order = 1
 
     @property
@@ -107,6 +108,7 @@ class LatestVersionRule(ProtocolVersionBaseRule):
     """Medium check: Verify the MCP protocol version is the latest available version."""
 
     rule_id = "protocol_version_latest"
+    basis = "MCP 2025-11-25 Lifecycle §Version Negotiation (SHOULD be the latest supported version)"
     rule_order = 3
 
     @property
@@ -152,6 +154,7 @@ class DeprecatedVersionRule(ProtocolVersionBaseRule):
     """High check: Verify the MCP protocol version is not deprecated."""
 
     rule_id = "protocol_version_not_deprecated"
+    basis = "MCP Versioning §Revisions (draft/current/final status)"
     rule_order = 2
 
     deprecated_versions: ClassVar[list[str]] = deprecated_versions()

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -59,6 +59,7 @@ class ResourcesDescriptionPresentRule(ResourcesBaseRule):
     """Medium check: Verify that all declared resources have a description."""
 
     rule_id = "resources_description_present"
+    basis = "MCP 2025-11-25 Resources §Resource (description)"
     rule_order = 1
 
     @property

--- a/mcpscore/rules/security.py
+++ b/mcpscore/rules/security.py
@@ -17,6 +17,7 @@ class TLSEnabledRule(BaseRule):
     """
 
     rule_id = "security_tls_enabled"
+    basis = "MCP 2025-11-25 Transports §Streamable HTTP Security Warning; TLS transport-security best practice"
     group_name = "security"
     group_order = 3
     rule_order = 1
@@ -107,6 +108,10 @@ class MalformedRequestHandlingRule(BaseRule):
     """
 
     rule_id = "security_malformed_request_handling"
+    basis = (
+        "MCP 2025-11-25 Transports §Sending Messages to the Server "
+        "(unacceptable input -> HTTP error / JSON-RPC error response)"
+    )
     group_name = "security"
     group_order = 3
     rule_order = 2
@@ -201,6 +206,7 @@ class ErrorDataLeakRule(BaseRule):
     """
 
     rule_id = "security_error_data_leak"
+    basis = "MCP 2025-11-25 Tools §Security Considerations (sanitize outputs); error-hygiene best practice"
     group_name = "security"
     group_order = 3
     rule_order = 3

--- a/mcpscore/rules/server_info.py
+++ b/mcpscore/rules/server_info.py
@@ -63,6 +63,7 @@ class ServerNamePresentRule(ServerInfoBaseRule):
     """Critical check: Verify that serverInfo.name is present."""
 
     rule_id = "server_name_present"
+    basis = "MCP 2025-11-25 Lifecycle §Initialization (serverInfo.name)"
     rule_order = 1
 
     @property
@@ -104,6 +105,7 @@ class ServerTitlePresentRule(ServerInfoBaseRule):
     """Medium check: Verify that serverInfo.title is present."""
 
     rule_id = "server_title_present"
+    basis = "MCP 2025-11-25 Lifecycle §Initialization (serverInfo.title)"
     rule_order = 3
 
     @property
@@ -145,6 +147,7 @@ class ServerVersionPresentRule(ServerInfoBaseRule):
     """High check: Verify that serverInfo.version is present."""
 
     rule_id = "server_version_present"
+    basis = "MCP 2025-11-25 Lifecycle §Initialization (serverInfo.version)"
     rule_order = 2
 
     @property
@@ -193,6 +196,7 @@ class ServerInstructionsPresentRule(BaseRule):
     group_name = "server_info"
     group_order = 2
     rule_id = "server_instructions_present"
+    basis = "MCP 2025-11-25 Lifecycle §Initialization (instructions)"
     rule_order = 4
 
     @property
@@ -238,6 +242,7 @@ class ServerWebsiteUrlPresentRule(ServerInfoBaseRule):
     """
 
     rule_id = "server_websiteurl_present"
+    basis = "MCP 2025-11-25 Lifecycle §Initialization (serverInfo.websiteUrl; 2025-11-25 field)"
     rule_order = 5
     min_spec_version = "2025-11-25"
 
@@ -287,6 +292,7 @@ class ServerIconsPresentRule(ServerInfoBaseRule):
     """
 
     rule_id = "server_icons_present"
+    basis = "MCP 2025-11-25 Lifecycle §Initialization (serverInfo.icons; 2025-11-25 field)"
     rule_order = 6
     min_spec_version = "2025-11-25"
 

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -72,6 +72,7 @@ class ToolsAtLeastOneRule(ToolsBaseRule):
     """Critical check: Verify the MCP server provides at least one tool."""
 
     rule_id = "tools_at_least_one"
+    basis = "MCP 2025-11-25 Tools §Listing Tools (tools/list)"
     rule_order = 1
 
     @property
@@ -109,6 +110,7 @@ class ToolsNamePresentRule(ToolsBaseRule):
     """Critical check: Verify that all tools have a name."""
 
     rule_id = "tools_name_present_in_all"
+    basis = "MCP 2025-11-25 Tools §Tool (name: unique identifier)"
     rule_order = 2
 
     @property
@@ -155,6 +157,7 @@ class ToolsNamesUniqueRule(ToolsBaseRule):
     """Critical check: Verify that all tool names are unique."""
 
     rule_id = "tools_names_unique"
+    basis = "MCP 2025-11-25 Tools §Tool Names (SHOULD be unique within a server)"
     rule_order = 3
 
     @property
@@ -197,6 +200,7 @@ class ToolsNamesValidFormatRule(ToolsBaseRule):
     """High check: Verify that all tool names follow the format."""
 
     rule_id = "tools_names_valid_format"
+    basis = "MCP 2025-11-25 Tools §Tool Names (allowed charset, 1-128 length)"
     rule_order = 4
 
     @property
@@ -246,6 +250,7 @@ class ToolsTitlePresentRule(ToolsBaseRule):
     """High check: Verify that all tools have a title."""
 
     rule_id = "tools_title_present_in_all"
+    basis = "MCP 2025-11-25 Tools §Tool (title: display name)"
     rule_order = 5
 
     @property
@@ -289,6 +294,7 @@ class ToolsDescriptionPresentRule(ToolsBaseRule):
     """High check: Verify that all tools have a description."""
 
     rule_id = "tools_description_present_in_all"
+    basis = "MCP 2025-11-25 Tools §Tool (description)"
     rule_order = 6
 
     @property
@@ -396,6 +402,7 @@ class ToolsInputSchemaValidRule(ToolsBaseRule):
     """High check: Verify that each tool has a valid input schema."""
 
     rule_id = "tools_input_schema_valid"
+    basis = "MCP 2025-11-25 Tools §Tool (inputSchema MUST be a valid JSON Schema object; 2020-12 default)"
     rule_order = 7
 
     @property
@@ -445,6 +452,7 @@ class ToolsOutputSchemaValidRule(ToolsBaseRule):
     """
 
     rule_id = "tools_output_schema_valid"
+    basis = "MCP 2025-11-25 Tools §Tool (outputSchema; JSON Schema usage guidelines)"
     rule_order = 8
 
     @property
@@ -509,6 +517,7 @@ class ToolsAnnotationsPresentRule(ToolsBaseRule):
     """
 
     rule_id = "tools_annotations_present"
+    basis = "MCP 2025-11-25 Tools §Tool (annotations)"
     rule_order = 9
 
     @property
@@ -560,6 +569,7 @@ class ToolsExecutionConsistentRule(BaseRule):
     group_name = "tools"
     group_order = 4
     rule_id = "tools_execution_consistent"
+    basis = "MCP 2025-11-25 Tools §Tool (execution.taskSupport); Lifecycle §Capability Negotiation (tasks)"
     rule_order = 10
     min_spec_version = "2025-11-25"
 

--- a/mcpscore/rules/transport.py
+++ b/mcpscore/rules/transport.py
@@ -15,6 +15,7 @@ class StreamableHTTPTransportRule(BaseRule):
     """
 
     rule_id = "transport_streamable_http"
+    basis = "MCP 2025-11-25 Transports §Streamable HTTP (replaces the deprecated HTTP+SSE transport from 2024-11-05)"
     group_name = "transport"
     group_order = 5
     rule_order = 1

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -746,3 +746,46 @@ async def test_get_audit_report():
     assert all(res["rule_id"] == "dummy_rule" for res in report["results"])
     assert report["results"][0]["passed"] is True
     assert report["results"][1]["passed"] is False
+
+
+class CitedRule(DummyRule):
+    """Dummy rule with a class-level basis, optionally self-citing in details."""
+
+    rule_id = "cited_rule"
+    basis = "MCP 2025-11-25 Example §Section (test citation)"
+
+    def __init__(self, *, inline_basis: str | None = None) -> None:
+        super().__init__(passed=True, severity=RuleSeverity.LOW)
+        self._inline_basis = inline_basis
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        details = {"basis": self._inline_basis} if self._inline_basis else None
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=True,
+            message="msg",
+            details=details,
+        )
+
+
+async def test_basis_is_injected_into_result_details():
+    """The class-level citation reaches the report even when a check sets no details."""
+    auditor = MCPAuditor()
+    auditor.rules = [CitedRule()]
+
+    await auditor.audit(DummyClient(None))
+
+    details = auditor.results[0].details
+    assert details is not None
+    assert details["basis"] == "MCP 2025-11-25 Example §Section (test citation)"
+
+
+async def test_inline_basis_is_never_overridden():
+    """A check's own details["basis"] (the auth-rule pattern) wins over the class attribute."""
+    auditor = MCPAuditor()
+    auditor.rules = [CitedRule(inline_basis="RFC 0000 §1 (inline)")]
+
+    await auditor.audit(DummyClient(None))
+
+    assert auditor.results[0].details["basis"] == "RFC 0000 §1 (inline)"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -34,12 +34,13 @@ def test_every_rule_cites_its_basis():
     auth rules). Readiness rules cite via their ``details["sep"]`` keys, which
     their own tests assert.
     """
+    from mcpscore.rules.auth import AuthPostureBaseRule
     from mcpscore.rules.base import READINESS_GROUP
 
     for rule in create_all_rules():
         if rule.group_name == READINESS_GROUP:
             continue  # cite via details["sep"], asserted in test_readiness_rules
-        if rule.group_name == "security" and rule.rule_id.startswith("auth_"):
+        if isinstance(rule, AuthPostureBaseRule):
             continue  # cite inline in details["basis"], asserted in test_auth_rules
         # Substantive citation required; the format is deliberately not
         # constrained to a source vocabulary (MCP/RFC/SEP/best-practice all

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -24,3 +24,22 @@ def test_registry_unique_ids():
     except ValueError:
         raised = True
     assert raised
+
+
+def test_every_rule_cites_its_basis():
+    """Every rule carries a primary-source citation (launch claim: "each citing the spec").
+
+    Non-readiness rules cite via the class-level ``basis`` attribute (injected
+    into result details by the auditor) or inline in their result details (the
+    auth rules). Readiness rules cite via their ``details["sep"]`` keys, which
+    their own tests assert.
+    """
+    from mcpscore.rules.base import READINESS_GROUP
+
+    for rule in create_all_rules():
+        if rule.group_name == READINESS_GROUP:
+            continue  # cite via details["sep"], asserted in test_readiness_rules
+        if rule.group_name == "security" and rule.rule_id.startswith("auth_"):
+            continue  # cite inline in details["basis"], asserted in test_auth_rules
+        assert rule.basis, f"{rule.rule_id} has no basis citation"
+        assert "MCP" in rule.basis or "RFC" in rule.basis, rule.rule_id

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -41,5 +41,8 @@ def test_every_rule_cites_its_basis():
             continue  # cite via details["sep"], asserted in test_readiness_rules
         if rule.group_name == "security" and rule.rule_id.startswith("auth_"):
             continue  # cite inline in details["basis"], asserted in test_auth_rules
+        # Substantive citation required; the format is deliberately not
+        # constrained to a source vocabulary (MCP/RFC/SEP/best-practice all
+        # valid) — only emptiness and throwaway strings are rejected.
         assert rule.basis, f"{rule.rule_id} has no basis citation"
-        assert "MCP" in rule.basis or "RFC" in rule.basis, rule.rule_id
+        assert len(rule.basis.strip()) >= 15, f"{rule.rule_id} basis citation is not substantive: {rule.basis!r}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata and report `details` enrichment only; no scoring or rule logic changes.
> 
> **Overview**
> **Every main-axis audit rule now names what it enforces.** A new optional `basis` on `BaseRule` holds an MCP spec section (or labeled best practice where the spec is silent). After each check, `MCPAuditor` merges that into `result.details["basis"]` unless the rule already set `details["basis"]` (auth-posture rules keep their inline RFC citations; readiness rules still use `details["sep"]`).
> 
> **34 rules** across capabilities, protocol version, server info, tools, prompts, resources, security, and transport gained class-level `basis` strings tied to MCP 2025-11-25 (or versioning) text.
> 
> **Guardrails:** `test_every_rule_cites_its_basis` in the registry suite requires a substantive `basis` for non-readiness, non-auth rules; auditor tests cover injection and non-override of inline `basis`. **CHANGELOG** documents the policy under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944e2305de837614ff303978fbd398848bca1c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->