### PR TITLE
Prepare the b6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0b6] - 2026-07-25
+
+### Added
+
+- **`mcpscore --version`.** It prints `mcpscore <version>` and exits 0 without
+  requiring a target, so identifying an installed build no longer means running
+  an audit or reading `--json` output. The greeting banner moved after argument
+  parsing, so `--version` and `--help` are no longer preceded by it — the
+  version line is the only thing written, and scripts can parse it.
+
+### Fixed
+
+- **`auth_challenge_references_metadata` now accepts an unquoted
+  `resource_metadata` value.** RFC 7235 §2.1 defines an auth-param value as
+  `token / quoted-string`, and a URL contains `:` and `/` — delimiters that are
+  not valid `token` characters — so strictly the value must be quoted.
+  Deployed servers send it bare anyway (verified against Stripe's MCP endpoint,
+  2026-07-25) and clients read it without trouble, so failing the rule reported
+  a discovery failure no real client experiences. The parser now reads both
+  forms, ending a bare value at the next comma or whitespace. Two related
+  corrections in the same parser: parameter names are matched
+  case-insensitively (RFC 7235 §2.1), and a name is matched only at a parameter
+  boundary, so `xresource_metadata=` is no longer mistaken for
+  `resource_metadata=`.
+
 ## [1.1.0b5] - 2026-07-25
 
 ### Fixed
@@ -439,7 +464,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b5...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b6...HEAD
+[1.1.0b6]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b5...v1.1.0b6
 [1.1.0b5]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b4...v1.1.0b5
 [1.1.0b4]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b3...v1.1.0b4
 [1.1.0b3]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b2...v1.1.0b3

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -39,6 +39,8 @@ The report's top-level shape: `schema_version`, `mcpscore_version`,
 - The invocation shape — `mcpscore <target>` with `--json`, `--header`,
   `--token` (and the `MCPSCORE_TOKEN` environment variable) — is stable.
   New flags may be added; existing flags keep their meaning.
+- `mcpscore --version` prints `mcpscore <version>` on stdout and exits 0,
+  with no other output and without needing a target. Scripts may parse it.
 - Exit codes are a contract: **0** audit completed (regardless of score);
   **1** the audit was never attempted — a usage error or a failed `--oauth`
   flow (timeout, refusal, registration or token-exchange failure);

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -57,6 +57,15 @@ def build_parser() -> argparse.ArgumentParser:
         "target",
         help="Path to a local MCP server (.py, .js) or URL of a remote server (Streamable HTTP / SSE)",
     )
