### PR TITLE
Add the workflow dispatch to be used in case of the main release pipe…

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,6 +7,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish, e.g. v1.1.0"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -23,6 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Publish the tag's wrapper, never whatever `main` happens to hold.
+          # A dispatch defaults to the ref it was started from, so without this
+          # a recovery run would push main's npm/ to the registry under the
+          # release's version — and npm publishes are immutable.
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
           persist-credentials: false
       # No dependency caching is enabled (the `cache:` input is omitted), so
       # there is no cache to poison; the publish is OIDC + provenance built

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,31 @@ name: Publish
 
 # Triggered by publishing a GitHub Release (not a raw tag push), so the
 # `pypi` environment's protection rules gate the deploy.
+#
+# workflow_dispatch is the recovery path: a GitHub Actions outage (or any
+# transient failure) can leave a published Release whose PyPI upload never
+# ran, and the release event cannot be re-fired without deleting or
+# draft-cycling a release that is already public. Dispatching re-runs the
+# same jobs for an existing tag. The `pypi` environment still gates it, so
+# its protection rules and Trusted Publishing are unchanged.
+#
+#   gh workflow run publish.yml -f tag=v1.2.3
+#
+# Run it from the DEFAULT BRANCH and name the tag as an input — do not pass
+# `--ref <tag>`. GitHub reads the workflow definition from the dispatched
+# ref, so older tags (cut before this trigger existed) have no
+# workflow_dispatch and are rejected outright. The checkout below uses the
+# `tag` input, so building from the default branch still ships the tag's
+# source.
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish, e.g. v1.1.0b6"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -16,6 +38,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Always build from the tag itself. On a release event this is what
+          # the default checkout would pick anyway; on a dispatch it stops a
+          # run started from the wrong ref (or with no --ref at all) from
+          # building `main` and uploading it under the tag's version.
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
@@ -58,4 +85,4 @@ jobs:
         run: gh release upload "$TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}


### PR DESCRIPTION
…line failture (e.g. wehen GitHub Actions tamporarilty fail)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release publishing workflows; mitigations pin checkout to the release tag and keep PyPI environment gating, but mistaken manual runs could still affect registry uploads.
> 
> **Overview**
> Adds a **manual recovery path** when a GitHub Release is live but the automated publish failed (e.g. transient Actions outage), since the `release: published` event cannot be replayed without reworking the release.
> 
> Both **`publish.yml`** (PyPI build/upload + release artifact attach) and **`publish-npm.yml`** now accept **`workflow_dispatch`** with a required **`tag`** input (e.g. `gh workflow run publish.yml -f tag=v1.2.3`). Checkout is pinned to **`github.event.release.tag_name || inputs.tag`** so recovery runs ship **that tag’s source**, not whatever ref the dispatch started from—avoiding uploading **`main`** under the release version (especially important for **immutable npm** publishes).
> 
> Docs in the workflow comments spell out running dispatch from the **default branch** with the tag as input (not `--ref <tag>`), and note that tags cut before this trigger existed won’t have `workflow_dispatch` on the tag ref. npm manual dispatch still runs even for pre-releases (unchanged `if` behavior vs release-triggered skips).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3c43da47ee35dd66b39e98432ee635e7bc2830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->