### PR TITLE
Fix an auth issue and prepare a new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0b5] - 2026-07-25
+
+### Fixed
+
+- **An unreachable authorization server no longer voids the protected-resource
+  findings.** The RFC 8414 discovery walk leaves the audited server's origin
+  for the authorization server's, and a transport failure there (DNS, refused
+  connection, timeout, TLS) propagated out of the auth-metadata probe and
+  discarded the RFC 9728 metadata already collected. Six auth rules
+  (`auth_protected_resource_metadata`, `auth_authorization_servers_https`,
+  `auth_metadata_https`, `auth_scopes_advertised`,
+  `auth_server_metadata_present`, `auth_server_metadata_pkce`) then skipped as
+  insufficient-data, shrinking `max_score` — so a server advertising a *bogus*
+  authorization server scored more leniently than one advertising a working
+  one, and `auth_server_metadata_present` skipped itself out of the very score
+  it exists to enforce. The walk now records the failure in
+  `auth_server_metadata_error` and leaves `auth_server_metadata_present` false,
+  keeping the protected-resource findings intact.
+- A transport error on one RFC 9728 well-known location no longer aborts the
+  discovery of the next. When *every* location fails to connect the probe still
+  reports `ERROR` (unverified) rather than `UNSUPPORTED` — an unreachable host
+  is not evidence that a server publishes no metadata, so the dependent rules
+  skip instead of failing it.
+
 ## [1.1.0b4] - 2026-07-25
 
 ### Added
@@ -405,7 +429,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b4...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b5...HEAD
+[1.1.0b5]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b4...v1.1.0b5
 [1.1.0b4]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b3...v1.1.0b4
 [1.1.0b3]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b2...v1.1.0b3
 [1.1.0b2]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b1...v1.1.0b2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one, and `auth_server_metadata_present` skipped itself out of the very score
   it exists to enforce. The walk now records the failure in
   `auth_server_metadata_error` and leaves `auth_server_metadata_present` false,
-  keeping the protected-resource findings intact.
+  keeping the protected-resource findings intact. This covers unusable issuer
+  URLs too (an invalid IPv4 literal, a bare IPv6 host): `authorization_servers`
+  is server-controlled and only scheme-checked, and those raise `InvalidURL`,
+  which does not derive from `HTTPError` — so advertising a malformed issuer
+  was a way for a server to skip those six rules out of its own `max_score`.
 - A transport error on one RFC 9728 well-known location no longer aborts the
   discovery of the next. When *every* location fails to connect the probe still
   reports `ERROR` (unverified) rather than `UNSUPPORTED` — an unreachable host
   is not evidence that a server publishes no metadata, so the dependent rules
