### PR TITLE
Prepare for the 1.1.0b4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0b4] - 2026-07-25
+
 ### Added
 
 - **`--oauth`: interactive browser OAuth flow.** mcpscore discovers the
@@ -403,7 +405,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b3...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b4...HEAD
+[1.1.0b4]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b3...v1.1.0b4
 [1.1.0b3]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b2...v1.1.0b3
 [1.1.0b2]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b1...v1.1.0b2
 [1.1.0b1]: https://github.com/mcp-box/mcpscore/compare/v0.9.0...v1.1.0b1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.1.0b3"
+version = "1.1.0b4"
 description = "CLI tool to analyze your MCP server and get a comprehensive report on its quality"
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.1.0b3"
+version = "1.1.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no application logic modified in this PR.
> 
> **Overview**
> **Release packaging only** — bumps the distributable version from `1.1.0b3` to **`1.1.0b4`** in `pyproject.toml` and `uv.lock`, with no runtime or CLI code changes in this diff.
> 
> **CHANGELOG** adds the **`[1.1.0b4] - 2026-07-25`** section (documenting features shipped in this beta, such as `--oauth`, stability docs, readiness score promotion, and rule `basis` citations) and updates the `[Unreleased]` / compare links to point at `v1.1.0b4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4f6251a2a5596953e4b777fec180cac96a3fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->