### PR TITLE
Promote readiness into the main score for modern-lifecycle servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,12 @@
   diagnostics may differ; the commands are authoritative.
 - **`rule_id` is a stable public contract**: never rename or reuse one. New rules must
   cite the MCP spec section (or SEP) they enforce in their result `details`.
-- Readiness rules (`group_name = "readiness"`) score on a separate axis and must never
-  affect the main score. Rules that cannot judge anything return a skip reason —
-  they never fail a server for missing observations.
+- Readiness rules (`group_name = "readiness"`) score on the readiness axis; since the
+  1.1.0 promotion they ALSO count in the main score, but only for modern-lifecycle
+  servers (era modern/dual-era) in full audits — never for legacy servers, never in
+  partial audits (`readiness_promoted` in mcp_auditor.py is the single switch).
+  Rules that cannot judge anything return a skip reason — they never fail a server
+  for missing observations.
 - **Probes must never invoke `tools/call`** against a target server — audits must be
   free of tool side effects. Probes never raise; network failures are
   `ProbeOutcome.ERROR` data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   populated as the breakdown and gains a `counted_in_main` flag. Legacy-only
   servers are unchanged (readiness stays informative), and partial audits
   are never promoted. This is the score migration the methodology doc
-  promised for spec-final; rule_ids are unchanged.
+  promised for spec-final; every `rule_id` is unchanged.
 
 - **Every rule now cites its primary source.** All 34 rules that predated the
   citation policy carry a `basis` in their result `details` — the MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Readiness promotion for modern-lifecycle servers.** A server that