-  skip instead of failing it.
+  skip instead of failing it. Locations that could not be contacted are listed
+  in the probe's `unreachable_locations`, and the `ERROR` outcome now keeps the
+  context it collected (`urls_tried`) instead of reporting the exception alone.
+- `auth_server_metadata_error` is now recorded only when *no* authorization-server
+  location could be contacted. An issuer answering one location with a 404 is
+  reachable and simply publishes nothing there; it previously kept an earlier
+  candidate's transport error, misreporting it as unreachable.
 
 ## [1.1.0b4] - 2026-07-25
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -492,12 +492,19 @@ async def _try_get_json_anonymous(
     server's. An unreachable, slow or TLS-broken hop there is a finding about
     *that* hop, so it must not discard what earlier hops already established.
 
+    ``InvalidURL`` is caught alongside ``HTTPError`` (it derives from
+    ``Exception``, not from it): these URLs are built from the audited server's
+    own ``authorization_servers`` values, and a syntactically plausible but
+    unusable one — ``https://256.256.256.256``, a bare IPv6 host, a zero-width
+    space in the hostname — must be a finding about that server, not an
+    exception that voids the audit's other observations.
+
     Returns (http_status, parsed_dict_or_None, exception_name_or_None); status
     is None when the request never completed.
     """
     try:
         status, parsed = await _get_json_anonymous(client, url)
-    except httpx2.HTTPError as e:
+    except (httpx2.HTTPError, httpx2.InvalidURL) as e:
         return None, None, type(e).__name__
     return status, parsed, None
 
@@ -525,21 +532,30 @@ async def _fetch_auth_server_metadata(client: httpx2.AsyncClient, issuer: str, d
     9700) / MCP-auth requirement.
 
     An authorization server that cannot be reached at all (DNS failure,
-    refused connection, timeout, TLS error) leaves
+    refused connection, timeout, TLS error, unusable URL) leaves
     ``auth_server_metadata_present`` False and records the transport failure in
     ``auth_server_metadata_error``: "the issuer this server advertises is
     unreachable" is itself the finding, and it must not void the
     protected-resource metadata already collected by the caller.
+
+    ``auth_server_metadata_error`` means *no* candidate location was contacted.
+    An issuer that answers one location (even with a 404 or a non-JSON body) is
+    reachable and simply publishes nothing usable there, so it records no
+    transport error — reporting one would misattribute a missing document to an
+    unreachable host.
     """
     details["auth_server_issuer"] = issuer
     details["auth_server_metadata_present"] = False
+    reached = False
+    last_error: str | None = None
     for candidate in _auth_server_metadata_urls(issuer):
         _status, metadata, error = await _try_get_json_anonymous(client, candidate)
         if error is not None:
-            details["auth_server_metadata_error"] = error
+            last_error = error
+            continue
+        reached = True
         if metadata is None:
             continue
-        details.pop("auth_server_metadata_error", None)
         methods = metadata.get("code_challenge_methods_supported")
         details["auth_server_metadata_url"] = candidate
         details["auth_server_metadata_present"] = True
@@ -548,6 +564,8 @@ async def _fetch_auth_server_metadata(client: httpx2.AsyncClient, issuer: str, d
         )
         details["auth_server_pkce_s256"] = isinstance(methods, list) and "S256" in methods
         return
+    if not reached:
+        details["auth_server_metadata_error"] = last_error
 
 
 async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeResult:
@@ -564,7 +582,9 @@ async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeRes
     the next, but "every location failed to connect" stays ERROR rather than
     UNSUPPORTED: an unreachable host is *unverified*, not proof that the
     server publishes no metadata, and the dependent rules must skip rather
-    than fail it.
+    than fail it. Locations that could not be contacted are listed in
+    ``unreachable_locations`` whatever the outcome, so a firewalled location is
+    distinguishable from one that simply answered 404.
     """
     details: dict[str, Any] = {"urls_tried": []}
     reached = False
@@ -574,6 +594,7 @@ async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeRes
         status, metadata, error = await _try_get_json_anonymous(client, candidate)
         if error is not None:
             last_error = error
+            details.setdefault("unreachable_locations", []).append(candidate)
             continue
         reached = True
         details["http_status"] = status
@@ -595,7 +616,9 @@ async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeRes
                 await _fetch_auth_server_metadata(client, first, details)
             return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.SUPPORTED, details, payload=metadata)
     if not reached:
-        return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.ERROR, {"exception": last_error})
+        # Keep what was established (urls_tried, unreachable_locations) — an
+        # ERROR outcome is the case that most needs the diagnostic context.
+        return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.ERROR, details | {"exception": last_error})
     return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.UNSUPPORTED, details)
 
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -482,6 +482,26 @@ async def _get_json_anonymous(client: httpx2.AsyncClient, url: str) -> tuple[int
     return response.status_code, parsed if isinstance(parsed, dict) else None
 
 
+async def _try_get_json_anonymous(
+    client: httpx2.AsyncClient, url: str
+) -> tuple[int | None, dict[str, Any] | None, str | None]:
+    """``_get_json_anonymous`` that reports transport failures as data, never raises.
+
+    The auth-discovery chain spans hosts the audited server does not control —
+    RFC 8414 discovery leaves the server's origin for the authorization
+    server's. An unreachable, slow or TLS-broken hop there is a finding about
+    *that* hop, so it must not discard what earlier hops already established.
+
+    Returns (http_status, parsed_dict_or_None, exception_name_or_None); status
+    is None when the request never completed.
+    """
+    try:
+        status, parsed = await _get_json_anonymous(client, url)
+    except httpx2.HTTPError as e:
+        return None, None, type(e).__name__
+    return status, parsed, None
+
+
 def _is_http_url(value: object) -> bool:
     """Whether a value is an http(s) URL string."""
     return isinstance(value, str) and value.startswith(("https://", "http://"))
@@ -503,13 +523,23 @@ async def _fetch_auth_server_metadata(client: httpx2.AsyncClient, issuer: str, d
     required authorization/token endpoints, and whether it advertises PKCE with
     S256 (`code_challenge_methods_supported`) — the OAuth security BCP (RFC
     9700) / MCP-auth requirement.
+
+    An authorization server that cannot be reached at all (DNS failure,
+    refused connection, timeout, TLS error) leaves
+    ``auth_server_metadata_present`` False and records the transport failure in
+    ``auth_server_metadata_error``: "the issuer this server advertises is
+    unreachable" is itself the finding, and it must not void the
+    protected-resource metadata already collected by the caller.
     """
     details["auth_server_issuer"] = issuer
     details["auth_server_metadata_present"] = False
     for candidate in _auth_server_metadata_urls(issuer):
-        _status, metadata = await _get_json_anonymous(client, candidate)
+        _status, metadata, error = await _try_get_json_anonymous(client, candidate)
+        if error is not None:
+            details["auth_server_metadata_error"] = error
         if metadata is None:
             continue
+        details.pop("auth_server_metadata_error", None)
         methods = metadata.get("code_challenge_methods_supported")
         details["auth_server_metadata_url"] = candidate
         details["auth_server_metadata_present"] = True
@@ -529,11 +559,23 @@ async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeRes
     where, plus the authorization server's endpoint/PKCE posture. Servers
     without authentication commonly 404 here — the dependent rules skip unless
     the endpoint demanded auth in the first place.
+
+    A transport error on one well-known location does not abort discovery of
+    the next, but "every location failed to connect" stays ERROR rather than
+    UNSUPPORTED: an unreachable host is *unverified*, not proof that the
+    server publishes no metadata, and the dependent rules must skip rather
+    than fail it.
     """
     details: dict[str, Any] = {"urls_tried": []}
+    reached = False
+    last_error: str | None = None
     for candidate in _well_known_urls(url):
         details["urls_tried"].append(candidate)
-        status, metadata = await _get_json_anonymous(client, candidate)
+        status, metadata, error = await _try_get_json_anonymous(client, candidate)
+        if error is not None:
+            last_error = error
+            continue
+        reached = True
         details["http_status"] = status
         if metadata is None:
             continue
@@ -552,6 +594,8 @@ async def _probe_auth_metadata(client: httpx2.AsyncClient, url: str) -> ProbeRes
             if first is not None:
                 await _fetch_auth_server_metadata(client, first, details)
             return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.SUPPORTED, details, payload=metadata)
+    if not reached:
+        return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.ERROR, {"exception": last_error})
     return ProbeResult(PROBE_AUTH_METADATA, ProbeOutcome.UNSUPPORTED, details)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.1.0b4"
+version = "1.1.0b5"
 description = "CLI tool to analyze your MCP server and get a comprehensive report on its quality"
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -271,6 +271,127 @@ class TestAuthMetadataProbe:
         assert d["auth_server_has_endpoints"] is True
         assert d["auth_server_pkce_s256"] is False
 
+    async def test_unreachable_authorization_server_preserves_resource_metadata(self):
+        """An unreachable AS is a finding about the AS — it must not void the PRM.
+
+        Regression: the RFC 8414 walk leaves the audited server's origin, so a
+        ConnectError there used to propagate out of the probe and discard the
+        protected-resource metadata already collected, silently skipping six
+        auth rules (and shrinking max_score) for a correctly-configured server.
+        """
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            if request.url.host == "auth.example":
+                raise httpx2.ConnectError("name resolution failed")
+            if request.url.path == "/.well-known/oauth-protected-resource/mcp":
+                return httpx2.Response(
+                    200,
+                    json={
+                        "resource": URL,
+                        "authorization_servers": ["https://auth.example"],
+                        "scopes_supported": ["read"],
+                    },
+                )
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        auth = results[PROBE_AUTH_METADATA]
+        assert auth.outcome is ProbeOutcome.SUPPORTED
+        # Everything established before the failing hop survives.
+        assert auth.details["resource"] == URL
+        assert auth.details["metadata_url"].endswith("/oauth-protected-resource/mcp")
+        assert auth.details["scopes_supported"] == ["read"]
+        # The unreachable issuer is recorded as data, not as a lost observation.
+        assert auth.details["auth_server_issuer"] == "https://auth.example"
+        assert auth.details["auth_server_metadata_present"] is False
+        assert auth.details["auth_server_metadata_error"] == "ConnectError"
+
+    async def test_authorization_server_timeout_is_recorded_not_raised(self):
+        """A merely slow authorization server degrades the same way as an absent one."""
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            if request.url.host == "auth.example":
+                raise httpx2.ReadTimeout("too slow")
+            if request.url.path == "/.well-known/oauth-protected-resource/mcp":
+                return httpx2.Response(200, json={"resource": URL, "authorization_servers": ["https://auth.example"]})
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        auth = results[PROBE_AUTH_METADATA]
+        assert auth.outcome is ProbeOutcome.SUPPORTED
+        assert auth.details["auth_server_metadata_present"] is False
+        assert auth.details["auth_server_metadata_error"] == "ReadTimeout"
+
+    async def test_oidc_fallback_recovers_after_first_candidate_transport_error(self):
+        """A transport error on the RFC 8414 URL still lets the OIDC location answer."""
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            path = request.url.path
+            if request.url.host == "auth.example":
+                if path == "/.well-known/oauth-authorization-server":
+                    raise httpx2.ConnectError("refused")
+                return httpx2.Response(
+                    200,
+                    json={
+                        "issuer": "https://auth.example",
+                        "authorization_endpoint": "https://auth.example/authorize",
+                        "token_endpoint": "https://auth.example/token",
+                        "code_challenge_methods_supported": ["S256"],
+                    },
+                )
+            if path == "/.well-known/oauth-protected-resource/mcp":
+                return httpx2.Response(200, json={"resource": URL, "authorization_servers": ["https://auth.example"]})
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        d = results[PROBE_AUTH_METADATA].details
+        assert d["auth_server_metadata_present"] is True
+        assert d["auth_server_pkce_s256"] is True
+        # A recovered candidate leaves no stale error behind.
+        assert "auth_server_metadata_error" not in d
+
+    async def test_well_known_transport_error_falls_through_to_origin_root(self):
+        """A transport error on the path-aware PRM location must not abort discovery."""
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            if request.url.path == "/.well-known/oauth-protected-resource/mcp":
+                raise httpx2.ConnectError("refused")
+            if request.url.path == "/.well-known/oauth-protected-resource":
+                return httpx2.Response(200, json={"resource": URL})
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        auth = results[PROBE_AUTH_METADATA]
+        assert auth.outcome is ProbeOutcome.SUPPORTED
+        assert auth.details["metadata_url"] == "https://server.example/.well-known/oauth-protected-resource"
+
+    async def test_all_well_known_locations_unreachable_stays_error(self):
+        """Unreachable ≠ "publishes no metadata" — the rules must skip, not fail.
+
+        Only the well-known fetches fail here, so the probe cannot claim the
+        server lacks a PRM document; ERROR keeps the dependent rules on
+        insufficient-data rather than scoring the server down for something
+        that was never observed.
+        """
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method == "GET":
+                raise httpx2.ConnectError("refused")
+            return _modern_server_handler(request)
+
+        results = await _run(handler)
+        auth = results[PROBE_AUTH_METADATA]
+        assert auth.outcome is ProbeOutcome.ERROR
+        assert auth.details["exception"] == "ConnectError"
+
     async def test_invalid_json_is_unsupported(self):
         def handler(request: httpx2.Request) -> httpx2.Response:
             if request.method == "GET":

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -3,6 +3,7 @@
 import json
 
 import httpx2
+import pytest
 
 from mcpscore.probes import (
     ERROR_HEADER_MISMATCH,
@@ -23,6 +24,7 @@ from mcpscore.probes import (
     PROBE_UNKNOWN_VERSION,
     ProbeOutcome,
     ProbeResult,
+    _fetch_auth_server_metadata,
     _well_known_urls,
     not_applicable_results,
     run_all_probes,
@@ -326,6 +328,32 @@ class TestAuthMetadataProbe:
         assert auth.details["auth_server_metadata_present"] is False
         assert auth.details["auth_server_metadata_error"] == "ReadTimeout"
 
+    async def test_reachable_issuer_publishing_nothing_records_no_transport_error(self):
+        """A 404 from the second AS location must clear the first one's transport error.
+
+        ``auth_server_metadata_error`` means "the issuer could not be contacted
+        at all". An issuer that answers one location — even with a 404 — is
+        reachable and simply publishes no usable document there; reporting a
+        stale transport error would misattribute that to an unreachable host.
+        """
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            path = request.url.path
+            if request.url.host == "auth.example":
+                if path == "/.well-known/oauth-authorization-server":
+                    raise httpx2.ConnectError("refused")
+                return httpx2.Response(404)  # reachable, just nothing published
+            if path == "/.well-known/oauth-protected-resource/mcp":
+                return httpx2.Response(200, json={"resource": URL, "authorization_servers": ["https://auth.example"]})
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        d = results[PROBE_AUTH_METADATA].details
+        assert d["auth_server_metadata_present"] is False
+        assert "auth_server_metadata_error" not in d
+
     async def test_oidc_fallback_recovers_after_first_candidate_transport_error(self):
         """A transport error on the RFC 8414 URL still lets the OIDC location answer."""
 
@@ -391,6 +419,66 @@ class TestAuthMetadataProbe:
         auth = results[PROBE_AUTH_METADATA]
         assert auth.outcome is ProbeOutcome.ERROR
         assert auth.details["exception"] == "ConnectError"
+        # An ERROR outcome is the case that most needs diagnostic context, so
+        # the details established before the failure must survive it.
+        assert auth.details["urls_tried"] == _well_known_urls(URL)
+        assert auth.details["unreachable_locations"] == _well_known_urls(URL)
+
+    async def test_partially_unreachable_locations_are_recorded(self):
+        """A firewalled location must stay distinguishable from one that answered 404.
+
+        The mixed case: one well-known location cannot be contacted, another
+        answers but carries no metadata. The outcome is UNSUPPORTED either way,
+        but silently dropping the transport error makes an unreachable location
+        look identical to an absent document.
+        """
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            if request.method != "GET":
+                return _modern_server_handler(request)
+            if request.url.path == "/.well-known/oauth-protected-resource/mcp":
+                raise httpx2.ConnectError("refused")
+            return httpx2.Response(404)
+
+        results = await _run(handler)
+        auth = results[PROBE_AUTH_METADATA]
+        assert auth.outcome is ProbeOutcome.UNSUPPORTED
+        assert auth.details["http_status"] == 404
+        assert auth.details["unreachable_locations"] == [
+            "https://server.example/.well-known/oauth-protected-resource/mcp"
+        ]
+
+    async def test_reachable_locations_record_no_unreachable_list(self):
+        """The diagnostic key is absent entirely when every location answered."""
+        results = await _run(_modern_server_handler)
+        assert "unreachable_locations" not in results[PROBE_AUTH_METADATA].details
+
+    @pytest.mark.parametrize(
+        "issuer",
+        [
+            "https://256.256.256.256",  # invalid IPv4 literal
+            "https://999.999.999.999",
+            "https://::1",  # bare IPv6, unbracketed
+            "http://[::1",  # unterminated bracket
+        ],
+    )
+    async def test_unusable_issuer_url_is_a_finding_not_an_exception(self, issuer: str):
+        """A syntactically plausible but unusable issuer must not void the audit.
+
+        ``authorization_servers`` is server-controlled and only prefix-checked,
+        so these values raise httpx2.InvalidURL — which does NOT derive from
+        HTTPError. Letting it escape would hand a server a way to skip the six
+        auth rules out of its own max_score by advertising a malformed issuer.
+
+        Hermetic: URL parsing fails before any connection is attempted, so the
+        real client here never touches the network.
+        """
+        details: dict[str, object] = {}
+        async with httpx2.AsyncClient(follow_redirects=True) as client:
+            await _fetch_auth_server_metadata(client, issuer, details)
+        assert details["auth_server_issuer"] == issuer
+        assert details["auth_server_metadata_present"] is False
+        assert details["auth_server_metadata_error"] == "InvalidURL"
 
     async def test_invalid_json_is_unsupported(self):
         def handler(request: httpx2.Request) -> httpx2.Response:

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.1.0b4"
+version = "1.1.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes auth scoring inputs and probe outcomes (ERROR vs UNSUPPORTED), which can shift audit scores and rule skips for gated servers; behavior is well-tested but affects security-relevant auth posture rules.
> 
> **Overview**
> **Release 1.1.0b5** documents and ships fixes to OAuth auth-metadata probing so scoring stays fair when discovery hops fail.
> 
> Auth discovery no longer aborts when RFC 8414 or RFC 9728 fetches hit **transport errors** (`HTTPError`, `InvalidURL`). A new `_try_get_json_anonymous` wrapper turns those into probe data instead of exceptions, so **protected-resource metadata already collected is kept** and unreachable issuers are recorded via `auth_server_metadata_error` rather than wiping the probe.
> 
> **Well-known URL walks** continue after a failed location, track `unreachable_locations`, and treat “every location unreachable” as **`ERROR`** (unverified) with preserved `urls_tried`—not **`UNSUPPORTED`**. **`auth_server_metadata_error`** is set only when **no** AS candidate was reachable (a later 404 clears a stale error from an earlier candidate).
> 
> Extensive **`test_probes`** regressions cover unreachable AS, timeouts, OIDC fallback, partial unreachable PRM paths, and malformed issuer URLs. Version bumps in **`pyproject.toml`** / **`uv.lock`** and **`CHANGELOG`** for **1.1.0b5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1544cf04c5e75cd6f6b03b26ce453ee474c2a3f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->