### PR TITLE
Stability doc + new feature: support for OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--oauth`: interactive browser OAuth flow.** mcpscore discovers the
+  server's authorization server (RFC 9728 → RFC 8414), registers a client
+  dynamically (RFC 7591), opens the browser for the authorization-code +
+  PKCE grant, catches the redirect on a loopback listener, and audits with
+  the obtained token — which is held in memory only, never written to disk,
+  never logged. For authorization servers without dynamic client
+  registration (e.g. GitHub's), `--oauth --client-id <id>` uses a
+  pre-registered client instead; the failure message suggests this when
+  registration is unavailable.
+
+- **Stability contract published** (`docs/stability.mdx`): what is stable
+  from 1.1.0 on (`rule_id` never renamed/reused, report schema versioned via
+  `schema_version`, CLI flags and exit codes, credentials never in
+  logs/reports) and what evolves by design (the score is ruleset-dependent;
+  messages/details/severities may improve in any release).
+
 - **Readiness promotion for modern-lifecycle servers.** A server that
   negotiates the 2026-07-28 lifecycle (era `modern` or `dual-era`) now has
   its readiness points counted in the main score; the readiness block stays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never logged. For authorization servers without dynamic client
   registration (e.g. GitHub's), `--oauth --client-id <id>` uses a
   pre-registered client instead; the failure message suggests this when
-  registration is unavailable.
+  registration is unavailable. `--callback-port` pins the loopback redirect
+  port for authorization servers that (against RFC 8252) require the exact
+  pre-registered redirect URI.
 
 - **Stability contract published** (`docs/stability.mdx`): what is stable
   from 1.1.0 on (`rule_id` never renamed/reused, report schema versioned via

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,7 +27,8 @@
         "group": "Scoring",
         "pages": [
           "methodology",
-          "rules"
+          "rules",
+          "stability"
         ]
       }
     ]

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -73,7 +73,10 @@ Many production MCP servers require OAuth 2.x. mcpscore handles them two ways:
   report is marked `partial` and its score is not comparable to a full audit's.
 - **With a token**, mcpscore audits behind the gate like any client. Pass
   `--token <TOKEN>` (sent as `Authorization: Bearer …`) or an arbitrary
-  `--header 'Name: Value'` (repeatable, for API-key or custom-auth servers).
+  `--header 'Name: Value'` (repeatable, for API-key or custom-auth servers),
+  or `--oauth` to let mcpscore run the browser OAuth flow itself
+  (authorization code + PKCE; add `--client-id` for authorization servers
+  without dynamic client registration).
   For CI, set `MCPSCORE_TOKEN` in the environment to keep tokens out of shell
   history. Token and header values are never logged or written to the report —
   only an `authenticated` flag is recorded (set when an Authorization

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -1,0 +1,92 @@
+---
+title: "Stability contract"
+description: "What mcpscore promises to keep stable across releases — and what deliberately evolves."
+---
+
+From the first stable release (1.1.0), mcpscore commits to a stability
+contract so CI integrations and report consumers can depend on it. This page
+is that contract.
+
+## Stable — breaking changes only with a major version
+
+### Rule identifiers
+
+Every check has a `rule_id` (e.g. `tools_description_present_in_all`). A
+`rule_id` is **never renamed and never reused** for a different check. Rules
+may be *added* in any release; a rule may be *retired* (stops running) but
+its identifier is never given a new meaning.
+
+Integrations should key on `rule_id` — not on rule names, messages, or
+positions, which may be reworded or reordered in any release.
+
+### Report schema
+
+The `--json` report carries `schema_version` (currently `1`). Within a
+schema version:
+
+- Existing fields keep their names, types, and meanings.
+- New fields **may be added** in any release — consumers must ignore
+  unknown fields.
+- Field removals or type changes bump `schema_version`.
+
+The report's top-level shape: `schema_version`, `mcpscore_version`,
+`generated_at`, `target`, `transport`, `score`, `max_score`,
+`authenticated`, `partial`, `partial_reason`, `summary`, `results[]`,
+`skipped_rules[]`, `spec`, `readiness`.
+
+### CLI interface
+
+- The invocation shape — `mcpscore <target>` with `--json`, `--header`,
+  `--token` (and the `MCPSCORE_TOKEN` environment variable) — is stable.
+  New flags may be added; existing flags keep their meaning.
+- Exit codes are a contract: **0** audit completed (regardless of score),
+  **1** usage error, **2** connection failure with no fallback available.
+- `--json` writes exactly one JSON document to stdout; all logs go to
+  stderr. Pipelines may rely on stdout being clean JSON.
+
+### Credential handling
+
+Header and token values are never logged and never written to the report —
+only the boolean `authenticated` flag is recorded. This is a permanent
+commitment, not a default.
+
+## Evolving by design — expect movement between releases
+
+### The score
+
+**The score is ruleset-dependent and the ruleset grows.** `score` and
+`max_score` are severity-weighted sums over the rules that ran: adding
+rules (most releases) changes both, so **a score is comparable only
+within the same mcpscore version against the same server**. Track
+`mcpscore_version` alongside any score you store. We would rather grow
+the checks than freeze the number early; a calibrated scoring frame is
+planned to revisit this once the ruleset stabilizes.
+
+Two flags qualify a score further:
+
+- `partial: true` — only the observable surface of an auth-gated server
+  was scored; not comparable to a full audit.
+- `readiness.counted_in_main: true` — a modern-lifecycle server's
+  readiness points are included in the main score (see
+  [methodology](/methodology)); a CI `min-score` threshold means something
+  slightly different on either side of this flag.
+
+### Messages, details, and rule metadata
+
+Human-readable `message` strings, `details` contents (including the
+`basis` citations), severities, and category groupings may be improved in
+any release. They are for humans and for context — not for keying logic.
+
+### Readiness rules
+
+Readiness rules target the *next* spec revision, so the readiness rule set
+turns over at each revision: rules for a now-current revision migrate into
+the main axis and new readiness rules appear for the next draft. Their
+`rule_id`s still follow the never-reused rule.
+
+## Versioning
+
+mcpscore follows [SemVer](https://semver.org/): breaking changes to
+anything in the "Stable" section require a major version; rule additions
+and score movement are minor-version territory; pre-releases (`bN`) may
+change anything and exact-pin their dependencies.

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -39,8 +39,10 @@ The report's top-level shape: `schema_version`, `mcpscore_version`,
 - The invocation shape — `mcpscore <target>` with `--json`, `--header`,
   `--token` (and the `MCPSCORE_TOKEN` environment variable) — is stable.
   New flags may be added; existing flags keep their meaning.
-- Exit codes are a contract: **0** audit completed (regardless of score),
-  **1** usage error, **2** connection failure with no fallback available.
+- Exit codes are a contract: **0** audit completed (regardless of score);
+  **1** the audit was never attempted — a usage error or a failed `--oauth`
+  flow (timeout, refusal, registration or token-exchange failure);
+  **2** connection failure to the target server with no fallback available.
 - `--json` writes exactly one JSON document to stdout; all logs go to
   stderr. Pipelines may rely on stdout being clean JSON.
 

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -245,6 +245,9 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
         sys.exit(1)
     if not args.oauth:
         return
+    if args.callback_port is not None and not 1 <= args.callback_port <= 65535:
+        logger.error("Usage error: --callback-port must be between 1 and 65535")
+        sys.exit(1)
     if has_authorization_credential(headers):
         logger.error(
             "Usage error: --oauth conflicts with an existing Authorization credential "
@@ -263,6 +266,10 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
     except OAuthFlowError as e:
         logger.error("OAuth: %s", e)  # noqa: TRY400 — user-facing outcome, not a traceback
         sys.exit(1)
+    # Replace any case-variant of the header (e.g. a blank 'authorization:')
+    # so the wire never carries duplicate Authorization headers.
+    for key in [name for name in headers if name.lower() == "authorization"]:
+        del headers[key]
     headers["Authorization"] = f"Bearer {access_token}"
     logger.info("OAuth flow completed — token held in memory only for this audit.")
 

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -236,7 +236,10 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
     if not args.oauth:
         return
     if any(name.lower() == "authorization" for name in headers):
-        logger.error("Usage error: --oauth conflicts with --token / an Authorization --header — pick one")
+        logger.error(
+            "Usage error: --oauth conflicts with an existing Authorization credential "
+            "(--token, an Authorization --header, or the MCPSCORE_TOKEN environment variable) — pick one"
+        )
         sys.exit(1)
     if not args.target.startswith(("http://", "https://")):
         logger.error("Usage error: --oauth requires an HTTP(S) server URL")

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -245,7 +245,7 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
         sys.exit(1)
     if not args.oauth:
         return
-    if any(name.lower() == "authorization" for name in headers):
+    if has_authorization_credential(headers):
         logger.error(
             "Usage error: --oauth conflicts with an existing Authorization credential "
             "(--token, an Authorization --header, or the MCPSCORE_TOKEN environment variable) — pick one"

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -240,7 +240,7 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
     Exits with code 1 on flag conflicts or a failed flow; a no-op when
     --oauth was not requested.
     """
-    if (args.client_id or args.callback_port) and not args.oauth:
+    if (args.client_id is not None or args.callback_port is not None) and not args.oauth:
         logger.error("Usage error: --client-id / --callback-port only make sense together with --oauth")
         sys.exit(1)
     if not args.oauth:

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -79,6 +79,25 @@ def build_parser() -> argparse.ArgumentParser:
             "Defaults to the MCPSCORE_TOKEN environment variable (keeps tokens out of shell history)."
         ),
     )
+    parser.add_argument(
+        "--oauth",
+        action="store_true",
+        help=(
+            "Obtain a token interactively: opens your browser for the server's OAuth flow "
+            "(authorization code + PKCE). The token is held in memory only — never written "
+            "to disk, never logged. Requires the authorization server to support dynamic "
+            "client registration unless --client-id is given."
+        ),
+    )
+    parser.add_argument(
+        "--client-id",
+        metavar="ID",
+        help=(
+            "Pre-registered OAuth client ID for --oauth, for authorization servers without "
+            "dynamic client registration (e.g. GitHub's). The registered app must allow a "
+            "loopback redirect URI (http://127.0.0.1:<port>/callback)."
+        ),
+    )
     return parser
 
 
@@ -205,6 +224,34 @@ def build_report(target: str, transport: MCPTransportType | None, auditor: MCPAu
     }
 
 
+async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> None:
+    """Run the --oauth browser flow and place the token into the header dict.
+
+    Exits with code 1 on flag conflicts or a failed flow; a no-op when
+    --oauth was not requested.
+    """
+    if args.client_id and not args.oauth:
+        logger.error("Usage error: --client-id only makes sense together with --oauth")
+        sys.exit(1)
+    if not args.oauth:
+        return
+    if any(name.lower() == "authorization" for name in headers):
+        logger.error("Usage error: --oauth conflicts with --token / an Authorization --header — pick one")
+        sys.exit(1)
+    if not args.target.startswith(("http://", "https://")):
+        logger.error("Usage error: --oauth requires an HTTP(S) server URL")
+        sys.exit(1)
+    from mcpscore.oauth import OAuthFlowError, obtain_token_interactively
+
+    try:
+        access_token = await obtain_token_interactively(args.target, client_id=args.client_id)
+    except OAuthFlowError as e:
+        logger.error("OAuth: %s", e)  # noqa: TRY400 — user-facing outcome, not a traceback
+        sys.exit(1)
+    headers["Authorization"] = f"Bearer {access_token}"
+    logger.info("OAuth flow completed — token held in memory only for this audit.")
+
+
 async def async_main() -> None:
     """Execute the main entry point for the MCPScore CLI application.
 
@@ -233,6 +280,8 @@ async def async_main() -> None:
     except ValueError as e:
         logger.error("Usage error: %s", e)  # noqa: TRY400 — usage error, not an exception to trace
         sys.exit(1)
+
+    await _apply_oauth(args, headers)
 
     if headers:
         logger.info("Using %d custom header(s).", len(headers))

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -98,6 +98,16 @@ def build_parser() -> argparse.ArgumentParser:
             "loopback redirect URI (http://127.0.0.1:<port>/callback)."
         ),
     )
+    parser.add_argument(
+        "--callback-port",
+        metavar="PORT",
+        type=int,
+        help=(
+            "Fixed loopback port for the --oauth redirect URI. RFC 8252 says authorization "
+            "servers must accept any port on loopback redirects, but if yours requires the "
+            "exact pre-registered URI, pin the port you registered (pairs with --client-id)."
+        ),
+    )
     return parser
 
 
@@ -230,8 +240,8 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
     Exits with code 1 on flag conflicts or a failed flow; a no-op when
     --oauth was not requested.
     """
-    if args.client_id and not args.oauth:
-        logger.error("Usage error: --client-id only makes sense together with --oauth")
+    if (args.client_id or args.callback_port) and not args.oauth:
+        logger.error("Usage error: --client-id / --callback-port only make sense together with --oauth")
         sys.exit(1)
     if not args.oauth:
         return
@@ -247,7 +257,9 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
     from mcpscore.oauth import OAuthFlowError, obtain_token_interactively
 
     try:
-        access_token = await obtain_token_interactively(args.target, client_id=args.client_id)
+        access_token = await obtain_token_interactively(
+            args.target, client_id=args.client_id, callback_port=args.callback_port
+        )
     except OAuthFlowError as e:
         logger.error("OAuth: %s", e)  # noqa: TRY400 — user-facing outcome, not a traceback
         sys.exit(1)

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -79,8 +79,9 @@ class _LoopbackCallbackServer:
     query parameters of the first request to the callback path.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, port: int | None = None) -> None:
         super().__init__()
+        self._requested_port = port or 0
         self._server: asyncio.Server | None = None
         self._result: asyncio.Future[dict[str, str]] = asyncio.get_running_loop().create_future()
         self.port: int = 0
@@ -90,7 +91,7 @@ class _LoopbackCallbackServer:
         return f"http://127.0.0.1:{self.port}{CALLBACK_PATH}"
 
     async def start(self) -> None:
-        self._server = await asyncio.start_server(self._handle, host="127.0.0.1", port=0)
+        self._server = await asyncio.start_server(self._handle, host="127.0.0.1", port=self._requested_port)
         self.port = self._server.sockets[0].getsockname()[1]
 
     async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -121,6 +122,7 @@ async def obtain_token_interactively(
     server_url: str,
     *,
     client_id: str | None = None,
+    callback_port: int | None = None,
     flow_timeout_s: float = FLOW_TIMEOUT_S,
     open_browser: Callable[[str], object] = webbrowser.open,
     transport: httpx2.AsyncBaseTransport | None = None,
@@ -132,6 +134,11 @@ async def obtain_token_interactively(
         client_id: Pre-registered OAuth client ID for authorization servers
             without dynamic client registration (e.g. GitHub's). When set,
             registration is skipped and this ID is used with the PKCE flow.
+        callback_port: Fixed loopback port for the redirect URI. RFC 8252
+            requires authorization servers to accept any port on loopback
+            redirects, but some (non-compliant) ones demand the exact
+            pre-registered URI — pin the port you registered here. Default:
+            an ephemeral port.
         flow_timeout_s: Seconds to wait for the user to finish in the browser.
         open_browser: Injection point for tests; production uses the default
             browser.
@@ -146,7 +153,7 @@ async def obtain_token_interactively(
             and, for registration failures, suggests ``--client-id``.
 
     """
-    callback = _LoopbackCallbackServer()
+    callback = _LoopbackCallbackServer(port=callback_port)
     try:
         await callback.start()
     except OSError as exc:

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -23,7 +23,7 @@ from urllib.parse import parse_qs, urlsplit
 import webbrowser
 
 import httpx2
-from mcp.client.auth import OAuthClientProvider, OAuthRegistrationError
+from mcp.client.auth import OAuthClientProvider, OAuthRegistrationError, OAuthTokenError
 from mcp.shared.auth import AuthorizationCodeResult, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 from pydantic import AnyUrl
 
@@ -210,14 +210,27 @@ async def obtain_token_interactively(
             async with httpx2.AsyncClient(
                 auth=provider, follow_redirects=True, timeout=30.0, transport=transport
             ) as client:
-                await client.post(server_url, json={})
+                # A well-formed JSON-RPC request: servers that validate the
+                # body before their auth middleware still answer 401 with the
+                # WWW-Authenticate challenge discovery needs (an empty {} can
+                # draw a 400 with no challenge from such servers).
+                await client.post(
+                    server_url,
+                    json={"jsonrpc": "2.0", "id": 0, "method": "ping"},
+                    headers={"Accept": "application/json, text/event-stream"},
+                )
         except OAuthFlowError:
             raise
         except Exception as exc:
             hint = ""
             if client_id is None and isinstance(exc, OAuthRegistrationError):
                 hint = " (the authorization server may not support dynamic client registration — try --client-id)"
-            raise OAuthFlowError(f"OAuth flow failed: {exc}{hint}") from exc
+            # This message is logged. Known SDK OAuth errors carry summary-style
+            # text that never includes token material; any other exception may
+            # echo response bodies, so only its type is included (module
+            # contract: errors never contain token material).
+            detail = str(exc) if isinstance(exc, (OAuthRegistrationError, OAuthTokenError)) else type(exc).__name__
+            raise OAuthFlowError(f"OAuth flow failed: {detail}{hint}") from exc
 
         tokens = await storage.get_tokens()
         if tokens is None or not tokens.access_token:

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -17,6 +17,7 @@ in both modes.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlsplit
@@ -102,6 +103,11 @@ class _LoopbackCallbackServer:
         self.port = self._server.sockets[0].getsockname()[1]
 
     async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        # Initialized before the try: a connection that dies during readline
+        # must still run the post-finally logic safely (no UnboundLocalError
+        # surfacing as an unhandled task exception).
+        params: dict[str, str] = {}
+        is_auth_response = False
         try:
             request_line = await reader.readline()
             parts = request_line.decode("latin-1").split(" ")
@@ -119,10 +125,12 @@ class _LoopbackCallbackServer:
                 writer.write(_WAITING_RESPONSE)
             else:
                 writer.write(_NOT_FOUND_RESPONSE)
-            await writer.drain()
+            with contextlib.suppress(ConnectionError):
+                await writer.drain()
         finally:
             writer.close()
-            await writer.wait_closed()
+            with contextlib.suppress(ConnectionError):
+                await writer.wait_closed()
         if is_auth_response and not self._result.done():
             self._result.set_result(params)
 

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -24,7 +24,7 @@ from urllib.parse import parse_qs, urlsplit
 import webbrowser
 
 import httpx2
-from mcp.client.auth import OAuthClientProvider
+from mcp.client.auth import OAuthClientProvider, OAuthRegistrationError
 from mcp.shared.auth import AuthorizationCodeResult, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 from pydantic import AnyUrl
 
@@ -103,6 +103,7 @@ class _LoopbackCallbackServer:
             await writer.drain()
         finally:
             writer.close()
+            await writer.wait_closed()
         split = urlsplit(target)
         if split.path == CALLBACK_PATH and not self._result.done():
             params = {key: values[0] for key, values in parse_qs(split.query).items()}
@@ -217,7 +218,7 @@ async def obtain_token_interactively(
             raise
         except Exception as exc:
             hint = ""
-            if client_id is None and "regist" in str(exc).lower():
+            if client_id is None and isinstance(exc, OAuthRegistrationError):
                 hint = " (the authorization server may not support dynamic client registration — try --client-id)"
             raise OAuthFlowError(f"OAuth flow failed: {exc}{hint}") from exc
 

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -113,8 +113,8 @@ class _LoopbackCallbackServer:
             if "code" in params or "error" in params:
                 self._result.set_result(params)
 
-    async def wait_for_callback(self, deadline_s: float) -> dict[str, str]:
-        return await asyncio.wait_for(self._result, timeout=deadline_s)
+    async def wait_for_callback(self, timeout_s: float) -> dict[str, str]:
+        return await asyncio.wait_for(self._result, timeout=timeout_s)
 
     async def close(self) -> None:
         if self._server is not None:

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -1,0 +1,234 @@
+"""Interactive browser OAuth flow for auditing OAuth-protected servers.
+
+Implements the CLI's ``--oauth`` mode: discover the server's authorization
+server (RFC 9728 → RFC 8414), register a client dynamically (RFC 7591) or
+use a pre-registered ``--client-id`` where the authorization server offers
+no dynamic registration, open the user's browser for the authorization-code
++ PKCE grant, catch the redirect on a loopback listener, and exchange the
+code for a token.
+
+The obtained access token is held **in memory only** — nothing is written
+to disk, and the token value is never logged. After the flow completes, the
+token feeds the same ``Authorization`` header plumbing as ``--token``, so
+the audit pipeline (client, probes, anonymous-probe isolation) is identical
+in both modes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlsplit
+import webbrowser
+
+import httpx2
+from mcp.client.auth import OAuthClientProvider
+from mcp.shared.auth import AuthorizationCodeResult, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+from pydantic import AnyUrl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+CALLBACK_PATH = "/callback"
+"""Path the loopback listener serves; part of the registered redirect URI."""
+
+FLOW_TIMEOUT_S = 300.0
+"""How long to wait for the user to complete the browser flow."""
+
+_CALLBACK_RESPONSE = (
+    b"HTTP/1.1 200 OK\r\ncontent-type: text/html; charset=utf-8\r\nconnection: close\r\n\r\n"
+    b"<html><body><p>mcpscore received the authorization response. You can close this tab.</p></body></html>"
+)
+
+
+class OAuthFlowError(RuntimeError):
+    """The interactive OAuth flow could not produce a token.
+
+    The message is user-facing and never contains token material.
+    """
+
+
+class _MemoryTokenStorage:
+    """In-memory TokenStorage: tokens and client info live and die with the process."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._tokens: OAuthToken | None = None
+        self._client_info: OAuthClientInformationFull | None = None
+
+    async def get_tokens(self) -> OAuthToken | None:
+        return self._tokens
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        self._tokens = tokens
+
+    async def get_client_info(self) -> OAuthClientInformationFull | None:
+        return self._client_info
+
+    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        self._client_info = client_info
+
+
+class _LoopbackCallbackServer:
+    """Minimal one-shot HTTP listener for the authorization redirect.
+
+    Binds an ephemeral port on 127.0.0.1 and resolves a future with the
+    query parameters of the first request to the callback path.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._server: asyncio.Server | None = None
+        self._result: asyncio.Future[dict[str, str]] = asyncio.get_event_loop().create_future()
+        self.port: int = 0
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"http://127.0.0.1:{self.port}{CALLBACK_PATH}"
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, host="127.0.0.1", port=0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            request_line = await reader.readline()
+            parts = request_line.decode("latin-1").split(" ")
+            target = parts[1] if len(parts) >= 2 else "/"
+            writer.write(_CALLBACK_RESPONSE)
+            await writer.drain()
+        finally:
+            writer.close()
+        split = urlsplit(target)
+        if split.path == CALLBACK_PATH and not self._result.done():
+            params = {key: values[0] for key, values in parse_qs(split.query).items()}
+            self._result.set_result(params)
+
+    async def wait_for_callback(self, deadline_s: float) -> dict[str, str]:
+        return await asyncio.wait_for(self._result, timeout=deadline_s)
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+
+def _loopback_port_available() -> bool:  # pragma: no cover - trivial platform guard
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+    except OSError:
+        return False
+    return True
+
+
+async def obtain_token_interactively(
+    server_url: str,
+    *,
+    client_id: str | None = None,
+    flow_timeout_s: float = FLOW_TIMEOUT_S,
+    open_browser: Callable[[str], object] = webbrowser.open,
+    transport: httpx2.AsyncBaseTransport | None = None,
+) -> str:
+    """Run the browser OAuth flow against a server and return the access token.
+
+    Args:
+        server_url: The MCP endpoint URL the audit will target.
+        client_id: Pre-registered OAuth client ID for authorization servers
+            without dynamic client registration (e.g. GitHub's). When set,
+            registration is skipped and this ID is used with the PKCE flow.
+        flow_timeout_s: Seconds to wait for the user to finish in the browser.
+        open_browser: Injection point for tests; production uses the default
+            browser.
+        transport: Test-only httpx transport injection; None uses the network.
+
+    Returns:
+        The access token string (held in memory by the caller; never logged).
+
+    Raises:
+        OAuthFlowError: On any failure — discovery, registration, user
+            timeout, or token exchange. The message says which step failed
+            and, for registration failures, suggests ``--client-id``.
+
+    """
+    if not _loopback_port_available():
+        raise OAuthFlowError("cannot bind a loopback port for the OAuth callback")
+
+    callback = _LoopbackCallbackServer()
+    await callback.start()
+    try:
+        storage = _MemoryTokenStorage()
+        if client_id is not None:
+            # Pre-seeding client info makes the SDK skip dynamic registration —
+            # the escape hatch for authorization servers without RFC 7591.
+            await storage.set_client_info(
+                OAuthClientInformationFull(
+                    client_id=client_id,
+                    redirect_uris=[AnyUrl(callback.redirect_uri)],
+                    token_endpoint_auth_method="none",  # noqa: S106 — public-client method name, not a secret
+                )
+            )
+
+        async def redirect_handler(authorization_url: str) -> None:
+            logger.info("Opening your browser to authorize (if nothing opens, visit the URL below):")
+            logger.info("%s", authorization_url)
+            open_browser(authorization_url)
+
+        async def callback_handler() -> AuthorizationCodeResult:
+            try:
+                params = await callback.wait_for_callback(flow_timeout_s)
+            except TimeoutError as exc:
+                raise OAuthFlowError(
+                    f"timed out after {flow_timeout_s:.0f}s waiting for the browser authorization"
+                ) from exc
+            if "error" in params:
+                description = params.get("error_description", "")
+                raise OAuthFlowError(f"authorization was refused: {params['error']} {description}".strip())
+            if "code" not in params:
+                raise OAuthFlowError("authorization response carried no code")
+            return AuthorizationCodeResult(code=params["code"], state=params.get("state"), iss=params.get("iss"))
+
+        provider = OAuthClientProvider(
+            server_url=server_url,
+            client_metadata=OAuthClientMetadata(
+                client_name="mcpscore",
+                redirect_uris=[AnyUrl(callback.redirect_uri)],
+                token_endpoint_auth_method="none",  # noqa: S106 — public-client method name, not a secret
+            ),
+            storage=storage,
+            redirect_handler=redirect_handler,
+            callback_handler=callback_handler,
+            timeout=flow_timeout_s,
+        )
+
+        # One authenticated request drives the whole flow: the 401 triggers
+        # discovery → (registration) → browser grant → token exchange, and the
+        # provider retries the request with the token.
+        try:
+            async with httpx2.AsyncClient(
+                auth=provider, follow_redirects=True, timeout=30.0, transport=transport
+            ) as client:
+                await client.post(server_url, json={})
+        except OAuthFlowError:
+            raise
+        except Exception as exc:
+            hint = ""
+            if client_id is None and "regist" in str(exc).lower():
+                hint = " (the authorization server may not support dynamic client registration — try --client-id)"
+            raise OAuthFlowError(f"OAuth flow failed: {exc}{hint}") from exc
+
+        tokens = await storage.get_tokens()
+        if tokens is None or not tokens.access_token:
+            hint = (
+                ""
+                if client_id is not None
+                else " (if the authorization server lacks dynamic client registration, pass --client-id)"
+            )
+            raise OAuthFlowError(f"the OAuth flow completed no token exchange{hint}")
+        return tokens.access_token
+    finally:
+        await callback.close()

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -107,7 +107,11 @@ class _LoopbackCallbackServer:
         split = urlsplit(target)
         if split.path == CALLBACK_PATH and not self._result.done():
             params = {key: values[0] for key, values in parse_qs(split.query).items()}
-            self._result.set_result(params)
+            # Only an actual authorization response counts — a stray visit to
+            # bare /callback (scanner, prefetch) must not consume the one-shot
+            # future while the real redirect is still coming.
+            if "code" in params or "error" in params:
+                self._result.set_result(params)
 
     async def wait_for_callback(self, deadline_s: float) -> dict[str, str]:
         return await asyncio.wait_for(self._result, timeout=deadline_s)
@@ -186,8 +190,7 @@ async def obtain_token_interactively(
             if "error" in params:
                 description = params.get("error_description", "")
                 raise OAuthFlowError(f"authorization was refused: {params['error']} {description}".strip())
-            if "code" not in params:
-                raise OAuthFlowError("authorization response carried no code")
+            # The listener only resolves with code or error, so code is present here.
             return AuthorizationCodeResult(code=params["code"], state=params.get("state"), iss=params.get("iss"))
 
         provider = OAuthClientProvider(
@@ -222,6 +225,13 @@ async def obtain_token_interactively(
         except OAuthFlowError:
             raise
         except Exception as exc:
+            # The retried request can fail after the grant and token exchange
+            # already succeeded (network blip, server hiccup) — the flow's
+            # purpose is the token, so salvage it before declaring failure.
+            salvaged = await storage.get_tokens()
+            if salvaged is not None and salvaged.access_token:
+                logger.info("OAuth flow completed (the follow-up request failed, but the token was obtained).")
+                return salvaged.access_token
             hint = ""
             if client_id is None and isinstance(exc, OAuthRegistrationError):
                 hint = " (the authorization server may not support dynamic client registration — try --client-id)"

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import socket
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlsplit
 import webbrowser
@@ -83,7 +82,7 @@ class _LoopbackCallbackServer:
     def __init__(self) -> None:
         super().__init__()
         self._server: asyncio.Server | None = None
-        self._result: asyncio.Future[dict[str, str]] = asyncio.get_event_loop().create_future()
+        self._result: asyncio.Future[dict[str, str]] = asyncio.get_running_loop().create_future()
         self.port: int = 0
 
     @property
@@ -118,15 +117,6 @@ class _LoopbackCallbackServer:
             await self._server.wait_closed()
 
 
-def _loopback_port_available() -> bool:  # pragma: no cover - trivial platform guard
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-            probe.bind(("127.0.0.1", 0))
-    except OSError:
-        return False
-    return True
-
-
 async def obtain_token_interactively(
     server_url: str,
     *,
@@ -156,11 +146,11 @@ async def obtain_token_interactively(
             and, for registration failures, suggests ``--client-id``.
 
     """
-    if not _loopback_port_available():
-        raise OAuthFlowError("cannot bind a loopback port for the OAuth callback")
-
     callback = _LoopbackCallbackServer()
-    await callback.start()
+    try:
+        await callback.start()
+    except OSError as exc:
+        raise OAuthFlowError(f"cannot bind a loopback port for the OAuth callback: {exc}") from exc
     try:
         storage = _MemoryTokenStorage()
         if client_id is not None:

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -38,10 +38,17 @@ CALLBACK_PATH = "/callback"
 FLOW_TIMEOUT_S = 300.0
 """How long to wait for the user to complete the browser flow."""
 
-_CALLBACK_RESPONSE = (
-    b"HTTP/1.1 200 OK\r\ncontent-type: text/html; charset=utf-8\r\nconnection: close\r\n\r\n"
-    b"<html><body><p>mcpscore received the authorization response. You can close this tab.</p></body></html>"
-)
+
+def _http_response(status_line: str, body: str) -> bytes:
+    return (
+        f"HTTP/1.1 {status_line}\r\ncontent-type: text/html; charset=utf-8\r\nconnection: close\r\n\r\n"
+        f"<html><body><p>{body}</p></body></html>"
+    ).encode()
+
+
+_SUCCESS_RESPONSE = _http_response("200 OK", "mcpscore received the authorization response. You can close this tab.")
+_WAITING_RESPONSE = _http_response("200 OK", "mcpscore is waiting for the authorization response…")
+_NOT_FOUND_RESPONSE = _http_response("404 Not Found", "Not found.")
 
 
 class OAuthFlowError(RuntimeError):
@@ -99,19 +106,25 @@ class _LoopbackCallbackServer:
             request_line = await reader.readline()
             parts = request_line.decode("latin-1").split(" ")
             target = parts[1] if len(parts) >= 2 else "/"
-            writer.write(_CALLBACK_RESPONSE)
+            split = urlsplit(target)
+            params = {key: values[0] for key, values in parse_qs(split.query).items()}
+            is_callback = split.path == CALLBACK_PATH
+            # Only an actual authorization response counts — a stray visit to
+            # bare /callback (scanner, prefetch) must not consume the one-shot
+            # future, and only a real response earns the success page.
+            is_auth_response = is_callback and ("code" in params or "error" in params)
+            if is_auth_response:
+                writer.write(_SUCCESS_RESPONSE)
+            elif is_callback:
+                writer.write(_WAITING_RESPONSE)
+            else:
+                writer.write(_NOT_FOUND_RESPONSE)
             await writer.drain()
         finally:
             writer.close()
             await writer.wait_closed()
-        split = urlsplit(target)
-        if split.path == CALLBACK_PATH and not self._result.done():
-            params = {key: values[0] for key, values in parse_qs(split.query).items()}
-            # Only an actual authorization response counts — a stray visit to
-            # bare /callback (scanner, prefetch) must not consume the one-shot
-            # future while the real redirect is still coming.
-            if "code" in params or "error" in params:
-                self._result.set_result(params)
+        if is_auth_response and not self._result.done():
+            self._result.set_result(params)
 
     async def wait_for_callback(self, timeout_s: float) -> dict[str, str]:
         return await asyncio.wait_for(self._result, timeout=timeout_s)

--- a/mcpscore/oauth.py
+++ b/mcpscore/oauth.py
@@ -244,12 +244,13 @@ async def obtain_token_interactively(
 
         tokens = await storage.get_tokens()
         if tokens is None or not tokens.access_token:
-            hint = (
-                ""
-                if client_id is not None
-                else " (if the authorization server lacks dynamic client registration, pass --client-id)"
+            # No hint here: this path has non-registration causes (an empty
+            # token from the AS, a target that never requested auth) — the
+            # --client-id hint lives on the typed registration-error path,
+            # where it is accurate.
+            raise OAuthFlowError(
+                "the OAuth flow completed no token exchange (the server may not have requested authentication)"
             )
-            raise OAuthFlowError(f"the OAuth flow completed no token exchange{hint}")
         return tokens.access_token
     finally:
         await callback.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1139,3 +1139,80 @@ class TestAuthCliFlow:
 
         assert exc.value.code == 2
         mock_auditor.audit_partial.assert_not_called()
+
+
+class TestOAuthCliFlow:
+    """--oauth flag wiring: conflicts, and the token landing in headers."""
+
+    async def test_client_id_without_oauth_exits_1(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--client-id", "abc"])
+        with pytest.raises(SystemExit) as exc:
+            await async_main()
+        assert exc.value.code == 1
+
+    async def test_oauth_conflicts_with_token(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth", "--token", "t"])
+        with pytest.raises(SystemExit) as exc:
+            await async_main()
+        assert exc.value.code == 1
+
+    async def test_oauth_requires_http_target(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "/local/server.py", "--oauth"])
+        with pytest.raises(SystemExit) as exc:
+            await async_main()
+        assert exc.value.code == 1
+
+    async def test_oauth_token_feeds_authorization_header(
+        self, monkeypatch: MonkeyPatch, mock_client: MagicMock, mock_auditor: MagicMock
+    ) -> None:
+        import mcpscore.oauth
+
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth"])
+
+        async def fake_flow(server_url: str, *, client_id=None, **kwargs) -> str:
+            assert server_url == "https://x/mcp"
+            assert client_id is None
+            return "flow-token"
+
+        monkeypatch.setattr(mcpscore.oauth, "obtain_token_interactively", fake_flow)
+        captured = {}
+
+        def capture_client(**kwargs):
+            captured["headers"] = kwargs.get("headers")
+            return mock_client
+
+        mock_client.detect_and_connect = AsyncMock(return_value=(True, MCPTransportType.STREAMABLE_HTTP))
+        with (
+            patch("mcpscore.cli.MCPClient", side_effect=capture_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        assert captured["headers"] == {"Authorization": "Bearer flow-token"}
+
+    async def test_oauth_flow_failure_exits_1(
+        self, monkeypatch: MonkeyPatch, mock_client: MagicMock, mock_auditor: MagicMock, caplog: LogCaptureFixture
+    ) -> None:
+        import mcpscore.oauth
+        from mcpscore.oauth import OAuthFlowError
+
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth"])
+
+        async def failing_flow(server_url: str, **kwargs) -> str:
+            raise OAuthFlowError("timed out after 300s waiting for the browser authorization")
+
+        monkeypatch.setattr(mcpscore.oauth, "obtain_token_interactively", failing_flow)
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            caplog.at_level(logging.ERROR),
+            pytest.raises(SystemExit) as exc,
+        ):
+            await async_main()
+
+        assert exc.value.code == 1
+        assert "timed out" in caplog.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1238,7 +1238,7 @@ class TestOAuthCliFlow:
         import mcpscore.oauth
 
         monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
-        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth", "--header", "Authorization:"])
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth", "--header", "authorization:"])
 
         async def fake_flow(server_url: str, **kwargs) -> str:
             return "flow-token"
@@ -1257,5 +1257,14 @@ class TestOAuthCliFlow:
         ):
             await async_main()
 
-        # The flow ran and its token replaced the blank header.
-        assert captured["headers"]["Authorization"] == "Bearer flow-token"
+        # The flow ran; its token replaced the blank header with NO duplicate
+        # case-variant left behind.
+        assert captured["headers"] == {"Authorization": "Bearer flow-token"}
+
+    async def test_callback_port_out_of_range_exits_1(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        for bad_port in ("0", "70000"):
+            monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth", "--callback-port", bad_port])
+            with pytest.raises(SystemExit) as exc:
+                await async_main()
+            assert exc.value.code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1230,3 +1230,32 @@ class TestOAuthCliFlow:
         with pytest.raises(SystemExit) as exc:
             await async_main()
         assert exc.value.code == 1
+
+    async def test_blank_authorization_header_does_not_block_oauth(
+        self, monkeypatch: MonkeyPatch, mock_client: MagicMock, mock_auditor: MagicMock
+    ) -> None:
+        """A blank Authorization header is no credential (has_authorization_credential) — --oauth proceeds."""
+        import mcpscore.oauth
+
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth", "--header", "Authorization:"])
+
+        async def fake_flow(server_url: str, **kwargs) -> str:
+            return "flow-token"
+
+        monkeypatch.setattr(mcpscore.oauth, "obtain_token_interactively", fake_flow)
+        captured = {}
+
+        def capture_client(**kwargs):
+            captured["headers"] = kwargs.get("headers")
+            return mock_client
+
+        mock_client.detect_and_connect = AsyncMock(return_value=(True, MCPTransportType.STREAMABLE_HTTP))
+        with (
+            patch("mcpscore.cli.MCPClient", side_effect=capture_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        # The flow ran and its token replaced the blank header.
+        assert captured["headers"]["Authorization"] == "Bearer flow-token"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1215,3 +1215,10 @@ class TestOAuthCliFlow:
 
         assert exc.value.code == 1
         assert "timed out" in caplog.text
+
+    async def test_callback_port_without_oauth_exits_1(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--callback-port", "8765"])
+        with pytest.raises(SystemExit) as exc:
+            await async_main()
+        assert exc.value.code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1222,3 +1222,11 @@ class TestOAuthCliFlow:
         with pytest.raises(SystemExit) as exc:
             await async_main()
         assert exc.value.code == 1
+
+    async def test_callback_port_zero_without_oauth_exits_1(self, monkeypatch: MonkeyPatch) -> None:
+        """Falsy-but-present values must not slip the only-with---oauth guard."""
+        monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--callback-port", "0"])
+        with pytest.raises(SystemExit) as exc:
+            await async_main()
+        assert exc.value.code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1197,13 +1197,12 @@ class TestOAuthCliFlow:
         self, monkeypatch: MonkeyPatch, mock_client: MagicMock, mock_auditor: MagicMock, caplog: LogCaptureFixture
     ) -> None:
         import mcpscore.oauth
-        from mcpscore.oauth import OAuthFlowError
 
         monkeypatch.delenv("MCPSCORE_TOKEN", raising=False)
         monkeypatch.setattr(sys, "argv", ["mcpscore", "https://x/mcp", "--oauth"])
 
         async def failing_flow(server_url: str, **kwargs) -> str:
-            raise OAuthFlowError("timed out after 300s waiting for the browser authorization")
+            raise mcpscore.oauth.OAuthFlowError("timed out after 300s waiting for the browser authorization")
 
         monkeypatch.setattr(mcpscore.oauth, "obtain_token_interactively", failing_flow)
         with (

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -197,25 +197,27 @@ async def test_registration_failure_hints_client_id():
         )
 
 
-async def test_callback_without_code_raises():
+async def test_stray_bare_callback_does_not_consume_the_flow():
+    """A parameterless /callback visit (scanner, prefetch) must not end the wait."""
     fake = FakeAuthServer()
     actions: list[asyncio.Task] = []
 
-    def bad_redirect(authorization_url: str) -> None:
+    def stray_then_real(authorization_url: str) -> None:
         async def complete() -> None:
             query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
+            redirect_uri = query["redirect_uri"]
             async with httpx2.AsyncClient() as browser:
-                # No code, no error — a broken AS redirect.
-                await browser.get(f"{query['redirect_uri']}?state={query.get('state', '')}")
+                await browser.get(redirect_uri)  # no code, no error — ignored
+                await browser.get(f"{redirect_uri}?code=fake-auth-code&state={query.get('state', '')}")
 
         actions.append(asyncio.create_task(complete()))
 
-    with pytest.raises(OAuthFlowError, match="carried no code"):
-        await obtain_token_interactively(
-            SERVER_URL,
-            open_browser=bad_redirect,
-            transport=httpx2.MockTransport(fake.handler),
-        )
+    token = await obtain_token_interactively(
+        SERVER_URL,
+        open_browser=stray_then_real,
+        transport=httpx2.MockTransport(fake.handler),
+    )
+    assert token == ACCESS_TOKEN
     await asyncio.gather(*actions)
 
 
@@ -385,3 +387,22 @@ async def test_unknown_exception_text_is_not_echoed():
         )
     assert "secret-sounding-content-xyz" not in str(exc.value)
     assert "RuntimeError" in str(exc.value)
+
+
+async def test_token_survives_failed_followup_request():
+    """A network error on the retried request must not discard an obtained token."""
+    fake = FakeAuthServer()
+    actions: list[asyncio.Task] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url).startswith(SERVER_URL) and request.headers.get("Authorization"):
+            raise httpx2.ConnectError("server hiccup on the authorized retry")
+        return fake.handler(request)
+
+    token = await obtain_token_interactively(
+        SERVER_URL,
+        open_browser=_fake_user(actions),
+        transport=httpx2.MockTransport(handler),
+    )
+    assert token == ACCESS_TOKEN
+    await asyncio.gather(*actions)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -207,7 +207,8 @@ async def test_stray_bare_callback_does_not_consume_the_flow():
             query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
             redirect_uri = query["redirect_uri"]
             async with httpx2.AsyncClient() as browser:
-                await browser.get(redirect_uri)  # no code, no error — ignored
+                stray = await browser.get(redirect_uri)  # no code, no error — ignored
+                assert "waiting" in stray.text
                 await browser.get(f"{redirect_uri}?code=fake-auth-code&state={query.get('state', '')}")
 
         actions.append(asyncio.create_task(complete()))
@@ -261,8 +262,10 @@ async def test_non_callback_requests_are_ignored():
             redirect_uri = query["redirect_uri"]
             base = redirect_uri.rsplit("/", 1)[0]
             async with httpx2.AsyncClient() as browser:
-                await browser.get(f"{base}/favicon.ico")  # ignored by the listener
-                await browser.get(f"{redirect_uri}?code=fake-auth-code&state={query.get('state', '')}")
+                favicon = await browser.get(f"{base}/favicon.ico")  # ignored by the listener
+                assert favicon.status_code == 404
+                success = await browser.get(f"{redirect_uri}?code=fake-auth-code&state={query.get('state', '')}")
+                assert "close this tab" in success.text
 
         actions.append(asyncio.create_task(complete()))
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -311,3 +311,37 @@ async def test_token_exchange_failure_has_no_client_id_hint():
 
 async def test_close_before_start_is_safe():
     await _LoopbackCallbackServer().close()  # must not raise
+
+
+async def test_fixed_callback_port_is_used():
+    """--callback-port pins the redirect URI for strict authorization servers."""
+    import socket as socket_module
+
+    with socket_module.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    fake = FakeAuthServer(dynamic_registration=False)
+    actions: list[asyncio.Task] = []
+    seen_redirects: list[str] = []
+
+    def check_redirect(authorization_url: str) -> None:
+        query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
+        seen_redirects.append(query["redirect_uri"])
+
+        async def complete() -> None:
+            async with httpx2.AsyncClient() as browser:
+                await browser.get(f"{query['redirect_uri']}?code=fake-auth-code&state={query.get('state', '')}")
+
+        actions.append(asyncio.create_task(complete()))
+
+    token = await obtain_token_interactively(
+        SERVER_URL,
+        client_id="preregistered-app",
+        callback_port=port,
+        open_browser=check_redirect,
+        transport=httpx2.MockTransport(fake.handler),
+    )
+    assert token == ACCESS_TOKEN
+    assert seen_redirects == [f"http://127.0.0.1:{port}/callback"]
+    await asyncio.gather(*actions)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -103,8 +103,7 @@ async def test_full_flow_with_dynamic_registration():
     # PKCE was used in the exchange, with the public-client method.
     assert fake.token_calls[0]["grant_type"] == "authorization_code"
     assert "code_verifier" in fake.token_calls[0]
-    for task in actions:
-        await task
+    await asyncio.gather(*actions)
 
 
 async def test_client_id_skips_dynamic_registration():
@@ -122,8 +121,7 @@ async def test_client_id_skips_dynamic_registration():
     assert token == ACCESS_TOKEN
     assert fake.register_calls == 0
     assert fake.token_calls[0]["client_id"] == "preregistered-app"
-    for task in actions:
-        await task
+    await asyncio.gather(*actions)
 
 
 async def test_user_timeout_raises_flow_failed():
@@ -141,13 +139,15 @@ async def test_user_timeout_raises_flow_failed():
 async def test_authorization_refusal_raises_flow_failed():
     fake = FakeAuthServer()
 
+    actions: list[asyncio.Task] = []
+
     def refuse(authorization_url: str) -> None:
         async def complete() -> None:
             query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
             async with httpx2.AsyncClient() as browser:
                 await browser.get(f"{query['redirect_uri']}?error=access_denied&state={query.get('state', '')}")
 
-        asyncio.get_event_loop().create_task(complete())
+        actions.append(asyncio.get_event_loop().create_task(complete()))
 
     with pytest.raises(OAuthFlowError, match="access_denied"):
         await obtain_token_interactively(
@@ -155,8 +155,118 @@ async def test_authorization_refusal_raises_flow_failed():
             open_browser=refuse,
             transport=httpx2.MockTransport(fake.handler),
         )
+    await asyncio.gather(*actions)
 
 
 def test_flow_timeout_default_is_generous():
     """A human completes a browser login; the default must allow minutes, not seconds."""
     assert FLOW_TIMEOUT_S >= 120
+
+
+async def test_registration_failure_hints_client_id():
+    """A 404 from the registration endpoint produces the --client-id hint."""
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        url = str(request.url)
+        if url.startswith(SERVER_URL):
+            metadata_url = "https://server.example/.well-known/oauth-protected-resource/mcp"
+            return httpx2.Response(401, headers={"WWW-Authenticate": f'Bearer resource_metadata="{metadata_url}"'})
+        if "oauth-protected-resource" in url:
+            return httpx2.Response(200, json={"resource": SERVER_URL, "authorization_servers": [AS_ISSUER]})
+        if "oauth-authorization-server" in url or "openid-configuration" in url:
+            return httpx2.Response(
+                200,
+                json={
+                    "issuer": AS_ISSUER,
+                    "authorization_endpoint": f"{AS_ISSUER}/authorize",
+                    "token_endpoint": f"{AS_ISSUER}/token",
+                    "registration_endpoint": f"{AS_ISSUER}/register",
+                    "response_types_supported": ["code"],
+                    "code_challenge_methods_supported": ["S256"],
+                },
+            )
+        if url.startswith(f"{AS_ISSUER}/register"):
+            return httpx2.Response(404, text="404 page not found")
+        return httpx2.Response(404)
+
+    with pytest.raises(OAuthFlowError, match="try --client-id"):
+        await obtain_token_interactively(
+            SERVER_URL,
+            open_browser=lambda _url: None,
+            transport=httpx2.MockTransport(handler),
+        )
+
+
+async def test_callback_without_code_raises():
+    fake = FakeAuthServer()
+    actions: list[asyncio.Task] = []
+
+    def bad_redirect(authorization_url: str) -> None:
+        async def complete() -> None:
+            query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
+            async with httpx2.AsyncClient() as browser:
+                # No code, no error — a broken AS redirect.
+                await browser.get(f"{query['redirect_uri']}?state={query.get('state', '')}")
+
+        actions.append(asyncio.get_event_loop().create_task(complete()))
+
+    with pytest.raises(OAuthFlowError, match="carried no code"):
+        await obtain_token_interactively(
+            SERVER_URL,
+            open_browser=bad_redirect,
+            transport=httpx2.MockTransport(fake.handler),
+        )
+    await asyncio.gather(*actions)
+
+
+async def test_empty_token_response_raises_with_hint():
+    """A token endpoint returning an empty access token yields the no-token error."""
+    fake = FakeAuthServer()
+    original = fake.handler
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url).startswith(f"{AS_ISSUER}/token"):
+            return httpx2.Response(200, json={"access_token": "", "token_type": "Bearer"})
+        return original(request)
+
+    actions: list[asyncio.Task] = []
+    with pytest.raises(OAuthFlowError, match="no token exchange"):
+        await obtain_token_interactively(
+            SERVER_URL,
+            open_browser=_fake_user(actions),
+            transport=httpx2.MockTransport(handler),
+        )
+    await asyncio.gather(*actions)
+
+
+async def test_loopback_unavailable_raises(monkeypatch: pytest.MonkeyPatch):
+    import mcpscore.oauth
+
+    monkeypatch.setattr(mcpscore.oauth, "_loopback_port_available", lambda: False)
+    with pytest.raises(OAuthFlowError, match="loopback port"):
+        await obtain_token_interactively(SERVER_URL)
+
+
+async def test_non_callback_requests_are_ignored():
+    """A stray request (e.g. favicon) must not consume the one-shot callback."""
+    fake = FakeAuthServer()
+    actions: list[asyncio.Task] = []
+
+    def browser_with_favicon(authorization_url: str) -> None:
+        async def complete() -> None:
+            query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
+            redirect_uri = query["redirect_uri"]
+            base = redirect_uri.rsplit("/", 1)[0]
+            async with httpx2.AsyncClient() as browser:
+                await browser.get(f"{base}/favicon.ico")  # ignored by the listener
+                await browser.get(f"{redirect_uri}?code=fake-auth-code&state={query.get('state', '')}")
+
+        actions.append(asyncio.get_event_loop().create_task(complete()))
+
+    token = await obtain_token_interactively(
+        SERVER_URL,
+        open_browser=browser_with_favicon,
+        transport=httpx2.MockTransport(fake.handler),
+    )
+    assert token == ACCESS_TOKEN
+    await asyncio.gather(*actions)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -345,3 +345,43 @@ async def test_fixed_callback_port_is_used():
     assert token == ACCESS_TOKEN
     assert seen_redirects == [f"http://127.0.0.1:{port}/callback"]
     await asyncio.gather(*actions)
+
+
+async def test_flow_request_is_valid_json_rpc():
+    """The flow-driving request must be valid JSON-RPC so strict servers still 401."""
+    seen_bodies: list[dict] = []
+    fake = FakeAuthServer()
+    original = fake.handler
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url).startswith(SERVER_URL) and request.content:
+            seen_bodies.append(json.loads(request.content))
+        return original(request)
+
+    actions: list[asyncio.Task] = []
+    await obtain_token_interactively(
+        SERVER_URL,
+        open_browser=_fake_user(actions),
+        transport=httpx2.MockTransport(handler),
+    )
+    assert seen_bodies, "the flow must have posted to the server"
+    assert seen_bodies[0].get("jsonrpc") == "2.0"
+    assert "method" in seen_bodies[0]
+    await asyncio.gather(*actions)
+
+
+async def test_unknown_exception_text_is_not_echoed():
+    """Arbitrary exception text may carry response bodies — only the type is safe to log."""
+
+    class ExplodingTransport(httpx2.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+            raise RuntimeError("body dump with secret-sounding-content-xyz")
+
+    with pytest.raises(OAuthFlowError) as exc:
+        await obtain_token_interactively(
+            SERVER_URL,
+            open_browser=lambda _url: None,
+            transport=ExplodingTransport(),
+        )
+    assert "secret-sounding-content-xyz" not in str(exc.value)
+    assert "RuntimeError" in str(exc.value)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -409,3 +409,31 @@ async def test_token_survives_failed_followup_request():
     )
     assert token == ACCESS_TOKEN
     await asyncio.gather(*actions)
+
+
+async def test_dropped_connection_does_not_break_the_flow():
+    """A client that connects and vanishes must not disturb the waiting flow."""
+    fake = FakeAuthServer()
+    actions: list[asyncio.Task] = []
+
+    def rude_visitor_then_real(authorization_url: str) -> None:
+        async def complete() -> None:
+            query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
+            redirect_uri = query["redirect_uri"]
+            port = int(urlsplit(redirect_uri).port)
+            # Connect and disappear without sending a request.
+            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            await writer.wait_closed()
+            async with httpx2.AsyncClient() as browser:
+                await browser.get(f"{redirect_uri}?code=fake-auth-code&state={query.get('state', '')}")
+
+        actions.append(asyncio.create_task(complete()))
+
+    token = await obtain_token_interactively(
+        SERVER_URL,
+        open_browser=rude_visitor_then_real,
+        transport=httpx2.MockTransport(fake.handler),
+    )
+    assert token == ACCESS_TOKEN
+    await asyncio.gather(*actions)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qs, urlsplit
 import httpx2
 import pytest
 
-from mcpscore.oauth import FLOW_TIMEOUT_S, OAuthFlowError, obtain_token_interactively
+from mcpscore.oauth import FLOW_TIMEOUT_S, OAuthFlowError, _LoopbackCallbackServer, obtain_token_interactively
 
 SERVER_URL = "https://server.example/mcp"
 AS_ISSUER = "https://auth.example"
@@ -83,7 +83,7 @@ def _fake_user(loop_actions: list[asyncio.Task]) -> object:
             async with httpx2.AsyncClient() as browser:
                 await browser.get(f"{redirect_uri}?code=fake-auth-code&state={state}")
 
-        loop_actions.append(asyncio.get_event_loop().create_task(complete()))
+        loop_actions.append(asyncio.create_task(complete()))
 
     return open_browser
 
@@ -147,7 +147,7 @@ async def test_authorization_refusal_raises_flow_failed():
             async with httpx2.AsyncClient() as browser:
                 await browser.get(f"{query['redirect_uri']}?error=access_denied&state={query.get('state', '')}")
 
-        actions.append(asyncio.get_event_loop().create_task(complete()))
+        actions.append(asyncio.create_task(complete()))
 
     with pytest.raises(OAuthFlowError, match="access_denied"):
         await obtain_token_interactively(
@@ -208,7 +208,7 @@ async def test_callback_without_code_raises():
                 # No code, no error — a broken AS redirect.
                 await browser.get(f"{query['redirect_uri']}?state={query.get('state', '')}")
 
-        actions.append(asyncio.get_event_loop().create_task(complete()))
+        actions.append(asyncio.create_task(complete()))
 
     with pytest.raises(OAuthFlowError, match="carried no code"):
         await obtain_token_interactively(
@@ -240,9 +240,10 @@ async def test_empty_token_response_raises_with_hint():
 
 
 async def test_loopback_unavailable_raises(monkeypatch: pytest.MonkeyPatch):
-    import mcpscore.oauth
+    async def failing_start(self) -> None:
+        raise OSError(98, "Address already in use")
 
-    monkeypatch.setattr(mcpscore.oauth, "_loopback_port_available", lambda: False)
+    monkeypatch.setattr(_LoopbackCallbackServer, "start", failing_start)
     with pytest.raises(OAuthFlowError, match="loopback port"):
         await obtain_token_interactively(SERVER_URL)
 
@@ -261,7 +262,7 @@ async def test_non_callback_requests_are_ignored():
                 await browser.get(f"{base}/favicon.ico")  # ignored by the listener
                 await browser.get(f"{redirect_uri}?code=fake-auth-code&state={query.get('state', '')}")
 
-        actions.append(asyncio.get_event_loop().create_task(complete()))
+        actions.append(asyncio.create_task(complete()))
 
     token = await obtain_token_interactively(
         SERVER_URL,
@@ -270,3 +271,43 @@ async def test_non_callback_requests_are_ignored():
     )
     assert token == ACCESS_TOKEN
     await asyncio.gather(*actions)
+
+
+async def test_second_callback_request_is_ignored():
+    """The listener is one-shot: a duplicate redirect must not disturb the result."""
+    listener = _LoopbackCallbackServer()
+    await listener.start()
+    try:
+        async with httpx2.AsyncClient() as browser:
+            await browser.get(f"{listener.redirect_uri}?code=first-code&state=s1")
+            # The user double-clicks / the browser retries: same redirect again.
+            await browser.get(f"{listener.redirect_uri}?code=stale-second-code&state=s2")
+        params = await listener.wait_for_callback(deadline_s=2)
+        assert params["code"] == "first-code"
+    finally:
+        await listener.close()
+
+
+async def test_token_exchange_failure_has_no_client_id_hint():
+    """A failure past registration (e.g. broken token endpoint) must not suggest --client-id."""
+    fake = FakeAuthServer()
+    original = fake.handler
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url).startswith(f"{AS_ISSUER}/token"):
+            return httpx2.Response(500, text="token endpoint exploded")
+        return original(request)
+
+    actions: list[asyncio.Task] = []
+    with pytest.raises(OAuthFlowError) as exc:
+        await obtain_token_interactively(
+            SERVER_URL,
+            open_browser=_fake_user(actions),
+            transport=httpx2.MockTransport(handler),
+        )
+    assert "--client-id" not in str(exc.value)
+    await asyncio.gather(*actions)
+
+
+async def test_close_before_start_is_safe():
+    await _LoopbackCallbackServer().close()  # must not raise

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -284,7 +284,7 @@ async def test_second_callback_request_is_ignored():
             await browser.get(f"{listener.redirect_uri}?code=first-code&state=s1")
             # The user double-clicks / the browser retries: same redirect again.
             await browser.get(f"{listener.redirect_uri}?code=stale-second-code&state=s2")
-        params = await listener.wait_for_callback(deadline_s=2)
+        params = await listener.wait_for_callback(timeout_s=2)
         assert params["code"] == "first-code"
     finally:
         await listener.close()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,162 @@
+"""Tests for the interactive OAuth flow (--oauth).
+
+The full loop runs hermetically: a MockTransport plays the gated MCP server
+and its authorization server (discovery, registration, token exchange), the
+real loopback listener catches the redirect, and a fake "user" completes the
+authorization by following the authorize URL's redirect programmatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import httpx2
+import pytest
+
+from mcpscore.oauth import FLOW_TIMEOUT_S, OAuthFlowError, obtain_token_interactively
+
+SERVER_URL = "https://server.example/mcp"
+AS_ISSUER = "https://auth.example"
+ACCESS_TOKEN = "test-access-token-123"
+
+
+class FakeAuthServer:
+    """MockTransport handler covering the gated server and its AS."""
+
+    def __init__(self, *, dynamic_registration: bool = True) -> None:
+        super().__init__()
+        self.dynamic_registration = dynamic_registration
+        self.register_calls = 0
+        self.token_calls: list[dict[str, str]] = []
+
+    def handler(self, request: httpx2.Request) -> httpx2.Response:
+        url = str(request.url)
+        if url.startswith(SERVER_URL):
+            if request.headers.get("Authorization") == f"Bearer {ACCESS_TOKEN}":
+                return httpx2.Response(200, json={})
+            metadata_url = "https://server.example/.well-known/oauth-protected-resource/mcp"
+            return httpx2.Response(
+                401,
+                headers={"WWW-Authenticate": f'Bearer resource_metadata="{metadata_url}"'},
+            )
+        if "oauth-protected-resource" in url:
+            return httpx2.Response(200, json={"resource": SERVER_URL, "authorization_servers": [AS_ISSUER]})
+        if "oauth-authorization-server" in url or "openid-configuration" in url:
+            metadata = {
+                "issuer": AS_ISSUER,
+                "authorization_endpoint": f"{AS_ISSUER}/authorize",
+                "token_endpoint": f"{AS_ISSUER}/token",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "code_challenge_methods_supported": ["S256"],
+            }
+            if self.dynamic_registration:
+                metadata["registration_endpoint"] = f"{AS_ISSUER}/register"
+            return httpx2.Response(200, json=metadata)
+        if url.startswith(f"{AS_ISSUER}/register"):
+            self.register_calls += 1
+            body = json.loads(request.content)
+            return httpx2.Response(
+                201,
+                json={"client_id": "registered-client", **body},
+            )
+        if url.startswith(f"{AS_ISSUER}/token"):
+            form = {key: values[0] for key, values in parse_qs(request.content.decode()).items()}
+            self.token_calls.append(form)
+            return httpx2.Response(
+                200,
+                json={"access_token": ACCESS_TOKEN, "token_type": "Bearer", "expires_in": 3600},
+            )
+        return httpx2.Response(404)
+
+
+def _fake_user(loop_actions: list[asyncio.Task]) -> object:
+    """Return an open_browser stand-in that "authorizes" via the loopback redirect."""
+
+    def open_browser(authorization_url: str) -> None:
+        async def complete() -> None:
+            query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
+            redirect_uri = query["redirect_uri"]
+            state = query.get("state", "")
+            async with httpx2.AsyncClient() as browser:
+                await browser.get(f"{redirect_uri}?code=fake-auth-code&state={state}")
+
+        loop_actions.append(asyncio.get_event_loop().create_task(complete()))
+
+    return open_browser
+
+
+async def test_full_flow_with_dynamic_registration():
+    fake = FakeAuthServer()
+    actions: list[asyncio.Task] = []
+
+    token = await obtain_token_interactively(
+        SERVER_URL,
+        open_browser=_fake_user(actions),
+        transport=httpx2.MockTransport(fake.handler),
+    )
+
+    assert token == ACCESS_TOKEN
+    assert fake.register_calls == 1
+    # PKCE was used in the exchange, with the public-client method.
+    assert fake.token_calls[0]["grant_type"] == "authorization_code"
+    assert "code_verifier" in fake.token_calls[0]
+    for task in actions:
+        await task
+
+
+async def test_client_id_skips_dynamic_registration():
+    """--client-id pre-seeds client info so no registration request is made."""
+    fake = FakeAuthServer(dynamic_registration=False)
+    actions: list[asyncio.Task] = []
+
+    token = await obtain_token_interactively(
+        SERVER_URL,
+        client_id="preregistered-app",
+        open_browser=_fake_user(actions),
+        transport=httpx2.MockTransport(fake.handler),
+    )
+
+    assert token == ACCESS_TOKEN
+    assert fake.register_calls == 0
+    assert fake.token_calls[0]["client_id"] == "preregistered-app"
+    for task in actions:
+        await task
+
+
+async def test_user_timeout_raises_flow_failed():
+    fake = FakeAuthServer()
+
+    with pytest.raises(OAuthFlowError, match="timed out"):
+        await obtain_token_interactively(
+            SERVER_URL,
+            flow_timeout_s=0.2,
+            open_browser=lambda _url: None,  # the "user" never authorizes
+            transport=httpx2.MockTransport(fake.handler),
+        )
+
+
+async def test_authorization_refusal_raises_flow_failed():
+    fake = FakeAuthServer()
+
+    def refuse(authorization_url: str) -> None:
+        async def complete() -> None:
+            query = {key: values[0] for key, values in parse_qs(urlsplit(authorization_url).query).items()}
+            async with httpx2.AsyncClient() as browser:
+                await browser.get(f"{query['redirect_uri']}?error=access_denied&state={query.get('state', '')}")
+
+        asyncio.get_event_loop().create_task(complete())
+
+    with pytest.raises(OAuthFlowError, match="access_denied"):
+        await obtain_token_interactively(
+            SERVER_URL,
+            open_browser=refuse,
+            transport=httpx2.MockTransport(fake.handler),
+        )
+
+
+def test_flow_timeout_default_is_generous():
+    """A human completes a browser login; the default must allow minutes, not seconds."""
+    assert FLOW_TIMEOUT_S >= 120


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an interactive OAuth path that handles tokens and opens a local callback listener; behavior is optional and well-tested, but it touches authentication and user-facing security semantics.
> 
> **Overview**
> **Interactive OAuth for full audits** — New `--oauth` runs authorization-code + PKCE in the browser: discover the AS (RFC 9728/8414), optionally register dynamically (RFC 7591) or use `--client-id`, catch the redirect on `127.0.0.1` via `--callback-port`, then audit with an in-memory `Authorization: Bearer` token (same path as `--token`). CLI validates conflicts (no `--token`/env credential), HTTP-only targets, and failed flows exit **1**.
> 
> **Stability contract** — New `docs/stability.mdx` (nav + CHANGELOG) documents stable surfaces (`rule_id`, `schema_version`, CLI/exit codes, no credentials in logs/reports) vs evolving score/messages; exit **1** now explicitly includes failed `--oauth`.
> 
> **Tests** — Broad `tests/test_oauth.py` and `TestOAuthCliFlow` in `tests/test_cli.py` cover the loopback edge cases and CLI wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c622ae39d577ed0f468b1a2c4252658036be991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->