### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,25 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # Every branch, so a branch pushed without an open PR is still checked.
+    # Without this a merged-then-reused branch can reach a release unverified.
+    branches: ['**']
   pull_request:
     branches: [main]
+
+concurrency:
+  # Keyed by event, then head repo, then branch.
+  #   event_name: a push run and its pull_request run must NOT share a group.
+  #     They report onto the same PR, so cancelling one renders as a FAILED
+  #     check and blocks merge even though CI passed.
+  #   head repo: without it a fork PR whose head branch is named `main` (or two
+  #     forks sharing a branch name) collides with an unrelated run.
+  #   branch: consecutive pushes to one branch still supersede each other.
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.head.repo.full_name || github.repository }}-${{
+    github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions: {}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,13 +12,29 @@ on:
       - "mcpscore/spec.py"
       - ".github/workflows/docs.yml"
   push:
-    branches: [main]
+    # Every branch, so a branch pushed without an open PR is still checked.
+    # Without this a merged-then-reused branch can reach a release unverified.
+    branches: ['**']
     paths:
       - "docs/**"
       - "scripts/generate_rules_doc.py"
       - "mcpscore/rules/**"
       - "mcpscore/spec.py"
   workflow_dispatch:
+
+concurrency:
+  # Keyed by event, then head repo, then branch.
+  #   event_name: a push run and its pull_request run must NOT share a group.
+  #     They report onto the same PR, so cancelling one renders as a FAILED
+  #     check and blocks merge even though CI passed.
+  #   head repo: without it a fork PR whose head branch is named `main` (or two
+  #     forks sharing a branch name) collides with an unrelated run.
+  #   branch: consecutive pushes to one branch still supersede each other.
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.head.repo.full_name || github.repository }}-${{
+    github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only changes that broaden verification and fix concurrency; no application or security logic is modified.
> 
> **Overview**
> **CI** and **Docs** GitHub Actions workflows now run on **push to any branch** (`branches: ['**']`) instead of only `main`, so reused or release branches still get checks even without an open PR.
> 
> Both workflows add a **`concurrency`** block: the group includes **workflow**, **event name**, **head repo** (fork-safe), and **branch/ref**, so **push** and **pull_request** runs for the same PR do not cancel each other (avoiding false failed checks). **`cancel-in-progress`** is enabled for non-`main` refs so rapid pushes on feature branches still supersede older runs; **`main`** keeps in-progress runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df1f4d9c29776a9c94a47214448af1e4e185935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->