+    # An "action=version" argument exits during parsing, before argparse
+    # enforces the required `target` — so `mcpscore --version` works on its
+    # own, which is the whole point of asking a tool what version it is.
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_mcpscore_version()}",
+        help="Show the installed mcpscore version and exit",
+    )
     parser.add_argument(
         "--json",
         action="store_true",
@@ -293,9 +302,11 @@ async def async_main() -> None:
     Exits with code 1 on usage errors, or code 2 if connection fails and the
     server shows no modern-lifecycle support either.
     """
-    logger.info("Welcome to MCPScore!")
-
+    # Parse before greeting: --version and --help exit during parsing, and
+    # neither should be preceded by a banner.
     args = build_parser().parse_args()
+
+    logger.info("Welcome to MCPScore!")
 
     try:
         headers = collect_headers(args)

--- a/mcpscore/rules/auth.py
+++ b/mcpscore/rules/auth.py
@@ -16,6 +16,7 @@ authorization server's own RFC 8414 metadata and check it advertises PKCE
 (S256), per the OAuth security BCP (RFC 9700).
 """
 
+import re
 from typing import ClassVar
 from urllib.parse import urlsplit
 
@@ -271,14 +272,29 @@ class AuthMetadataBaseRule(AuthPostureBaseRule):
 
 
 def _parse_www_authenticate_param(header: str, param: str) -> str | None:
-    """Extract a quoted parameter (e.g. resource_metadata="…") from a challenge."""
-    marker = f'{param}="'
-    start = header.find(marker)
-    if start == -1:
+    """Extract an auth-param from a challenge, accepting the quoted and bare forms.
+
+    RFC 7235 §2.1 defines an auth-param value as ``token / quoted-string``, and
+    a URL contains ``:`` and ``/`` — delimiters that are not valid ``token``
+    characters — so strictly it must be quoted. Deployed servers send it bare
+    anyway (Stripe's MCP endpoint, verified 2026-07-25), and clients read it
+    fine, so scoring that as "no resource_metadata parameter" would report a
+    discovery failure no real client experiences.
+
+    The bare value ends at the next comma or whitespace, the auth-param
+    separators. Param names are matched case-insensitively (RFC 7235 §2.1) and
+    only at a parameter boundary, so ``xresource_metadata=`` is not mistaken
+    for ``resource_metadata=``.
+    """
+    pattern = re.compile(
+        rf"(?:^|[\s,]){re.escape(param)}\s*=\s*(?:\"([^\"]*)\"|([^\s,]+))",
+        re.IGNORECASE,
+    )
+    match = pattern.search(header)
+    if match is None:
         return None
-    start += len(marker)
-    end = header.find('"', start)
-    return header[start:end] if end != -1 else None
+    quoted, bare = match.groups()
+    return quoted if quoted is not None else bare
 
 
 @register_rule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.1.0b5"
+version = "1.1.0b6"
 description = "CLI tool to analyze your MCP server and get a comprehensive report on its quality"
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/tests/test_auth_rules.py
+++ b/tests/test_auth_rules.py
@@ -242,6 +242,47 @@ class TestChallengeReferencesMetadata:
         data = _data(_unauth(www_authenticate=None))
         assert AuthChallengeReferencesMetadataRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
 
+    def test_passes_on_unquoted_parameter(self):
+        """Stripe's real header form: a bare, unquoted resource_metadata value.
+
+        RFC 7235 §2.1 wants a quoted-string for a URL value, but deployed
+        servers send it bare and clients read it — scoring that as "no
+        resource_metadata parameter" reports a failure no client experiences.
+        """
+        unauth = _unauth(www_authenticate=f"Bearer resource_metadata={METADATA_URL}")
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is True
+        assert result.details is not None
+        assert result.details["resource_metadata"] == METADATA_URL
+
+    def test_unquoted_value_stops_at_parameter_separator(self):
+        """A bare value ends at the auth-param comma, not at the end of the header."""
+        unauth = _unauth(www_authenticate=f'Bearer resource_metadata={METADATA_URL}, error="invalid_token"')
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is True
+        assert result.details is not None
+        assert result.details["resource_metadata"] == METADATA_URL
+
+    def test_unquoted_cross_origin_is_still_caught(self):
+        """Tolerating the bare form must not weaken the cross-origin check."""
+        unauth = _unauth(www_authenticate="Bearer resource_metadata=https://evil.example/.well-known/x")
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is False
+        assert "not on this server's origin" in result.message
+
+    def test_param_name_is_matched_case_insensitively(self):
+        """RFC 7235 §2.1: auth-param names are case-insensitive."""
+        unauth = _unauth(www_authenticate=f'Bearer Resource_Metadata="{METADATA_URL}"')
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is True
+
+    def test_similarly_named_parameter_is_not_mistaken_for_the_real_one(self):
+        """``xresource_metadata`` is a different parameter and must not match."""
+        unauth = _unauth(www_authenticate='Bearer xresource_metadata="https://evil.example/x"')
+        result = AuthChallengeReferencesMetadataRule().check(_data(unauth, _full_metadata()))
+        assert result.passed is False
+        assert "no resource_metadata parameter" in result.message
+
 
 class TestMetadataHttps:
     def test_passes_for_https(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ This module tests the command-line interface functionality including:
 
 from __future__ import annotations
 
+import contextlib
 from datetime import datetime
 import json
 import logging
@@ -21,9 +22,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mcpscore import MCPAuditor, MCPClient, MCPTransportType
-from mcpscore.cli import async_main, build_parser, build_report, main
+from mcpscore.cli import _mcpscore_version, async_main, build_parser, build_report, main
 
 if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
     from _pytest.logging import LogCaptureFixture
     from _pytest.monkeypatch import MonkeyPatch
 
@@ -233,9 +235,11 @@ class TestAsyncMain:
             await async_main()
 
         assert exc_info.value.code == 1
-        assert "Welcome to MCPScore!" in caplog.text
         assert "Usage error" in caplog.text
         assert "target" in caplog.text
+        # The banner now follows argument parsing, so a usage error is not
+        # preceded by a greeting (same reason --version and --help aren't).
+        assert "Welcome to MCPScore!" not in caplog.text
 
     async def test_async_main_connection_failure(
         self,
@@ -671,6 +675,37 @@ class TestJSONOutput:
 
         assert exc_info.value.code == 1
         assert "Usage error" in caplog.text
+
+
+class TestVersionFlag:
+    """`mcpscore --version` — the first thing anyone runs to identify a build."""
+
+    def test_version_works_without_the_required_target(self, capsys: CaptureFixture[str]) -> None:
+        """--version exits 0 during parsing, before `target` is enforced."""
+        with pytest.raises(SystemExit) as exc_info:
+            build_parser().parse_args(["--version"])
+
+        assert exc_info.value.code == 0
+        assert capsys.readouterr().out.strip() == f"mcpscore {_mcpscore_version()}"
+
+    async def test_version_prints_no_banner(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]) -> None:
+        """Nothing precedes the version on stdout or stderr — it must stay parseable."""
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "--version"])
+        with pytest.raises(SystemExit) as exc_info:
+            await async_main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 0
+        assert captured.out.strip() == f"mcpscore {_mcpscore_version()}"
+        assert "Welcome" not in captured.out + captured.err
+
+    async def test_normal_runs_still_greet(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
+        """Moving the parse ahead of the banner must not drop it from real audits."""
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://example.com/mcp"])
+        with caplog.at_level(logging.INFO), contextlib.suppress(SystemExit):
+            await async_main()
+
+        assert "Welcome to MCPScore!" in caplog.text
 
 
 class TestBuildReport:

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.1.0b5"
+version = "1.1.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CLI output ordering, a documented `--version` flag, and more permissive auth-header parsing with added tests; audit scoring may shift slightly for servers that previously failed on unquoted metadata.
> 
> **Overview**
> Release **1.1.0b6** bundles a CLI ergonomics fix and a scoring fix for real-world OAuth challenges.
> 
> **`mcpscore --version`** prints `mcpscore <version>` on stdout and exits 0 **without** a target. Argument parsing (including `--version` / `--help`) now runs **before** the welcome banner so scripts get clean, parseable output. The stability docs record this as part of the CLI contract.
> 
> **`auth_challenge_references_metadata`** no longer fails when `WWW-Authenticate` carries an **unquoted** `resource_metadata` URL (common in production). `_parse_www_authenticate_param` now accepts quoted and bare values (bare values end at comma/whitespace), matches parameter names **case-insensitively**, and only matches at parameter boundaries so `xresource_metadata` is not confused with `resource_metadata`. Cross-origin checks are unchanged.
> 
> Version metadata is updated in `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77720d58a115e0668b0e1ab9767581d67748b8b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->