### PR TITLE
Updated hex values to lowercase

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,9 +4,9 @@
   "name": "mcpscore",
   "description": "Lighthouse for MCP \u2014 audit any MCP server and get a scored, actionable report in seconds.",
   "colors": {
-    "primary": "#0D9373",
-    "light": "#2EBD85",
-    "dark": "#0D9373"
+    "primary": "#0d9373",
+    "light": "#2ebd85",
+    "dark": "#0d9373"
   },
   "favicon": "/favicon.svg",
   "navigation": {

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="7" fill="#0D9373"/>
+  <rect width="32" height="32" rx="7" fill="#0d9373"/>
   <path d="M8 20 a8 8 0 0 1 16 0" fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round"/>
   <line x1="16" y1="20" x2="21" y2="13" stroke="#ffffff" stroke-width="3" stroke-linecap="round"/>
   <circle cx="16" cy="20" r="2.2" fill="#ffffff"/>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic documentation-only color string normalization; no runtime or security impact.
> 
> **Overview**
> **Docs branding colors** are normalized to **lowercase hex** in Mintlify config and the favicon so they match a consistent style.
> 
> In `docs/docs.json`, `primary`, `light`, and `dark` change from values like `#0D9373` / `#2EBD85` to `#0d9373` / `#2ebd85`. `docs/favicon.svg` uses the same lowercase green for the icon background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6487a928eb7c82d32069b605c6ac3c6fdaf7fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->