### PR TITLE
Updated docs

### DIFF
--- a/docs/authenticated-servers.mdx
+++ b/docs/authenticated-servers.mdx
@@ -80,11 +80,13 @@ parts of quality an unauthenticated client can see are real:
   and points at HTTPS-only authorization servers.
 - **TLS** and **transport** behavior.
 
-The report is marked `partial` with a `partial_reason`, and the CLI says so:
+The report is marked `partial` with a `partial_reason`, and the CLI says so
+in the report tail:
 
 ```
-⚠️  Partial audit (Server requires authentication — running a partial audit
-of the observable surface.).
+⚠️  Partial audit (Server requires authentication (HTTP 401); scored the
+unauthenticated surface only — pass a token to audit behind the gate.).
+Only the auth, TLS, and transport surface was scored — not comparable to a full audit.
 ```
 
 <Note>

--- a/docs/authenticated-servers.mdx
+++ b/docs/authenticated-servers.mdx
@@ -1,0 +1,138 @@
+---
+title: "Authenticated Servers"
+description: "Audit servers behind OAuth or API keys — bring a token, run the browser flow, or score the observable surface without credentials."
+icon: "lock"
+---
+
+Many production MCP servers sit behind OAuth 2.x or an API key. mcpscore audits
+them the way any MCP client connects to them: present a credential and audit
+behind the gate, or present nothing and score what an unauthenticated client
+can observe. Credential values are **never logged and never written to the
+report** — the only trace is a boolean `authenticated` flag.
+
+## Bearer tokens
+
+If you already have a token, pass it directly:
+
+```bash
+mcpscore https://your-server.example/mcp --token "$MY_TOKEN"
+```
+
+`--token` is shorthand for `--header 'Authorization: Bearer <TOKEN>'`. When the
+flag is omitted, mcpscore falls back to the `MCPSCORE_TOKEN` environment
+variable — the recommended form in CI and anywhere shell history is a concern:
+
+```bash
+export MCPSCORE_TOKEN="$MY_TOKEN"
+mcpscore https://your-server.example/mcp
+```
+
+## API keys and custom headers
+
+For servers gated by an API key or any non-OAuth scheme, send arbitrary
+headers with `--header` (repeatable):
+
+```bash
+mcpscore https://your-server.example/mcp \
+  --header 'X-Api-Key: <key>' \
+  --header 'X-Tenant: acme'
+```
+
+An explicit `Authorization` header always wins over `--token` /
+`MCPSCORE_TOKEN`. Only an `Authorization` credential sets the report's
+`authenticated` flag — other custom headers are sent but don't claim the audit
+was authenticated.
+
+## Interactive OAuth
+
+No token at hand? Let mcpscore obtain one:
+
+```bash
+mcpscore https://your-server.example/mcp --oauth
+```
+
+This opens your browser for the server's OAuth flow (authorization code +
+PKCE, per the [MCP authorization
+spec](https://modelcontextprotocol.io/specification/draft/basic/authorization)).
+The token is held **in memory only** — never written to disk, never logged.
+
+`--oauth` relies on the authorization server supporting **dynamic client
+registration** (RFC 7591). Some don't — GitHub's authorization server, for
+example, has no registration endpoint. For those, register an OAuth app once
+yourself and pass its ID:
+
+```bash
+mcpscore https://your-server.example/mcp --oauth --client-id <your-app-id>
+```
+
+The registered app must allow a loopback redirect URI
+(`http://127.0.0.1:<port>/callback`). RFC 8252 requires authorization servers
+to accept any port on loopback redirects; if yours insists on the exact
+pre-registered URI, pin the port with `--callback-port`.
+
+## No credentials? Partial audits
+
+An auth-gated server audited without credentials is still worth scoring — the
+parts of quality an unauthenticated client can see are real:
+
+- **Authorization posture** — the server answers 401 with a proper
+  `WWW-Authenticate` challenge, serves RFC 9728 protected-resource metadata,
+  and points at HTTPS-only authorization servers.
+- **TLS** and **transport** behavior.
+
+The report is marked `partial` with a `partial_reason`, and the CLI says so:
+
+```
+⚠️  Partial audit (Server requires authentication — running a partial audit
+of the observable surface.).
+```
+
+<Note>
+A partial score covers fewer checks than a full audit, so the two are **not
+comparable** — don't gate CI on a partial score threshold you calibrated
+against full audits.
+</Note>
+
+## Worked example: GitHub Copilot MCP
+
+GitHub's Copilot MCP server is OAuth-gated. Without credentials you get a
+partial audit of its auth posture, TLS, and transport:
+
+```bash
+mcpscore https://api.githubcopilot.com/mcp/
+```
+
+With a GitHub token you audit behind the gate — tools, schemas, the full
+report:
+
+```bash
+mcpscore https://api.githubcopilot.com/mcp/ --token "$GITHUB_TOKEN"
+```
+
+(`--oauth` against GitHub needs `--client-id`, since GitHub's authorization
+server doesn't offer dynamic client registration — see above.)
+
+## In CI
+
+Store the token as a secret and export it as `MCPSCORE_TOKEN`; nothing else
+changes. With the [GitHub Action](/github-action):
+
+```yaml
+- uses: mcp-box/mcpscore-action@v1
+  with:
+    target: https://your-server.example/mcp
+    min-score: 80
+  env:
+    MCPSCORE_TOKEN: ${{ secrets.MCPSCORE_TOKEN }}
+```
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="GitHub Action" icon="github" href="/github-action">
+    Gate pull requests on quality — including gated servers
+  </Card>
+  <Card title="Rules Reference" icon="list-check" href="/rules">
+    The auth-posture rules, with their spec and RFC citations
+  </Card>
+</CardGroup>

--- a/docs/authenticated-servers.mdx
+++ b/docs/authenticated-servers.mdx
@@ -7,8 +7,10 @@ icon: "lock"
 Many production MCP servers sit behind OAuth 2.x or an API key. mcpscore audits
 them the way any MCP client connects to them: present a credential and audit
 behind the gate, or present nothing and score what an unauthenticated client
-can observe. Credential values are **never logged and never written to the
-report** — the only trace is a boolean `authenticated` flag.
+can observe. Credential **values** are **never logged and never written to
+the report** — about the credential itself, the report records only the
+boolean `authenticated` flag (other report fields like `partial_reason`
+describe the server's auth requirements, never your secrets).
 
 ## Bearer tokens
 

--- a/docs/badge.mdx
+++ b/docs/badge.mdx
@@ -33,9 +33,14 @@ for your server; the shape is:
 
 ## How it stays fresh
 
-- The badge always reflects the **newest completed audit** for the exact
-  server URL in the query string. Re-audit the server (on mcpscore.dev or via
-  CI) and every README embed updates on its own — no new snippet needed.
+- The badge **image** always reflects the **newest completed audit** for the
+  exact server URL in the query string. Re-audit the server (on mcpscore.dev
+  or via CI) and every README embed updates on its own — no new snippet
+  needed.
+- The **click-through link** is different: it points at the specific audit
+  report you copied the snippet from, and stays pinned to it. Re-copy the
+  snippet from a newer report when you want the link to lead somewhere
+  fresher — the image keeps itself current either way.
 - It's served with a short cache (~5 minutes), so a fresh score shows up
   quickly.
 - A server that has never been audited gets a neutral **"no data"** badge —

--- a/docs/badge.mdx
+++ b/docs/badge.mdx
@@ -1,0 +1,65 @@
+---
+title: "Score Badge"
+description: "Embed a live mcpscore badge in your README — it updates automatically every time your server is re-audited."
+icon: "shield-check"
+---
+
+Every server audited on [mcpscore.dev](https://mcpscore.dev) gets a stable
+badge URL, keyed by the server's URL — not by any single audit. Embed it once
+and it always shows the **latest completed score**:
+
+```
+https://mcpscore.dev/api/v1/servers/badge.svg?url=<url-encoded server URL>
+```
+
+## Embed it
+
+The report page on mcpscore.dev has a copy-paste block with these prefilled
+for your server; the shape is:
+
+<CodeGroup>
+
+```markdown Markdown
+[![mcpscore score](https://mcpscore.dev/api/v1/servers/badge.svg?url=https%3A%2F%2Fyour-server.example%2Fmcp)](https://mcpscore.dev/audits/<audit-id>)
+```
+
+```html HTML
+<a href="https://mcpscore.dev/audits/<audit-id>">
+  <img src="https://mcpscore.dev/api/v1/servers/badge.svg?url=https%3A%2F%2Fyour-server.example%2Fmcp" alt="mcpscore score" />
+</a>
+```
+
+</CodeGroup>
+
+## How it stays fresh
+
+- The badge always reflects the **newest completed audit** for the exact
+  server URL in the query string. Re-audit the server (on mcpscore.dev or via
+  CI) and every README embed updates on its own — no new snippet needed.
+- It's served with a short cache (~5 minutes), so a fresh score shows up
+  quickly.
+- A server that has never been audited gets a neutral **"no data"** badge —
+  the embed never breaks.
+
+<Note>
+The `url` parameter must match the audited server URL exactly (URL-encoded).
+`https://example.com/mcp` and `https://example.com/mcp/other` are different
+servers as far as the badge is concerned.
+</Note>
+
+## Safe to embed
+
+Requesting the badge **never triggers an audit** — it's a read-only lookup of
+the latest score, so embedding it in a high-traffic README costs your server
+nothing.
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="GitHub Action" icon="github" href="/github-action">
+    Re-audit on every pull request, so the badge tracks your main branch
+  </Card>
+  <Card title="Scoring Methodology" icon="scale-balanced" href="/methodology">
+    What the number on the badge actually measures
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -18,6 +18,13 @@
         ]
       },
       {
+        "group": "Guides",
+        "pages": [
+          "authenticated-servers",
+          "badge"
+        ]
+      },
+      {
         "group": "Use in CI",
         "pages": [
           "github-action"

--- a/docs/github-action.mdx
+++ b/docs/github-action.mdx
@@ -80,6 +80,38 @@ at the entry file:
     min-score: 85
 ```
 
+### Audit an auth-gated server
+
+Store the credential as an Actions secret and export it as `MCPSCORE_TOKEN` —
+the CLI picks it up automatically and the value never appears in logs or in
+the report:
+
+```yaml
+- uses: mcp-box/mcpscore-action@v1
+  with:
+    target: https://your-server.example/mcp
+    min-score: 80
+  env:
+    MCPSCORE_TOKEN: ${{ secrets.MCPSCORE_TOKEN }}
+```
+
+For API-key servers, pass a header through `args` instead — see
+[Authenticated Servers](/authenticated-servers) for all the flavors:
+
+```yaml
+- uses: mcp-box/mcpscore-action@v1
+  with:
+    target: https://your-server.example/mcp
+    args: --header 'X-Api-Key: ${{ secrets.MCP_API_KEY }}'
+```
+
+<Note>
+Without a credential, an auth-gated server gets a **partial audit** of its
+observable surface (auth posture, TLS, transport). Partial scores cover fewer
+checks and are not comparable to full-audit scores — calibrate `min-score`
+against whichever kind of audit the workflow actually runs.
+</Note>
+
 ### Also require readiness for the upcoming spec
 
 ```yaml

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -82,6 +82,9 @@ Many production MCP servers require OAuth 2.x. mcpscore handles them two ways:
   only an `authenticated` flag is recorded (set when an Authorization
   credential was sent; other custom headers do not set it).
 
+The [Authenticated Servers guide](/authenticated-servers) walks through every
+flavor, including a worked example against GitHub's Copilot MCP server.
+
 Example output tail:
 
 ```
@@ -99,8 +102,14 @@ Readiness for MCP 2026-07-28: 3/13 (informative — not part of the main score)
   <Card title="Rules Reference" icon="list-check" href="/rules">
     Every rule, its severity, and when it applies
   </Card>
+  <Card title="Authenticated Servers" icon="lock" href="/authenticated-servers">
+    Audit behind OAuth and API keys — or score the observable surface
+  </Card>
   <Card title="GitHub Action" icon="github" href="/github-action">
     Gate pull requests on quality, with a report comment
+  </Card>
+  <Card title="Score Badge" icon="shield-check" href="/badge">
+    A live badge for your README that tracks your latest score
   </Card>
   <Card title="Source" icon="code" href="https://github.com/mcp-box/mcpscore">
     mcp-box/mcpscore — issues and contributing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling code modifications.
> 
> **Overview**
> Adds a **Guides** section to the Mintlify docs with two new pages and wires them into the home page and GitHub Action docs.
> 
> **Authenticated Servers** documents how to audit OAuth/API-key MCP servers: `--token` / `MCPSCORE_TOKEN`, repeatable `--header`, interactive `--oauth` (PKCE, dynamic registration vs `--client-id`), partial audits when unauthenticated, a GitHub Copilot MCP example, and CI patterns.
> 
> **Score Badge** explains embedding `badge.svg` keyed by server URL, how the image tracks the latest audit vs a pinned click-through link, caching, and that badge requests are read-only.
> 
> `docs.json` adds a Guides nav group; `index.mdx` links the auth guide and adds cards for both guides; `github-action.mdx` adds an **Audit an auth-gated server** subsection (`MCPSCORE_TOKEN`, `args` for API keys, partial-audit `min-score` caveat).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14180396c5fab4e41b7601b7a977f117613a8160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->