### PR TITLE
Fix auth-gated connection message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The auth-gated connection messages no longer claim mcpscore cannot audit
+  gated servers.** Both read "MCPScore can only audit publicly accessible
+  servers", which stopped being true in 1.1.0b2 when credential-free partial
+  audits landed — and it is the text a consumer surfaces when it reports the
+  connection failure. They now state the observation only (`The MCP server
+  requires authentication (HTTP 401).`); the actionable hint belongs to the
+  caller, which knows whether it can carry credentials at all.
+
 ## [1.1.0b6] - 2026-07-25
 
 ### Added

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -37,12 +37,13 @@ _REASON_MESSAGES: dict[ConnectionErrorReason, str] = {
     ConnectionErrorReason.INVALID_URL: "Invalid server URL or path.",
     ConnectionErrorReason.UNREACHABLE: "Could not reach the server (connection refused, DNS failure, or host down).",
     ConnectionErrorReason.TIMEOUT: "The server did not respond in time.",
-    ConnectionErrorReason.UNAUTHORIZED: (
-        "The MCP server requires authentication (HTTP 401). MCPScore can only audit publicly accessible servers."
-    ),
-    ConnectionErrorReason.FORBIDDEN: (
-        "The MCP server refused access (HTTP 403). MCPScore can only audit publicly accessible servers."
-    ),
+    # Auth-gated servers are auditable: no session opens, but the caller runs a
+    # partial audit of the observable surface (auth posture, TLS, transport).
+    # These messages state the observation only — the actionable hint belongs to
+    # the caller, which knows whether it can carry credentials at all (the CLI
+    # suggests --token; the web service cannot).
+    ConnectionErrorReason.UNAUTHORIZED: "The MCP server requires authentication (HTTP 401).",
+    ConnectionErrorReason.FORBIDDEN: "The MCP server refused access (HTTP 403).",
     ConnectionErrorReason.HTTP_ERROR: "The server returned an HTTP error during the MCP handshake.",
     ConnectionErrorReason.NOT_MCP: (
         "The endpoint was reachable but did not complete an MCP handshake — it may not be an MCP server."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> User-facing copy only in connection error strings; no connection or audit logic changes.
> 
> **Overview**
> **401/403 connection failure text no longer says MCPScore cannot audit gated servers.** The `UNAUTHORIZED` and `FORBIDDEN` entries in `_REASON_MESSAGES` (`mcp_client.py`) are trimmed to the HTTP observation only (e.g. `The MCP server requires authentication (HTTP 401).`), dropping the outdated “MCPScore can only audit publicly accessible servers” clause that conflicted with credential-free partial audits since 1.1.0b2.
> 
> Inline comments document that actionable hints belong to callers (CLI vs web). **CHANGELOG** records the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439cd2e20aa91eee20c3782515ad5db3988c7533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->