+  negotiates the 2026-07-28 lifecycle (era `modern` or `dual-era`) now has
+  its readiness points counted in the main score; the readiness block stays
+  populated as the breakdown and gains a `counted_in_main` flag. Legacy-only
+  servers are unchanged (readiness stays informative), and partial audits
+  are never promoted. This is the score migration the methodology doc
+  promised for spec-final; rule_ids are unchanged.
+
 - **Every rule now cites its primary source.** All 34 rules that predated the
   citation policy carry a `basis` in their result `details` — the MCP
   2025-11-25 spec section (or, where the spec is silent, the best-practice

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -118,7 +118,11 @@ Two things worth knowing about how these run:
   breakdown of that share. Legacy-only servers keep readiness informative
   (guidance, not punishment), and **partial audits are never promoted** — a
   partial score is already not comparable to a full audit's. The `rule_id`s
-  never change, so CI integrations and report consumers are unaffected.
+  never change, so integrations keyed on rule IDs are unaffected — but
+  **score-based consumers** (e.g. a CI `min-score` threshold) should note
+  that a modern-lifecycle server's `score`/`max_score` now include the
+  readiness points; check `readiness.counted_in_main` to know which mode
+  scored a given audit.
 
 <Note>
 **Draft-spec citations** — the 2026-07-28 revision is final-pending (release candidate

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -111,9 +111,14 @@ Two things worth knowing about how these run:
   modern support, because a legacy-only server keeping sessions is correct behavior,
   not leakage. A dual-era server (serving both lifecycles) is spec-legal and scores
   normally — what's flagged is legacy artifacts inside *modern* interactions.
-- When the 2026-07-28 revision goes final and adoption normalizes, these rules migrate
-  into the main score for servers that negotiate it — **their `rule_id`s never
-  change**, so CI integrations and report consumers are unaffected.
+- **Promotion (since 1.1.0):** a server that negotiates the modern lifecycle
+  (era `modern` or `dual-era`) has its readiness points **counted in the main
+  score** — the report's `readiness.counted_in_main` flag says which mode a
+  given audit used, and the readiness block stays populated as the transparent
+  breakdown of that share. Legacy-only servers keep readiness informative
+  (guidance, not punishment), and **partial audits are never promoted** — a
+  partial score is already not comparable to a full audit's. The `rule_id`s
+  never change, so CI integrations and report consumers are unaffected.
 
 <Note>
 **Draft-spec citations** — the 2026-07-28 revision is final-pending (release candidate

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -165,10 +165,13 @@ def log_audit_outcome(auditor: MCPAuditor) -> None:
     )
     if readiness["max_score"] > 0:
         logger.info(
-            "Readiness for MCP %s: %s/%s (informative — not part of the main score)",
+            "Readiness for MCP %s: %s/%s (%s)",
             spec["readiness_target"],
             readiness["score"],
             readiness["max_score"],
+            "counted in the main score — modern-lifecycle server"
+            if readiness.get("counted_in_main")
+            else "informative — not part of the main score",
         )
     else:
         logger.info(

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -145,8 +145,9 @@ def log_audit_outcome(auditor: MCPAuditor) -> None:
     """Log the human-readable audit outcome: score, spec/era line, readiness line.
 
     The main score and the readiness score are deliberately separate lines —
-    readiness for the next spec revision is informative and never part of the
-    main score (see the multi-spec-version design).
+    readiness for the next spec revision is informative for legacy servers
+    and counted in the main score for modern-lifecycle full audits — the
+    line says which mode applied (readiness promotion).
     """
     report = auditor.get_audit_report()
     spec = report["spec"]

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -80,9 +80,10 @@ class MCPAuditor:
         self.results: list[RuleResult] = []
         self.skipped_rules: list[SkippedRule] = []
 
-        # Readiness axis: rules in the READINESS_GROUP score here, never in
-        # the main score — readiness for the next spec revision is
-        # informative, not punitive (see the multi-spec-version design).
+        # Readiness axis: rules in the READINESS_GROUP score here. For
+        # legacy servers this stays informative, not punitive; for
+        # modern-lifecycle full audits the same points are ALSO counted in
+        # the main score (readiness promotion — see _run_all_rules).
         self.readiness_score: int = 0
         self.readiness_max: int = 0
         self.readiness_results: list[RuleResult] = []
@@ -558,7 +559,7 @@ class MCPAuditor:
             - spec: Negotiated/latest/readiness-target spec versions and the
               observed lifecycle era (legacy / modern / dual-era)
             - readiness: Independent readiness score for the next spec
-              revision, with its per-rule results — never part of the main score
+              revision, with its per-rule results and the counted_in_main flag
 
         """
         return {

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -139,6 +139,7 @@ class MCPAuditor:
         self.readiness_max = 0
         self.readiness_results = []
         self.era = None
+        self.readiness_promoted = False
 
     async def audit_modern_only(self, url: str) -> bool:
         """Audit a modern-only HTTP server via probes, without a legacy session.
@@ -315,14 +316,25 @@ class MCPAuditor:
         A separator line is logged before the first readiness rule so the two
         sections are visually distinct in the streamed output.
         """
+        # Readiness promotion (the documented migration in methodology.mdx):
+        # a server that negotiates the modern lifecycle gets its readiness
+        # rules counted in the MAIN score. Legacy-only servers keep readiness
+        # informative — guidance, not punishment. Partial audits are never
+        # promoted: their score is already not comparable to a full audit's,
+        # and folding a second axis in would make it less interpretable.
+        self.readiness_promoted = self.era in (Era.MODERN, Era.DUAL) and not self.audit_data.partial
+
         readiness_header_emitted = False
         for rule in sorted(self.rules, key=lambda r: r.sort_order):
             if rule.group_name == READINESS_GROUP and not readiness_header_emitted:
                 readiness_header_emitted = True
                 logger.info("")
                 logger.info(
-                    "🔭 Readiness checks for MCP %s (informative — not part of the main score):",
+                    "🔭 Readiness checks for MCP %s (%s):",
                     (DRAFT or LATEST).version,
+                    "counted in the main score — modern-lifecycle server"
+                    if self.readiness_promoted
+                    else "informative — not part of the main score",
                 )
 
             skip_reason: str | None = None
@@ -356,6 +368,13 @@ class MCPAuditor:
                 if res.passed:
                     self.readiness_score += res.severity.value
                 self.readiness_results.append(res)
+                if self.readiness_promoted:
+                    # Same points also count toward the main score; the
+                    # readiness sub-report stays populated as the transparent
+                    # breakdown of this share of the score.
+                    self.max_score += res.severity.value
+                    if res.passed:
+                        self.score += res.severity.value
             else:
                 self.max_score += res.severity.value
                 if res.passed:
@@ -564,6 +583,10 @@ class MCPAuditor:
             "readiness": {
                 "score": self.readiness_score,
                 "max_score": self.readiness_max,
+                # True when this server negotiates the modern lifecycle and
+                # these points are included in the top-level score/max_score
+                # (never true for partial audits).
+                "counted_in_main": self.readiness_promoted,
                 "results": [res.to_dict() for res in self.readiness_results],
                 "skipped": sum(1 for s in self.skipped_rules if s.group_name == READINESS_GROUP),
             },

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -90,6 +90,10 @@ class MCPAuditor:
         self.era: Era | None = None
         """Lifecycle era(s) the server was observed to support (set during audit)."""
 
+        self.readiness_promoted: bool = False
+        """Whether this run counted readiness in the main score (modern-lifecycle
+        server, full audit). Recomputed per run in _run_all_rules."""
+
     async def audit(self, client: MCPClient) -> tuple[int, int]:
         """Execute the complete audit process for an MCP server.
 

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -789,3 +789,14 @@ async def test_inline_basis_is_never_overridden():
     await auditor.audit(DummyClient(None))
 
     assert auditor.results[0].details["basis"] == "RFC 0000 §1 (inline)"
+
+
+def test_fresh_auditor_report_before_any_audit():
+    """get_audit_report() on a never-run auditor must not raise.
+
+    Regression: readiness_promoted was set only in _reset_run_state, which
+    __init__ does not call — a fresh auditor raised AttributeError.
+    """
+    report = MCPAuditor().get_audit_report()
+    assert report["score"] == 0
+    assert report["readiness"]["counted_in_main"] is False

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -356,3 +356,44 @@ async def test_audit_partial_over_http_records_unverified_tls(stub_probes):
     assert await auditor.audit_partial("http://server.example/mcp", reason="auth") is True
     assert auditor.audit_data.tls_verified is False
     assert auditor.audit_data.tls_version is None
+
+
+async def test_modern_server_readiness_counts_in_main_score(stub_probes, monkeypatch: pytest.MonkeyPatch):
+    """A modern-lifecycle server's readiness points are promoted into the main score."""
+    stub_probes(_modern_probe_results())
+    monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+    auditor = MCPAuditor()
+    assert await auditor.audit_modern_only("https://modern.example/mcp") is True
+
+    report = auditor.get_audit_report()
+    assert auditor.era is Era.MODERN
+    assert report["readiness"]["counted_in_main"] is True
+    assert report["readiness"]["max_score"] > 0
+    # The main axis includes exactly the readiness points on top of its own.
+    main_only_max = report["max_score"] - report["readiness"]["max_score"]
+    assert main_only_max > 0  # main-axis rules still scored on their own
+    main_only_score = report["score"] - report["readiness"]["score"]
+    assert main_only_score >= 0
+
+
+async def test_partial_audit_never_promotes_readiness(stub_probes, monkeypatch: pytest.MonkeyPatch):
+    """Even a modern-era server keeps readiness informative in a partial audit.
+
+    A partial score is already not comparable to a full audit's; folding the
+    readiness axis in would make it less interpretable.
+    """
+    stub_probes(_modern_probe_results())
+    monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+    auditor = MCPAuditor()
+    assert await auditor.audit_partial("https://gated-modern.example/mcp", reason="auth") is True
+
+    report = auditor.get_audit_report()
+    assert auditor.era is Era.MODERN
+    assert report["partial"] is True
+    assert report["readiness"]["counted_in_main"] is False
+    # Main score excludes the readiness axis entirely.
+    readiness_ids = {r["rule_id"] for r in report["readiness"]["results"]}
+    main_ids = {r["rule_id"] for r in report["results"]}
+    assert not (readiness_ids & main_ids)

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -369,12 +369,20 @@ async def test_modern_server_readiness_counts_in_main_score(stub_probes, monkeyp
     report = auditor.get_audit_report()
     assert auditor.era is Era.MODERN
     assert report["readiness"]["counted_in_main"] is True
-    assert report["readiness"]["max_score"] > 0
-    # The main axis includes exactly the readiness points on top of its own.
-    main_only_max = report["max_score"] - report["readiness"]["max_score"]
-    assert main_only_max > 0  # main-axis rules still scored on their own
-    main_only_score = report["score"] - report["readiness"]["score"]
-    assert main_only_score >= 0
+    # Ground truth recomputed from the per-result severities: the main score
+    # must equal main-axis points PLUS readiness points — no more (double
+    # counting) and no less (flag set but scoring not updated).
+    main_max = sum(r.severity.value for r in auditor.results)
+    main_score = sum(r.severity.value for r in auditor.results if r.passed)
+    ready_max = sum(r.severity.value for r in auditor.readiness_results)
+    ready_score = sum(r.severity.value for r in auditor.readiness_results if r.passed)
+    assert ready_max > 0
+    assert main_max > 0  # main-axis rules still scored on their own
+    assert auditor.max_score == main_max + ready_max
+    assert auditor.score == main_score + ready_score
+    # The readiness axis itself is not inflated by the promotion.
+    assert auditor.readiness_max == ready_max
+    assert auditor.readiness_score == ready_score
 
 
 async def test_partial_audit_never_promotes_readiness(stub_probes, monkeypatch: pytest.MonkeyPatch):
@@ -393,7 +401,11 @@ async def test_partial_audit_never_promotes_readiness(stub_probes, monkeypatch: 
     assert auditor.era is Era.MODERN
     assert report["partial"] is True
     assert report["readiness"]["counted_in_main"] is False
-    # Main score excludes the readiness axis entirely.
+    # Main score equals exactly the main-axis points — readiness contributes
+    # nothing to it in a partial audit, even for a modern-era server.
+    assert auditor.max_score == sum(r.severity.value for r in auditor.results)
+    assert auditor.score == sum(r.severity.value for r in auditor.results if r.passed)
+    assert auditor.readiness_max == sum(r.severity.value for r in auditor.readiness_results)
     readiness_ids = {r["rule_id"] for r in report["readiness"]["results"]}
     main_ids = {r["rule_id"] for r in report["results"]}
     assert not (readiness_ids & main_ids)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Scoring semantics change for modern-lifecycle full audits can shift CI min-score thresholds; integrations keyed on `rule_id` are unaffected.
> 
> **Overview**
> **Readiness promotion (1.1.0)** folds 2026 readiness rule points into the top-level `score` / `max_score` when the server is observed on the **modern** or **dual-era** lifecycle and the run is a **full** audit. Legacy-only servers behave as before (readiness stays guidance-only), and **partial** audits never promote.
> 
> `MCPAuditor` drives this with `readiness_promoted` in `_run_all_rules`: passing readiness rules still populate `readiness.*`, and when promoted the same severities are added to the main totals without duplicating rule rows in `results`. The JSON report exposes `readiness.counted_in_main`; CLI logging matches that mode.
> 
> Docs (`methodology.mdx`, `CHANGELOG`, `AGENTS.md`) describe the migration and warn **score-based** consumers (e.g. CI `min-score`) that modern full audits have a higher ceiling. Tests cover promotion math, partial exclusion, and `get_audit_report()` on a fresh auditor (`counted_in_main` false).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 154a20f61e9da0a4d1f098fce4cedb9a154ba169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->