### PR TITLE
Prepare the final 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,13 +106,15 @@ First stable release. Ships the day the MCP `2026-07-28` revision went final.
 - **Corrected two swapped SEP citations.** `server/discover` is introduced by
   [SEP-2575][sep-2575], not SEP-2567 ("Sessionless MCP via Explicit State
   Handles", which explicitly does not introduce it); the removal of
-  protocol-level sessions and `Mcp-Session-Id` is SEP-2567, not SEP-2575. The
-  `readiness_2026_server_discover` and `readiness_2026_no_session_id` rules
-  reported each other's SEP in their message and `details.sep`.
+  protocol-level sessions and `Mcp-Session-Id` is [SEP-2567][sep-2567], not
+  SEP-2575. The `readiness_2026_server_discover` and
+  `readiness_2026_no_session_id` rules reported each other's SEP in their
+  message and `details.sep`.
 - **`readiness_2026_no_session_id` no longer overstates the requirement.** The
   spec's backward-compatibility section is SHOULD-level ("ignore it, and do not
   mint or echo session IDs"); the message said "must".
 
+[sep-2567]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567
 [sep-2575]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575
 [sep-2577]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,17 @@ First stable release. Ships the day the MCP `2026-07-28` revision went final.
   | yes | listing did not answer | ❌ fail — clients will call it and fail |
 
   Severity stays CRITICAL, because what remains is a genuine MUST violation.
-  The MCP spec's own docs server (`modelcontextprotocol.io/mcp`) goes from
-  failing `capability_prompts_present` to passing it.
+
+  **These rules only judge a listing the auditor actually attempted.** `tools`,
+  `resources` and `prompts` being `None` is ambiguous — the session path lists a
+  feature only when the server declares it, and `audit_modern_only` collects
+  tools alone from the stateless probe. A rule whose listing never ran now
+  skips as `insufficient-data` (see `AuditData.listings_attempted`) instead of
+  reading silence as a failed listing, which had cost a modern server declaring
+  resources and prompts 10 CRITICAL points (verified on a fixture: 103/123
+  before, 103/113 after). The trade-off is stated in the rule docstring:
+  serving a feature without declaring it is only caught when the listing ran
+  for another reason.
 
 - **`listChanged` rules downgraded from HIGH to LOW** and relabelled as
   advisory. 2025-11-25 §Capabilities: *"Both `subscribe` and `listChanged` are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,115 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-28
+
+First stable release. Ships the day the MCP `2026-07-28` revision went final.
+
+### Added
+
+- **`2026-07-28` is now a recognized protocol version** (`MCPProtocolVersion.v2026_07_28`,
+  and `MCPProtocolVersion.Latest` now points at it).
+
+### Changed
+
+- **Pinned to the MCP Python SDK `2.0.0` stable** (from `2.0.0rc1`), published
+  2026-07-28 alongside the spec revision it implements. The SDK's own notes
+  report no API changes between rc1 and stable — the breaking changes all
+  landed earlier in the pre-release cycle, and the two we had already absorbed
+  (`OAuthClientProvider(timeout=…)` removal, `httpx2`) are unaffected.
+
+  Verified: the full gate passes, and DeepWiki scores **82/90 on both pins with
+  byte-identical per-rule results** (all 32 main rules plus all 12 readiness
+  rules compared individually, not just the total). The auth-gated path was
+  re-checked too — Linear still returns a 25/25 partial audit with all 8
+  auth-posture rules scored.
+
+- **The 2026-07-28 revision went final on 2026-07-28 and the spec registry
+  flipped with it**: `2026-07-28` DRAFT → CURRENT, `2025-11-25` CURRENT →
+  SUPERSEDED. Two consequences:
+
+  - **Fixes a CRITICAL false positive.** `allowed_versions()` deliberately
+    excludes draft revisions, so while `2026-07-28` was a draft, a server
+    correctly speaking the new revision failed `protocol_version_allowed`
+    (CRITICAL, −5). Our own modern-lifecycle fixture was failing it.
+  - `protocol_version_latest` (MEDIUM) now expects `2026-07-28`, so servers
+    still negotiating `2025-11-25` are marked as behind — accurate, and the
+    point of the rule, but it moves every legacy server's score by 2.
+
+- **All spec facts re-verified against the dated final URLs** on publication
+  day: changelog and SEP attributions, the Streamable HTTP request-header
+  table (`MCP-Protocol-Version` on every POST; `Mcp-Method` on all requests;
+  `Mcp-Name` on `tools/call`/`resources/read`/`prompts/get`), the error-code
+  allocation policy (`-32020`/`-32021`/`-32022`) and the deprecated-features
+  registry (Roots, Sampling, Logging, DCR, `includeContext`, HTTP+SSE). **No
+  fact changed from the release candidate** — the RC-era entry was correct.
+
+- **The capability-presence rules now check declared-vs-served consistency**
+  instead of demanding every capability. `capability_tools_present`,
+  `capability_prompts_present` and `capability_resources_present` cited "servers
+  that support X MUST declare the X capability" while failing servers that
+  simply do not offer X — penalizing a tools-only server (the median MCP
+  server) 10 CRITICAL points for a legitimate design choice. They now compare
+  the declaration against what the listing actually returns:
+
+  | declared | served | verdict |
+  |---|---|---|
+  | yes | yes (incl. empty) | ✅ pass |
+  | no | no | ✅ pass — the capability is only required of servers that support the feature |
+  | no | yes | ❌ fail — the real spec MUST |
+  | yes | listing did not answer | ❌ fail — clients will call it and fail |
+
+  Severity stays CRITICAL, because what remains is a genuine MUST violation.
+  The MCP spec's own docs server (`modelcontextprotocol.io/mcp`) goes from
+  failing `capability_prompts_present` to passing it.
+
+- **`listChanged` rules downgraded from HIGH to LOW** and relabelled as
+  advisory. 2025-11-25 §Capabilities: *"Both `subscribe` and `listChanged` are
+  optional — servers can support neither, either, or both."* The signal is
+  worth keeping (an agent silently works from a stale list without it) but it
+  is an mcpscore recommendation, and the `basis` now says so rather than citing
+  a spec section that says the opposite.
+
+  Net effect on live servers: DeepWiki 90/101 → 84/90 (89.1% → 93.3%),
+  Context7 88/101 → 86/90 (87.1% → 95.6%), mcp-docs 84/101 → 85/90
+  (83.2% → 94.4%). Rule count is unchanged at 52; `max_score` falls because
+  optional features no longer carry required-level weight.
+
+### Removed
+
+- **Retired `capability_resources_subscribe` (HIGH) and
+  `capability_logging_present` (MEDIUM).** Both scored the *absence* of a
+  capability the spec section they cited calls optional — *"Both `subscribe`
+  and `listChanged` are optional: servers can support neither, either, or
+  both"* (2025-11-25 Resources §Capabilities) — and the 2026-07-28 revision
+  goes further: [SEP-2575][sep-2575] removes `resources/subscribe` in favour of
+  `subscriptions/listen`, and [SEP-2577][sep-2577] deprecates Logging.
+
+  `capability_logging_present` also contradicted `readiness_2026_deprecated_features`,
+  which fails a server for *declaring* `logging`. With readiness promoted into
+  the main score for modern and dual-era servers, **no server could pass both**:
+  every server in the acceptance corpus failed one or the other.
+
+  Scores are unaffected for servers that already passed these rules; every other
+  server gains up to 5 points as `max_score` drops by the same amount. The
+  audit now has **52 rules** (40 main + 12 readiness). Both `rule_id`s are
+  retired permanently and will never be reused.
+
+### Fixed
+
+- **Corrected two swapped SEP citations.** `server/discover` is introduced by
+  [SEP-2575][sep-2575], not SEP-2567 ("Sessionless MCP via Explicit State
+  Handles", which explicitly does not introduce it); the removal of
+  protocol-level sessions and `Mcp-Session-Id` is SEP-2567, not SEP-2575. The
+  `readiness_2026_server_discover` and `readiness_2026_no_session_id` rules
+  reported each other's SEP in their message and `details.sep`.
+- **`readiness_2026_no_session_id` no longer overstates the requirement.** The
+  spec's backward-compatibility section is SHOULD-level ("ignore it, and do not
+  mint or echo session IDs"); the message said "must".
+
+[sep-2575]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575
+[sep-2577]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577
+
 ## [1.1.0rc1] - 2026-07-27
 
 ### Changed
@@ -494,7 +603,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0rc1...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/mcp-box/mcpscore/compare/v1.1.0rc1...v1.1.0
 [1.1.0rc1]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b6...v1.1.0rc1
 [1.1.0b6]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b5...v1.1.0b6
 [1.1.0b5]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b4...v1.1.0b5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,15 @@ First stable release. Ships the day the MCP `2026-07-28` revision went final.
   (83.2% → 94.4%). Rule count is unchanged at 52; `max_score` falls because
   optional features no longer carry required-level weight.
 
+### Changed
+
+- **Coverage floor raised to 97%, and Codecov now has an explicit config.**
+  `fail_under` in `pyproject.toml` and both Codecov statuses (project and
+  patch) are pinned to the same 97%, so the local gate and the PR checks fail
+  together. Codecov previously used its "auto" target — the base commit's
+  coverage — which failed a PR at 98.71% patch against a 98.84% base while the
+  project sat above 99%.
+
 ### Removed
 
 - **Retired `capability_resources_subscribe` (HIGH) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,12 @@ First stable release. Ships the day the MCP `2026-07-28` revision went final.
   skips as `insufficient-data` (see `AuditData.listings_attempted`) instead of
   reading silence as a failed listing, which had cost a modern server declaring
   resources and prompts 10 CRITICAL points (verified on a fixture: 103/123
-  before, 103/113 after). The trade-off is stated in the rule docstring:
-  serving a feature without declaring it is only caught when the listing ran
-  for another reason.
+  before, 103/113 after). On the modern path the attempt is recorded on the
+  server's *answer*, not on a usable one — a server that declares tools and
+  then fails `tools/list` fails the rule rather than skipping it, while an
+  unobservable probe (network error) still skips. The trade-off is stated in
+  the rule docstring: serving a feature without declaring it is only caught
+  when the listing ran for another reason.
 
 - **`listChanged` rules downgraded from HIGH to LOW** and relabelled as
   advisory. 2025-11-25 §Capabilities: *"Both `subscribe` and `listChanged` are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ make format         # Auto-format (ruff)
 make lint           # Lint without fixing
 make typecheck      # Pyright (0 errors required in mcpscore/)
 make test           # Run the test suite
-make testcov        # Tests with coverage report (95% minimum enforced)
+make testcov        # Tests with coverage report (97% minimum enforced)
 make all            # Everything CI runs
 ```
 
@@ -48,7 +48,8 @@ violations are CRITICAL/HIGH, recommendations are MEDIUM/LOW.
 ## Pull request expectations
 
 - Keep PRs focused; separate refactors from behavior changes.
-- New code needs tests — coverage must stay at or above 95%.
+- New code needs tests — coverage must stay at or above 97%, for the project
+  total and for the diff of your PR (Codecov enforces both; see codecov.yml).
 - Public functions and classes carry type hints and docstrings.
 - Update `CHANGELOG.md` under `[Unreleased]`.
 - Formatting is automated (`make format`); style debates are out of scope.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Lighthouse for MCP.** Audit any MCP (Model Context Protocol) server and get a scored, actionable report in seconds.
 
-Point mcpscore at a server — from the CLI, a GitHub Action, or [mcpscore.dev](https://mcpscore.dev) — and it grades protocol conformance, tool quality, security and auth posture, and readiness for the upcoming spec revision, then tells you exactly what to fix. Deterministic, no API key, no sign-up.
+Point mcpscore at a server — from the CLI, a GitHub Action, or [mcpscore.dev](https://mcpscore.dev) — and it grades protocol conformance, tool quality, security and auth posture, and readiness for the 2026-07-28 spec revision, then tells you exactly what to fix. Deterministic, no API key, no sign-up.
 
 ## Why mcpscore?
 
@@ -47,11 +47,11 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-54 rules across four categories — the same four the report, the JSON output, and
+52 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 
-**Protocol** (18 rules) — protocol version (allowed, latest, not deprecated), server
+**Protocol** (16 rules) — protocol version (allowed, latest, not deprecated), server
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
@@ -67,7 +67,7 @@ metadata, the RFC 8414 authorization-server chain, and whether PKCE (S256) is en
 A gated server is scored on this surface without credentials — see
 [auditing authenticated servers](https://docs.mcpscore.dev/authenticated-servers/).
 
-**Readiness** (12 rules) — how ready the server is for the upcoming MCP spec revision,
+**Readiness** (12 rules) — how ready the server is for the 2026-07-28 MCP spec revision,
 reported on its own axis. For servers already speaking the new lifecycle those points
 also count toward the main score; for everyone else the axis stays informative.
 

--- a/README.md
+++ b/README.md
@@ -116,18 +116,16 @@ Transport: stdio
 Starting the audit...
 ✅ Protocol version '2025-11-25' is one of the allowed versions
 ✅ Protocol version '2025-11-25' is not deprecated
-✅ Protocol version '2025-11-25' is the latest version
+❌ Not using the latest protocol version: negotiated '2025-11-25', latest is '2026-07-28'
 ✅ Server name is present: 'weather'
 ✅ Server version is present: '1.17.0'
 ❌ Server title is not present in server info
-✅ Tools capability is present
+✅ Declares the tools capability and serves 3 via tools/list
 ❌ listChanged is not supported by Tools
-✅ Prompts capability is present
+✅ Declares the prompts capability and serves 1 via prompts/list
 ❌ listChanged is not supported by Prompts
-✅ Resources capability is present
+✅ Declares the resources capability and serves 2 via resources/list
 ❌ listChanged is not supported by Resources
-❌ subscribe is not supported by Resources
-❌ Logging is not present in capabilities
 ✅ MCP Server provides at least one tool
 ✅ All Tools have a Name property specified
 ✅ All Tools have a Title property specified

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+# Codecov configuration.
+#
+# Both statuses are pinned to 97%, matching `fail_under` in pyproject.toml, so
+# the local gate (`make all`) and the PR checks agree. Before this file existed
+# both statuses used Codecov's "auto" target — the base commit's coverage —
+# which failed PR #57 at 98.71% patch against a 98.84% base: a single partial
+# branch in a small diff, while the project sat above 99%. A fixed target says
+# what the bar actually is instead of ratcheting it upward silently.
+#
+# The floor is deliberately below where the suite sits (99%+): it is a
+# regression alarm, not the goal. Raise it when the real number has been
+# comfortably above a new floor for a while.
+
+coverage:
+  status:
+    project:
+      default:
+        target: 97%
+        # Tolerate rounding noise between runs; a real drop still trips it.
+        threshold: 0.5%
+    patch:
+      default:
+        target: 97%
+
+comment:
+  layout: "condensed_header, diff, flags, components"
+  require_changes: true

--- a/docs/github-action.mdx
+++ b/docs/github-action.mdx
@@ -28,7 +28,7 @@ regress past**:
   and contributors see the impact of a change without running anything.
 - **Readiness tracking for the next spec.** The action reports the separate
   [readiness score](/methodology#the-readiness-score-separate-informative) for the
-  upcoming MCP revision, so you know where you stand well before it lands.
+  2026-07-28 MCP revision, so you know where you stand as clients adopt it.
 - **Deterministic and fast.** No API keys, no LLM calls — the same server state
   always produces the same result, in seconds.
 
@@ -112,7 +112,7 @@ checks and are not comparable to full-audit scores — calibrate `min-score`
 against whichever kind of audit the workflow actually runs.
 </Note>
 
-### Also require readiness for the upcoming spec
+### Also require readiness for the 2026-07-28 spec
 
 ```yaml
 - uses: mcp-box/mcpscore-action@v1

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -82,7 +82,7 @@ version as a *property of your server that it detects*, not a mode of the tool:
 ## The readiness score (separate, informative)
 
 Ahead of a new spec revision, mcpscore answers a second question: **"is this server
-ready for the upcoming spec?"** This is deliberately a *separate* score
+ready for the 2026-07-28 spec?"** This is deliberately a *separate* score
 (`readiness.score / readiness.max_score` in the report), never mixed into the main
 score — a fully compliant 2025-11-25 server keeps its clean main score, and readiness
 is guidance, not punishment.
@@ -125,9 +125,12 @@ Two things worth knowing about how these run:
   scored a given audit.
 
 <Note>
-**Draft-spec citations** — the 2026-07-28 revision is final-pending (release candidate
-locked 2026-05-21). All citations above will be re-verified against the dated spec
-URLs when the revision is published, before the corresponding mcpscore release.
+**Citations re-verified 2026-07-28** — the 2026-07-28 revision was published final
+that day, and every citation above was re-checked against the dated spec URLs
+(`/specification/2026-07-28/`): the changelog, the transport header table, the
+error-code allocation and the deprecated-features registry all matched the release
+candidate, so no rule changed. The re-check is mechanical and repeats whenever a
+revision goes final — error codes were renumbered once already, after the RC lock.
 </Note>
 
 ## What mcpscore deliberately does not test

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -79,31 +79,33 @@ version as a *property of your server that it detects*, not a mode of the tool:
   server answers stateless requests, mcpscore audits it through its probe layer
   instead of reporting a connection failure.
 
-## The readiness score (separate, informative)
+## The readiness score (separate axis)
 
-Ahead of a new spec revision, mcpscore answers a second question: **"is this server
-ready for the 2026-07-28 spec?"** This is deliberately a *separate* score
-(`readiness.score / readiness.max_score` in the report), never mixed into the main
-score — a fully compliant 2025-11-25 server keeps its clean main score, and readiness
-is guidance, not punishment.
+mcpscore answers a second question: **"is this server ready for the 2026-07-28
+spec?"** Results always appear as their own axis
+(`readiness.score / readiness.max_score` in the report). For legacy-only servers
+that axis stays informative — guidance, not punishment — so a fully compliant
+2025-11-25 server keeps a clean main score. For servers already on the modern
+lifecycle, readiness points are also counted in the main score (see Promotion
+below).
 
 Readiness rules for the **2026-07-28** revision, each anchored to normative spec
 language (MUST/MUST NOT unless noted):
 
 | Rule | Severity | Normative basis |
 |---|---|---|
-| `readiness_2026_server_discover` | CRITICAL | Servers MUST implement `server/discover` ([SEP-2567](https://modelcontextprotocol.io/specification/draft/server/discover)) |
-| `readiness_2026_stateless_request` | CRITICAL | Requests carry their context in `_meta`; the `initialize` handshake is removed ([SEP-2575](https://modelcontextprotocol.io/specification/draft/basic/index)) |
+| `readiness_2026_server_discover` | CRITICAL | Servers MUST implement `server/discover` ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) |
+| `readiness_2026_stateless_request` | CRITICAL | Requests carry their context in `_meta`; the `initialize` handshake is removed ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) |
 | `readiness_2026_meta_validation` | HIGH | Requests missing required `_meta` fields MUST be rejected with `-32602` + HTTP 400 |
-| `readiness_2026_header_validation` | HIGH | Header/body mismatches MUST be rejected with `-32020` (HeaderMismatch) + HTTP 400 ([SEP-2243](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http)) |
-| `readiness_2026_cache_metadata` | HIGH | List/discover results MUST carry `ttlMs >= 0` and `cacheScope` ([SEP-2549](https://modelcontextprotocol.io/specification/draft/server/utilities/caching)) |
+| `readiness_2026_header_validation` | HIGH | Header/body mismatches MUST be rejected with `-32020` (HeaderMismatch) + HTTP 400 ([SEP-2243](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http)) |
+| `readiness_2026_cache_metadata` | HIGH | List/discover results MUST carry `ttlMs >= 0` and `cacheScope` ([SEP-2549](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching)) |
 | `readiness_2026_unsupported_version_error` | MEDIUM | Unknown protocol versions MUST be rejected with `-32022` naming the supported versions |
-| `readiness_2026_error_code_migration` | MEDIUM | Missing resources yield `-32602`; the legacy `-32002` MUST NOT be emitted ([SEP-2164](https://modelcontextprotocol.io/specification/draft/changelog)) |
-| `readiness_2026_result_type` | MEDIUM | All results carry the `resultType` discriminator ([SEP-2322](https://modelcontextprotocol.io/specification/draft/basic/patterns/mrtr)) |
-| `readiness_2026_deprecated_features` | MEDIUM | Features deprecated in 2026-07-28 (logging; SHOULD NOT adopt) ([SEP-2577](https://modelcontextprotocol.io/specification/draft/deprecated)) |
-| `readiness_2026_tool_schema_dialect` | LOW | Tool schemas valid under the default JSON Schema 2020-12 dialect; no network-URI `$ref` ([SEP-2106](https://modelcontextprotocol.io/specification/draft/basic/index)) |
-| `readiness_2026_no_session_id` | HIGH | No `Mcp-Session-Id` minted or echoed on modern requests — leaked legacy session bookkeeping |
-| `readiness_2026_removed_methods` | MEDIUM | Removed methods (e.g. `ping`) rejected with 404 + `-32601`, not served — leaked legacy surface |
+| `readiness_2026_error_code_migration` | MEDIUM | Missing resources yield `-32602`; the legacy `-32002` MUST NOT be emitted ([SEP-2164](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) |
+| `readiness_2026_result_type` | MEDIUM | All results carry the `resultType` discriminator ([SEP-2322](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr)) |
+| `readiness_2026_deprecated_features` | MEDIUM | Features deprecated in 2026-07-28 (logging; SHOULD NOT adopt) ([SEP-2577](https://modelcontextprotocol.io/specification/2026-07-28/deprecated)) |
+| `readiness_2026_tool_schema_dialect` | LOW | Tool schemas valid under the default JSON Schema 2020-12 dialect; no network-URI `$ref` ([SEP-2106](https://modelcontextprotocol.io/specification/2026-07-28/basic/index)) |
+| `readiness_2026_no_session_id` | HIGH | No `Mcp-Session-Id` minted or echoed on modern requests — leaked legacy session bookkeeping ([SEP-2567](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) |
+| `readiness_2026_removed_methods` | MEDIUM | Removed methods (e.g. `ping`) rejected with 404 + `-32601`, not served — leaked legacy surface ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) |
 
 Two things worth knowing about how these run:
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -36,14 +36,12 @@ Every rule mcpscore runs, generated from the rule registry
 
 | Rule ID | Name | Severity | Weight | Applies to |
 |---|---|---|---|---|
-| `capability_tools_present` | Capabilities - Tools Present | CRITICAL | 5 | all versions |
-| `capability_tools_list_changed` | Capabilities - Tools listChanged Implemented | HIGH | 3 | all versions |
-| `capability_prompts_present` | Capabilities - Prompts Present | CRITICAL | 5 | all versions |
-| `capability_prompts_list_changed` | Capabilities - Prompts listChanged Implemented | HIGH | 3 | all versions |
-| `capability_resources_present` | Capabilities - Resources Present | CRITICAL | 5 | all versions |
-| `capability_resources_list_changed` | Capabilities - Resources listChanged Implemented | HIGH | 3 | all versions |
-| `capability_resources_subscribe` | Capabilities - Resources subscribe Implemented | HIGH | 3 | all versions |
-| `capability_logging_present` | Capabilities - Logging Present | MEDIUM | 2 | all versions |
+| `capability_tools_present` | Capabilities - Tools Declared Consistently | CRITICAL | 5 | all versions |
+| `capability_tools_list_changed` | Capabilities - Tools listChanged Implemented | LOW | 1 | all versions |
+| `capability_prompts_present` | Capabilities - Prompts Declared Consistently | CRITICAL | 5 | all versions |
+| `capability_prompts_list_changed` | Capabilities - Prompts listChanged Implemented | LOW | 1 | all versions |
+| `capability_resources_present` | Capabilities - Resources Declared Consistently | CRITICAL | 5 | all versions |
+| `capability_resources_list_changed` | Capabilities - Resources listChanged Implemented | LOW | 1 | all versions |
 
 ## Security
 

--- a/mcpscore/enums.py
+++ b/mcpscore/enums.py
@@ -75,9 +75,12 @@ class MCPProtocolVersion(StrEnum):
     """MCP protocol version from June 18, 2025."""
 
     v2025_11_25 = "2025-11-25"
-    """Latest MCP protocol version (November 25, 2025)."""
+    """MCP protocol version from November 25, 2025 — the last stateful revision."""
 
-    Latest = v2025_11_25
+    v2026_07_28 = "2026-07-28"
+    """Latest MCP protocol version (July 28, 2026): the stateless revision."""
+
+    Latest = v2026_07_28
     """Alias for the latest protocol version.
 
     This is an enum alias, not a distinct member: it does not appear in

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -14,6 +14,7 @@ from .mcp_client import MCPClient
 from .probes import (
     PROBE_DISCOVER,
     PROBE_STATELESS_LIST,
+    ProbeOutcome,
     detect_era,
     has_modern_support,
     not_applicable_results,
@@ -266,16 +267,22 @@ class MCPAuditor:
             self.audit_data.protocol_version = (DRAFT or LATEST).version
 
         stateless = probes.get(PROBE_STATELESS_LIST)
-        if stateless is not None and stateless.payload is not None:
-            raw_tools = stateless.payload.get("tools")
-            if isinstance(raw_tools, list):
-                # The probe *is* the tools listing on this path; resources and
-                # prompts are never listed, so their rules stay unjudgeable.
+        if stateless is not None:
+            # The probe *is* the tools listing on this path (resources and
+            # prompts are never listed, so their rules stay unjudgeable). The
+            # attempt is recorded on the server's answer, not on a usable one:
+            # a server that declares tools and then does not answer tools/list
+            # must fail the consistency rule, not skip it. ERROR/NOT_APPLICABLE
+            # mean we could not observe — those still skip.
+            if stateless.outcome in (ProbeOutcome.SUPPORTED, ProbeOutcome.UNSUPPORTED):
                 self.audit_data.listings_attempted |= {"tools"}
-                try:
-                    self.audit_data.tools = [Tool.model_validate(tool) for tool in raw_tools]
-                except ValidationError as e:
-                    logger.info("Could not parse tools from the stateless probe payload: %s", e)
+            if stateless.payload is not None:
+                raw_tools = stateless.payload.get("tools")
+                if isinstance(raw_tools, list):
+                    try:
+                        self.audit_data.tools = [Tool.model_validate(tool) for tool in raw_tools]
+                    except ValidationError as e:
+                        logger.info("Could not parse tools from the stateless probe payload: %s", e)
 
     @staticmethod
     def _parse_payload_model(model: type, value: object):

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -269,6 +269,9 @@ class MCPAuditor:
         if stateless is not None and stateless.payload is not None:
             raw_tools = stateless.payload.get("tools")
             if isinstance(raw_tools, list):
+                # The probe *is* the tools listing on this path; resources and
+                # prompts are never listed, so their rules stay unjudgeable.
+                self.audit_data.listings_attempted |= {"tools"}
                 try:
                     self.audit_data.tools = [Tool.model_validate(tool) for tool in raw_tools]
                 except ValidationError as e:
@@ -499,6 +502,7 @@ class MCPAuditor:
             logger.error("No MCP client to audit")
             return
 
+        self.audit_data.listings_attempted |= {"tools"}
         tools: list[Tool] | None = await self.mcp_client.list_tools()
         if tools is None:
             logger.error("No Tools to audit")
@@ -518,6 +522,7 @@ class MCPAuditor:
             logger.error("No MCP client to audit")
             return
 
+        self.audit_data.listings_attempted |= {"resources"}
         resources: list[Resource] | None = await self.mcp_client.list_resources()
         if resources is None:
             logger.error("No Resources to audit")
@@ -537,6 +542,7 @@ class MCPAuditor:
             logger.error("No MCP client to audit")
             return
 
+        self.audit_data.listings_attempted |= {"prompts"}
         prompts: list[Prompt] | None = await self.mcp_client.list_prompts()
         if prompts is None:
             logger.error("No prompts to audit")

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -290,7 +290,7 @@ def _base_details(response: _ProbeResponse) -> dict[str, Any]:
 
 
 async def _probe_discover(client: httpx2.AsyncClient, url: str) -> ProbeResult:
-    """``server/discover`` — mandatory for modern servers (SEP-2567).
+    """``server/discover`` — mandatory for modern servers (SEP-2575).
 
     SUPPORTED when the server returns a DiscoverResult carrying
     ``supportedVersions``; the details also record the caching hints so the

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -31,12 +31,10 @@ from .base import (
     SkippedRule,
 )
 from .capabilities import (
-    CapabilityLoggingPresentRule,
     CapabilityPromptsListChangedRule,
     CapabilityPromptsPresentRule,
     CapabilityResourcesListChangedRule,
     CapabilityResourcesPresentRule,
-    CapabilityResourcesSubscribeRule,
     CapabilityToolsListChangedRule,
     CapabilityToolsPresentRule,
 )
@@ -109,12 +107,10 @@ __all__ = (
     "AuthWwwAuthenticateRule",
     "BaseRule",
     "CacheMetadataReadinessRule",
-    "CapabilityLoggingPresentRule",
     "CapabilityPromptsListChangedRule",
     "CapabilityPromptsPresentRule",
     "CapabilityResourcesListChangedRule",
     "CapabilityResourcesPresentRule",
-    "CapabilityResourcesSubscribeRule",
     "CapabilityToolsListChangedRule",
     "CapabilityToolsPresentRule",
     "DeprecatedFeaturesReadinessRule",

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -137,6 +137,14 @@ class AuditData:
     partial: bool = False
     partial_reason: str | None = None
 
+    # Which listings ("tools", "resources", "prompts") the auditor actually
+    # attempted. `tools=None` is ambiguous on its own — the listing may have
+    # failed, or may never have been tried (the session path only lists a
+    # feature the server declares; the modern-only probe path collects tools
+    # alone). Rules that judge declared-vs-served must skip what was never
+    # attempted instead of reading silence as failure.
+    listings_attempted: frozenset[str] = frozenset()
+
 
 # Decorators to specify what data a rule needs
 def requires_protocol_version(func: Callable) -> Callable:

--- a/mcpscore/rules/capabilities.py
+++ b/mcpscore/rules/capabilities.py
@@ -193,7 +193,7 @@ class CapabilityToolsListChangedRule(CapabilityBaseRule):
         return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """High check: Verify that capabilities.tools has listChanged implemented.
+        """Advisory check: verify that capabilities.tools declares listChanged.
 
         Args:
             capabilities: Server capabilities to check
@@ -262,7 +262,7 @@ class CapabilityPromptsListChangedRule(CapabilityBaseRule):
         return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """High check: Verify that capabilities.prompts has listChanged implemented.
+        """Advisory check: verify that capabilities.prompts declares listChanged.
 
         Args:
             capabilities: Server capabilities to check
@@ -331,7 +331,7 @@ class CapabilityResourcesListChangedRule(CapabilityBaseRule):
         return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """High check: Verify that capabilities.resources has listChanged implemented.
+        """Advisory check: verify that capabilities.resources declares listChanged.
 
         Args:
             capabilities: Server capabilities to check

--- a/mcpscore/rules/capabilities.py
+++ b/mcpscore/rules/capabilities.py
@@ -1,9 +1,25 @@
+"""Rules over the server's declared capabilities.
+
+Two kinds of rule live here, and the distinction is deliberate:
+
+- **Consistency rules** (CRITICAL) enforce a real spec MUST — "servers that
+  support tools/resources/prompts MUST declare the corresponding capability".
+  They compare what the server *declares* against what it actually *serves*,
+  so a server that legitimately offers no resources is not penalized for the
+  capability being absent; only a mismatch fails.
+- **Advisory rules** (LOW) cover `listChanged`, which the spec calls optional
+  ("servers can support neither, either, or both"). They are mcpscore quality
+  opinions — an agent holding a stale tool list is a real UX problem — and
+  their severity says so rather than dressing a recommendation as a
+  requirement.
+"""
+
 from abc import abstractmethod
 
 from mcp_types import ServerCapabilities
 from pydantic import BaseModel
 
-from .base import BaseRule, RuleResult, RuleSeverity, requires_capabilities
+from .base import BaseRule, RuleResult, RuleSeverity, requires_capabilities, requires_fields
 from .registry import register_rule
 
 
@@ -71,54 +87,101 @@ class CapabilityBaseRule(BaseRule):
         ...
 
 
-@register_rule
-class CapabilityToolsPresentRule(CapabilityBaseRule):
-    """Critical check: Verify that capabilities.tools is present."""
+class CapabilityDeclarationRule(BaseRule):
+    """Base class for the declared-vs-served consistency rules.
 
-    rule_id = "capability_tools_present"
-    basis = "MCP 2025-11-25 Tools §Capabilities (servers supporting tools MUST declare the capability)"
-    rule_order = 1
+    The spec requires the *declaration* of a feature the server supports, never
+    the feature itself: "Servers that support resources MUST declare the
+    resources capability". So the failure conditions are a mismatch in either
+    direction — serving items without declaring, or declaring while the listing
+    does not answer — and a server that neither declares nor serves the feature
+    passes, because that is a legitimate design choice (most MCP servers are
+    tools-only).
+    """
 
-    @property
-    def rule_name(self) -> str:
-        return "Capabilities - Tools Present"
+    group_name = "capabilities"
+    group_order = 3
+
+    feature: str = ""
+    """Capability attribute name on ServerCapabilities (e.g. "resources")."""
+
+    method: str = ""
+    """The listing method this feature is served over (e.g. "resources/list")."""
 
     @property
     def severity(self) -> RuleSeverity:
         return RuleSeverity.CRITICAL
 
-    def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """Critical check: Verify that capabilities.tools is present.
+    def _evaluate(self, capabilities: ServerCapabilities | None, items: list | None) -> RuleResult:
+        """Compare the declared capability against what the server served."""
+        declared = getattr(capabilities, self.feature, None) is not None if capabilities is not None else False
+        served = items is not None
 
-        Args:
-            capabilities: Server capabilities to check
-
-        Returns:
-            RuleResult with the check outcome
-
-        """
-        if not hasattr(capabilities, "tools") or not capabilities.tools:
-            passed = False
-            message = "❌ Tools is not present in capabilities"
-        else:
+        if declared and served:
             passed = True
-            message = "✅ Tools capability is present"
+            message = f"✅ Declares the {self.feature} capability and serves {len(items or [])} via {self.method}"
+        elif not declared and not served:
+            passed = True
+            message = (
+                f"✅ Server offers no {self.feature} and declares none — "
+                f"the {self.feature} capability is only required of servers that support it"
+            )
+        elif served and not declared:
+            passed = False
+            message = (
+                f"❌ Server serves {len(items or [])} {self.feature} but does not declare the "
+                f"{self.feature} capability — servers that support {self.feature} MUST declare it"
+            )
+        else:
+            passed = False
+            message = (
+                f"❌ Server declares the {self.feature} capability but {self.method} did not answer — "
+                "clients will call it and fail"
+            )
 
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"capability_tools": _wire_str(getattr(capabilities, "tools", None))},
+            details={
+                f"capability_{self.feature}": _wire_str(getattr(capabilities, self.feature, None)),
+                "declared": declared,
+                "served": served,
+            },
         )
 
 
 @register_rule
+class CapabilityToolsPresentRule(CapabilityDeclarationRule):
+    """Critical check: the declared tools capability matches what the server serves."""
+
+    rule_id = "capability_tools_present"
+    basis = "MCP 2025-11-25 Tools §Capabilities (servers supporting tools MUST declare the capability)"
+    rule_order = 1
+    feature = "tools"
+    method = "tools/list"
+
+    @property
+    def rule_name(self) -> str:
+        return "Capabilities - Tools Declared Consistently"
+
+    @requires_fields("capabilities", "tools")
+    def check(self, capabilities: ServerCapabilities | None, items: list | None) -> RuleResult:  # type: ignore[override]
+        """Compare the declared tools capability against the served tools."""
+        return self._evaluate(capabilities, items)
+
+
+@register_rule
 class CapabilityToolsListChangedRule(CapabilityBaseRule):
-    """High check: Verify that capabilities.tools has listChanged implemented."""
+    """Advisory: the tools capability declares listChanged so clients can refresh a stale list.
+
+    Optional per the spec — an mcpscore quality opinion, scored LOW: without
+    it an agent caches the tools list and silently works from a stale copy.
+    """
 
     rule_id = "capability_tools_list_changed"
-    basis = "MCP 2025-11-25 Tools §Capabilities (listChanged)"
+    basis = "mcpscore recommendation; MCP 2025-11-25 Tools §Capabilities defines listChanged as optional"
     rule_order = 2
 
     @property
@@ -127,7 +190,7 @@ class CapabilityToolsListChangedRule(CapabilityBaseRule):
 
     @property
     def severity(self) -> RuleSeverity:
-        return RuleSeverity.HIGH
+        return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
         """High check: Verify that capabilities.tools has listChanged implemented.
@@ -159,53 +222,35 @@ class CapabilityToolsListChangedRule(CapabilityBaseRule):
 
 
 @register_rule
-class CapabilityPromptsPresentRule(CapabilityBaseRule):
-    """Critical check: Verify that capabilities.prompts is present."""
+class CapabilityPromptsPresentRule(CapabilityDeclarationRule):
+    """Critical check: the declared prompts capability matches what the server serves."""
 
     rule_id = "capability_prompts_present"
     basis = "MCP 2025-11-25 Prompts §Capabilities (servers supporting prompts MUST declare the capability)"
     rule_order = 3
+    feature = "prompts"
+    method = "prompts/list"
 
     @property
     def rule_name(self) -> str:
-        return "Capabilities - Prompts Present"
+        return "Capabilities - Prompts Declared Consistently"
 
-    @property
-    def severity(self) -> RuleSeverity:
-        return RuleSeverity.CRITICAL
-
-    def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """Critical check: Verify that capabilities.prompts is present.
-
-        Args:
-            capabilities: Server capabilities to check
-
-        Returns:
-            RuleResult with the check outcome
-
-        """
-        if not hasattr(capabilities, "prompts") or not capabilities.prompts:
-            passed = False
-            message = "❌ Prompts is not present in capabilities"
-        else:
-            passed = True
-            message = "✅ Prompts capability is present"
-
-        return RuleResult(
-            rule_name=self.rule_name,
-            severity=self.severity,
-            passed=passed,
-            message=message,
-            details={"capability_prompts": _wire_str(getattr(capabilities, "prompts", None))},
-        )
+    @requires_fields("capabilities", "prompts")
+    def check(self, capabilities: ServerCapabilities | None, items: list | None) -> RuleResult:  # type: ignore[override]
+        """Compare the declared prompts capability against the served prompts."""
+        return self._evaluate(capabilities, items)
 
 
 @register_rule
 class CapabilityPromptsListChangedRule(CapabilityBaseRule):
-    """High check: Verify that capabilities.prompts has listChanged implemented."""
+    """Advisory: the prompts capability declares listChanged so clients can refresh a stale list.
+
+    Optional per the spec — an mcpscore quality opinion, scored LOW: without
+    it an agent caches the prompts list and silently works from a stale copy.
+    """
 
     rule_id = "capability_prompts_list_changed"
-    basis = "MCP 2025-11-25 Prompts §Capabilities (listChanged)"
+    basis = "mcpscore recommendation; MCP 2025-11-25 Prompts §Capabilities defines listChanged as optional"
     rule_order = 4
 
     @property
@@ -214,7 +259,7 @@ class CapabilityPromptsListChangedRule(CapabilityBaseRule):
 
     @property
     def severity(self) -> RuleSeverity:
-        return RuleSeverity.HIGH
+        return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
         """High check: Verify that capabilities.prompts has listChanged implemented.
@@ -246,53 +291,35 @@ class CapabilityPromptsListChangedRule(CapabilityBaseRule):
 
 
 @register_rule
-class CapabilityResourcesPresentRule(CapabilityBaseRule):
-    """Critical check: Verify that capabilities.resources is present."""
+class CapabilityResourcesPresentRule(CapabilityDeclarationRule):
+    """Critical check: the declared resources capability matches what the server serves."""
 
     rule_id = "capability_resources_present"
     basis = "MCP 2025-11-25 Resources §Capabilities (servers supporting resources MUST declare the capability)"
     rule_order = 5
+    feature = "resources"
+    method = "resources/list"
 
     @property
     def rule_name(self) -> str:
-        return "Capabilities - Resources Present"
+        return "Capabilities - Resources Declared Consistently"
 
-    @property
-    def severity(self) -> RuleSeverity:
-        return RuleSeverity.CRITICAL
-
-    def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """Critical check: Verify that capabilities.resources is present.
-
-        Args:
-            capabilities: Server capabilities to check
-
-        Returns:
-            RuleResult with the check outcome
-
-        """
-        if not hasattr(capabilities, "resources") or not capabilities.resources:
-            passed = False
-            message = "❌ Resources is not present in capabilities"
-        else:
-            passed = True
-            message = "✅ Resources capability is present"
-
-        return RuleResult(
-            rule_name=self.rule_name,
-            severity=self.severity,
-            passed=passed,
-            message=message,
-            details={"capability_resources": _wire_str(getattr(capabilities, "resources", None))},
-        )
+    @requires_fields("capabilities", "resources")
+    def check(self, capabilities: ServerCapabilities | None, items: list | None) -> RuleResult:  # type: ignore[override]
+        """Compare the declared resources capability against the served resources."""
+        return self._evaluate(capabilities, items)
 
 
 @register_rule
 class CapabilityResourcesListChangedRule(CapabilityBaseRule):
-    """High check: Verify that capabilities.resources has listChanged implemented."""
+    """Advisory: the resources capability declares listChanged so clients can refresh a stale list.
+
+    Optional per the spec — an mcpscore quality opinion, scored LOW: without
+    it an agent caches the resources list and silently works from a stale copy.
+    """
 
     rule_id = "capability_resources_list_changed"
-    basis = "MCP 2025-11-25 Resources §Capabilities (listChanged)"
+    basis = "mcpscore recommendation; MCP 2025-11-25 Resources §Capabilities defines listChanged as optional"
     rule_order = 6
 
     @property
@@ -301,7 +328,7 @@ class CapabilityResourcesListChangedRule(CapabilityBaseRule):
 
     @property
     def severity(self) -> RuleSeverity:
-        return RuleSeverity.HIGH
+        return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
         """High check: Verify that capabilities.resources has listChanged implemented.
@@ -332,88 +359,19 @@ class CapabilityResourcesListChangedRule(CapabilityBaseRule):
         )
 
 
-@register_rule
-class CapabilityResourcesSubscribeRule(CapabilityBaseRule):
-    """High check: Verify that capabilities.resources has subscribe implemented."""
-
-    rule_id = "capability_resources_subscribe"
-    basis = "MCP 2025-11-25 Resources §Capabilities (subscribe)"
-    rule_order = 7
-
-    @property
-    def rule_name(self) -> str:
-        return "Capabilities - Resources subscribe Implemented"
-
-    @property
-    def severity(self) -> RuleSeverity:
-        return RuleSeverity.HIGH
-
-    def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """High check: Verify that capabilities.resources has subscribe implemented.
-
-        Args:
-            capabilities: Server capabilities to check
-
-        Returns:
-            RuleResult with the check outcome
-
-        """
-        if not hasattr(capabilities, "resources") or not capabilities.resources:
-            passed = False
-            message = "❌ Resources is not present in capabilities"
-        elif not capabilities.resources.subscribe:
-            passed = False
-            message = "❌ subscribe is not supported by Resources"
-        else:
-            passed = True
-            message = f"✅ Resources support subscribe: '{_wire_str(capabilities.resources)}'"
-
-        return RuleResult(
-            rule_name=self.rule_name,
-            severity=self.severity,
-            passed=passed,
-            message=message,
-            details={"capability_resources": _wire_str(getattr(capabilities, "resources", None))},
-        )
-
-
-@register_rule
-class CapabilityLoggingPresentRule(CapabilityBaseRule):
-    """Medium check: Verify that capabilities.logging is present."""
-
-    rule_id = "capability_logging_present"
-    basis = "MCP 2025-11-25 Lifecycle §Capability Negotiation (logging)"
-    rule_order = 8
-
-    @property
-    def rule_name(self) -> str:
-        return "Capabilities - Logging Present"
-
-    @property
-    def severity(self) -> RuleSeverity:
-        return RuleSeverity.MEDIUM
-
-    def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
-        """Medium check: Verify that capabilities.logging is present.
-
-        Args:
-            capabilities: Server capabilities to check
-
-        Returns:
-            RuleResult with the check outcome
-
-        """
-        if not hasattr(capabilities, "logging") or not capabilities.logging:
-            passed = False
-            message = "❌ Logging is not present in capabilities"
-        else:
-            passed = True
-            message = f"✅ Logging capability is present: '{_wire_str(capabilities.logging)}'"
-
-        return RuleResult(
-            rule_name=self.rule_name,
-            severity=self.severity,
-            passed=passed,
-            message=message,
-            details={"capability_logging": _wire_str(getattr(capabilities, "logging", None))},
-        )
+# Retired in 1.1.0 — `capability_resources_subscribe` (HIGH) and
+# `capability_logging_present` (MEDIUM). Both scored the *absence* of a
+# capability the spec section they cited calls optional:
+#
+#   "Both `subscribe` and `listChanged` are optional — servers can support
+#    neither, either, or both." (2025-11-25 Resources §Capabilities)
+#
+# and the 2026-07-28 revision goes further: SEP-2575 removes
+# `resources/subscribe`/`unsubscribe` in favour of `subscriptions/listen`, and
+# SEP-2577 deprecates Logging with the guidance that new implementations should
+# not adopt it. `capability_logging_present` also directly contradicted
+# `readiness_2026_deprecated_features`, which fails a server for *declaring*
+# `logging` — with readiness promoted into the main score for modern/dual-era
+# servers, no server could pass both.
+#
+# Their rule_ids are retired, never reused (rule_id is a public contract).

--- a/mcpscore/rules/capabilities.py
+++ b/mcpscore/rules/capabilities.py
@@ -19,7 +19,15 @@ from abc import abstractmethod
 from mcp_types import ServerCapabilities
 from pydantic import BaseModel
 
-from .base import BaseRule, RuleResult, RuleSeverity, requires_capabilities, requires_fields
+from .base import (
+    SKIP_REASON_INSUFFICIENT_DATA,
+    AuditData,
+    BaseRule,
+    RuleResult,
+    RuleSeverity,
+    requires_capabilities,
+    requires_fields,
+)
 from .registry import register_rule
 
 
@@ -92,11 +100,19 @@ class CapabilityDeclarationRule(BaseRule):
 
     The spec requires the *declaration* of a feature the server supports, never
     the feature itself: "Servers that support resources MUST declare the
-    resources capability". So the failure conditions are a mismatch in either
-    direction — serving items without declaring, or declaring while the listing
-    does not answer — and a server that neither declares nor serves the feature
-    passes, because that is a legitimate design choice (most MCP servers are
-    tools-only).
+    resources capability". A server that neither declares nor serves the
+    feature passes, because that is a legitimate design choice (most MCP
+    servers are tools-only).
+
+    **Only judges a listing the auditor actually attempted.** `items is None`
+    does not mean "the listing failed": the session path lists a feature only
+    when the server declares it, and the modern-only probe path collects tools
+    alone. Reading that silence as failure cost a modern server declaring
+    resources and prompts 10 CRITICAL points for nothing. Rules whose listing
+    was never attempted skip as insufficient-data — see `listings_attempted`.
+
+    That gating also bounds what the rule can detect: serving a feature without
+    declaring it is caught only when something else caused the listing to run.
     """
 
     group_name = "capabilities"
@@ -111,6 +127,12 @@ class CapabilityDeclarationRule(BaseRule):
     @property
     def severity(self) -> RuleSeverity:
         return RuleSeverity.CRITICAL
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when this feature's listing was never attempted — silence is not evidence."""
+        if self.feature not in audit_data.listings_attempted:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
 
     def _evaluate(self, capabilities: ServerCapabilities | None, items: list | None) -> RuleResult:
         """Compare the declared capability against what the server served."""

--- a/mcpscore/rules/protocol_version.py
+++ b/mcpscore/rules/protocol_version.py
@@ -138,7 +138,10 @@ class LatestVersionRule(ProtocolVersionBaseRule):
                 f"✅ Protocol version '{protocol_version}' is newer than the latest final version '{LATEST.version}'"
             )
         else:
-            message: str = f"❌ Not using the latest protocol version. Current: '{protocol_version}'"
+            message: str = (
+                f"❌ Not using the latest protocol version: negotiated '{protocol_version}', "
+                f"latest is '{LATEST.version}'"
+            )
 
         return RuleResult(
             rule_name=self.rule_name,

--- a/mcpscore/rules/readiness.py
+++ b/mcpscore/rules/readiness.py
@@ -104,7 +104,7 @@ class ProbeBackedReadinessRule(ReadinessBaseRule):
 
 @register_rule
 class ServerDiscoverReadinessRule(ProbeBackedReadinessRule):
-    """Gateway check: the server implements the mandatory ``server/discover`` (SEP-2567)."""
+    """Gateway check: the server implements the mandatory ``server/discover`` (SEP-2575)."""
 
     rule_id = "readiness_2026_server_discover"
     rule_order = 1
@@ -127,13 +127,13 @@ class ServerDiscoverReadinessRule(ProbeBackedReadinessRule):
                 f"✅ Server answers server/discover (supported versions: {probe.details.get('supported_versions')})"
             )
         else:
-            message = f"❌ Server does not answer server/discover — mandatory from {READINESS_TARGET} (SEP-2567)"
+            message = f"❌ Server does not answer server/discover — mandatory from {READINESS_TARGET} (SEP-2575)"
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"sep": "SEP-2567", "target_version": READINESS_TARGET, **probe.details},
+            details={"sep": "SEP-2575", "target_version": READINESS_TARGET, **probe.details},
         )
 
 
@@ -566,10 +566,12 @@ class ToolSchemaDialectReadinessRule(ReadinessBaseRule):
 class NoSessionIdReadinessRule(ProbeBackedReadinessRule):
     """Legacy-leakage check: no ``Mcp-Session-Id`` minted or echoed on modern requests.
 
-    Session IDs are removed in the target revision; a server serving modern
-    requests must ignore an incoming ``Mcp-Session-Id`` and never mint or echo
-    one. Runs only when modern support was detected (inverse gating): a
-    legacy-only server keeping sessions is correct behavior, not leakage.
+    Protocol-level sessions are removed in the target revision (SEP-2567). A
+    server that serves modern requests SHOULD ignore an incoming
+    ``Mcp-Session-Id`` and not mint or echo one — the strength the spec's
+    backward-compatibility section uses. Runs only when modern support was
+    detected (inverse gating): a legacy-only server keeping sessions is correct
+    behavior, not leakage.
     """
 
     rule_id = "readiness_2026_no_session_id"
@@ -593,19 +595,20 @@ class NoSessionIdReadinessRule(ProbeBackedReadinessRule):
         elif echoed is not None:
             message = (
                 f"❌ Server echoes/mints an Mcp-Session-Id ('{echoed}') on a modern request — "
-                f"session IDs are removed in {READINESS_TARGET} and must not be emitted (SEP-2575)"
+                f"protocol-level sessions are removed in {READINESS_TARGET}; servers should not "
+                "mint or echo session IDs (SEP-2567)"
             )
         else:
             message = (
                 "❌ Server does not serve a modern request carrying a spurious Mcp-Session-Id — "
-                "the header must be ignored, not treated as an error (SEP-2575)"
+                "the header should be ignored, not treated as an error (SEP-2567)"
             )
         return RuleResult(
             rule_name=self.rule_name,
             severity=self.severity,
             passed=passed,
             message=message,
-            details={"sep": "SEP-2575", "target_version": READINESS_TARGET, **probe.details},
+            details={"sep": "SEP-2567", "target_version": READINESS_TARGET, **probe.details},
         )
 
 

--- a/mcpscore/spec.py
+++ b/mcpscore/spec.py
@@ -10,10 +10,13 @@ any new probes/rules) — never rewriting support for older versions.
 Version identifiers are the wire values (``YYYY-MM-DD`` date strings), which
 makes lexicographic comparison a total chronological order — see :func:`compare`.
 
-Facts for the ``2026-07-28`` entry were verified against the release candidate
-(locked 2026-05-21). The changelog is published under ``/specification/draft/``
-until the revision goes final; re-verify the entry against the dated spec URL
-on release before flipping its status to ``CURRENT``.
+Facts for the ``2026-07-28`` entry were first taken from the release candidate
+(locked 2026-05-21) and **re-verified against the dated final URL**
+(``/specification/2026-07-28/``) on 2026-07-28, the day it was published: the
+changelog, the transport header table, the error-code allocation and the
+deprecated-features registry all matched the RC, so no fact changed. Repeat that
+mechanical re-check whenever a revision goes final — the error codes were
+renumbered once already, after the RC was locked.
 """
 
 from __future__ import annotations
@@ -155,7 +158,7 @@ SPEC_VERSIONS: tuple[SpecVersion, ...] = (
         version="2025-11-25",
         release_date=date(2025, 11, 25),
         lifecycle=Lifecycle.STATEFUL,
-        status=SpecStatus.CURRENT,
+        status=SpecStatus.SUPERSEDED,
         deprecated_features=frozenset({"http-sse-transport", "sampling-include-context"}),
         required_request_headers=frozenset({"MCP-Protocol-Version"}),
         tool_schema_default_dialect=None,
@@ -165,7 +168,7 @@ SPEC_VERSIONS: tuple[SpecVersion, ...] = (
         version="2026-07-28",
         release_date=date(2026, 7, 28),
         lifecycle=Lifecycle.STATELESS,
-        status=SpecStatus.DRAFT,
+        status=SpecStatus.CURRENT,
         deprecated_features=frozenset(
             {
                 "http-sse-transport",
@@ -179,7 +182,7 @@ SPEC_VERSIONS: tuple[SpecVersion, ...] = (
         required_request_headers=frozenset({"MCP-Protocol-Version", "Mcp-Method"}),
         tool_schema_default_dialect="2020-12",
         notes=(
-            "Release candidate locked 2026-05-21; flip status to CURRENT once final. "
+            "Published final 2026-07-28; facts re-verified against the dated spec URL that day. "
             "Removes the initialize handshake (per-request _meta; mandatory server/discover). "
             "Mcp-Name is additionally required on tools/call, resources/read, and prompts/get. "
             "Deprecated features have earliest removal 2027-07-28 and remain functional."

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-box/mcpscore",
-  "version": "0.9.0",
+  "version": "1.1.0",
   "description": "Audit an MCP server and get a scored, actionable quality report in seconds. Node wrapper for the Python mcpscore CLI.",
   "bin": {
     "mcpscore": "bin/mcpscore.js"
@@ -33,7 +33,7 @@
     "developer-tools"
   ],
   "mcpscore": {
-    "pythonVersion": "0.9.0"
+    "pythonVersion": "1.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.1.0rc1"
+version = "1.1.0"
 description = "Audit an MCP server and get a scored, actionable quality report in seconds."
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"
@@ -39,7 +39,7 @@ keywords = [
     "developer-tools",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -57,7 +57,7 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
-    "mcp==2.0.0rc1",
+    "mcp==2.0.0",
     "httpx2>=2.5.0",
     "jsonschema>=4.21",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,9 @@ source = ["mcpscore"]
 branch = true
 
 [tool.coverage.report]
-fail_under = 95
+# Kept in step with codecov.yml (project and patch both 97%) so the local gate
+# and the PR checks fail together instead of one surprising the other.
+fail_under = 97
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",

--- a/tests/test_capabilities_rules.py
+++ b/tests/test_capabilities_rules.py
@@ -4,6 +4,7 @@ from mcp_types import ResourcesCapability
 from pydantic import BaseModel
 
 from mcpscore.rules import AuditData, RuleSeverity
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
 from mcpscore.rules.capabilities import (
     CapabilityPromptsListChangedRule,
     CapabilityPromptsPresentRule,
@@ -143,3 +144,46 @@ def test_capabilities_feature_rules_declared_but_disabled(capabilities_full):
         result = rule.check(AuditData(capabilities=caps))
         assert result.passed is False
         assert "not supported" in result.message
+
+
+class TestListingNeverAttempted:
+    """A listing the auditor never ran must not be scored as a failed listing.
+
+    Regression for the review finding on PR #57: the session path lists a
+    feature only when the server declares it, and `audit_modern_only` collects
+    tools alone from the stateless probe. Treating `items is None` as "the
+    listing did not answer" failed a modern server that declares resources and
+    prompts for 10 CRITICAL points it had done nothing to deserve.
+    """
+
+    def test_modern_only_shape_skips_uncollected_listings(self, capabilities_full):
+        """Modern probe path: tools observed, resources/prompts never listed."""
+        data = AuditData(
+            capabilities=capabilities_full,
+            tools=[object()],
+            listings_attempted=frozenset({"tools"}),
+        )
+
+        assert CapabilityToolsPresentRule().skip_reason(data) is None
+        assert CapabilityToolsPresentRule().check(data).passed
+        for rule_cls in (CapabilityResourcesPresentRule, CapabilityPromptsPresentRule):
+            assert rule_cls().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_attempted_listing_is_judged(self, capabilities_full):
+        """Once a listing ran, silence really does mean it did not answer."""
+        data = AuditData(
+            capabilities=capabilities_full,
+            resources=None,
+            listings_attempted=frozenset({"resources"}),
+        )
+
+        rule = CapabilityResourcesPresentRule()
+        assert rule.skip_reason(data) is None
+        result = rule.check(data)
+        assert not result.passed
+        assert "did not answer" in result.message
+
+    def test_default_audit_data_attempts_nothing(self):
+        """The default is 'not attempted', so no rule can fail on absent data."""
+        for rule_cls, _ in DECLARATION_RULES:
+            assert rule_cls().skip_reason(AuditData()) == SKIP_REASON_INSUFFICIENT_DATA

--- a/tests/test_capabilities_rules.py
+++ b/tests/test_capabilities_rules.py
@@ -3,16 +3,12 @@ from dataclasses import replace
 from mcp_types import ResourcesCapability
 from pydantic import BaseModel
 
-from mcpscore.rules import (
-    AuditData,
-    CapabilityLoggingPresentRule,
-)
+from mcpscore.rules import AuditData, RuleSeverity
 from mcpscore.rules.capabilities import (
     CapabilityPromptsListChangedRule,
     CapabilityPromptsPresentRule,
     CapabilityResourcesListChangedRule,
     CapabilityResourcesPresentRule,
-    CapabilityResourcesSubscribeRule,
     CapabilityToolsListChangedRule,
     CapabilityToolsPresentRule,
     _wire_str,
@@ -39,23 +35,72 @@ class TestWireStr:
         assert _wire_str(Plain()) == "flag=True"
 
 
-def test_capabilities_presence_rules(capabilities_full, capabilities_missing):
-    """Test that capability presence rules correctly identify missing capabilities.
+DECLARATION_RULES = (
+    (CapabilityToolsPresentRule, "tools"),
+    (CapabilityPromptsPresentRule, "prompts"),
+    (CapabilityResourcesPresentRule, "resources"),
+)
+"""Each consistency rule with the AuditData field carrying what the server served."""
 
-    This test verifies that rules for tools, prompts, resources, and logging
-    capabilities properly detect when these capabilities are present or missing
-    in the server's capability declaration.
+
+def _audit_data(capabilities, feature, items):
+    return AuditData(capabilities=capabilities, **{feature: items})
+
+
+def test_declared_and_served_passes(capabilities_full):
+    for rule_cls, feature in DECLARATION_RULES:
+        result = rule_cls().check(_audit_data(capabilities_full, feature, [object()]))
+        assert result.passed, feature
+
+
+def test_neither_declared_nor_served_passes(capabilities_missing):
+    """A tools-only server must not lose points for having no resources or prompts.
+
+    The spec requires the declaration only of servers that *support* the
+    feature; scoring its absence penalized the majority of real servers for a
+    legitimate design choice.
     """
-    presence_rules = [
-        CapabilityToolsPresentRule(),
-        CapabilityPromptsPresentRule(),
-        CapabilityResourcesPresentRule(),
-        CapabilityLoggingPresentRule(),
-    ]
+    for rule_cls, feature in DECLARATION_RULES:
+        result = rule_cls().check(_audit_data(capabilities_missing, feature, None))
+        assert result.passed, feature
+        assert "only required of servers that support it" in result.message
 
-    for rule in presence_rules:
-        assert rule.check(AuditData(capabilities=capabilities_full)).passed
-        assert not rule.check(AuditData(capabilities=capabilities_missing)).passed
+
+def test_served_without_being_declared_fails(capabilities_missing):
+    """The actual spec MUST: serving the feature obliges declaring it."""
+    for rule_cls, feature in DECLARATION_RULES:
+        result = rule_cls().check(_audit_data(capabilities_missing, feature, [object(), object()]))
+        assert not result.passed, feature
+        assert "MUST declare it" in result.message
+        details = result.details or {}
+        assert details["served"] is True
+        assert details["declared"] is False
+
+
+def test_declared_but_listing_does_not_answer_fails(capabilities_full):
+    """Advertising a feature whose listing method fails is a broken promise."""
+    for rule_cls, feature in DECLARATION_RULES:
+        result = rule_cls().check(_audit_data(capabilities_full, feature, None))
+        assert not result.passed, feature
+        assert "did not answer" in result.message
+
+
+def test_declared_and_served_empty_passes(capabilities_full):
+    """An empty list is a valid answer — a server may declare a feature it has none of yet."""
+    for rule_cls, feature in DECLARATION_RULES:
+        assert rule_cls().check(_audit_data(capabilities_full, feature, [])).passed, feature
+
+
+def test_list_changed_rules_are_advisory():
+    """The listChanged rules are optional per spec, so they may only ever cost a LOW point."""
+    for rule in (
+        CapabilityToolsListChangedRule(),
+        CapabilityPromptsListChangedRule(),
+        CapabilityResourcesListChangedRule(),
+    ):
+        assert rule.severity is RuleSeverity.LOW
+        assert rule.basis is not None
+        assert "optional" in rule.basis
 
 
 def test_capabilities_feature_rules(capabilities_full, capabilities_missing):
@@ -69,7 +114,6 @@ def test_capabilities_feature_rules(capabilities_full, capabilities_missing):
         CapabilityToolsListChangedRule(),
         CapabilityPromptsListChangedRule(),
         CapabilityResourcesListChangedRule(),
-        CapabilityResourcesSubscribeRule(),
     ]
 
     for rule in feature_rules:
@@ -87,13 +131,12 @@ def test_capabilities_feature_rules_declared_but_disabled(capabilities_full):
         capabilities_full,
         tools=replace(capabilities_full.tools, list_changed=False),
         prompts=replace(capabilities_full.prompts, list_changed=False),
-        resources=replace(capabilities_full.resources, list_changed=False, subscribe=False),
+        resources=replace(capabilities_full.resources, list_changed=False),
     )
     feature_rules = [
         CapabilityToolsListChangedRule(),
         CapabilityPromptsListChangedRule(),
         CapabilityResourcesListChangedRule(),
-        CapabilityResourcesSubscribeRule(),
     ]
 
     for rule in feature_rules:

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -236,6 +236,20 @@ class TestToolsListingAttempt:
         assert "capability_tools_present" in failed
         assert "capability_tools_present" not in skipped
 
+    async def test_absent_stateless_probe_is_not_an_attempt(self, stub_probes, monkeypatch: pytest.MonkeyPatch):
+        """Defensive path: no stateless observation at all in the probe map."""
+        results = _modern_probe_results()
+        del results[PROBE_STATELESS_LIST]
+        stub_probes(results)
+        monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+        auditor = MCPAuditor()
+        assert await auditor.audit_modern_only(URL) is True
+
+        assert auditor.audit_data.listings_attempted == frozenset()
+        assert auditor.audit_data.tools is None
+        assert "capability_tools_present" in {s.rule_id for s in auditor.skipped_rules}
+
     async def test_unobservable_probe_is_not_an_attempt(self, stub_probes, monkeypatch: pytest.MonkeyPatch):
         """A network error is not evidence about the server — skip, do not fail."""
         results = _modern_probe_results()

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -207,6 +207,51 @@ async def test_stateless_probe_without_payload_leaves_tools_none(stub_probes, mo
     assert auditor.audit_data.tools is None
 
 
+class TestToolsListingAttempt:
+    """`listings_attempted` records the server's answer, not a usable one.
+
+    Regression for the second review finding on PR #57: marking the attempt
+    only when a list-shaped tools payload parsed meant a modern server that
+    declares tools and then fails `tools/list` skipped
+    `capability_tools_present` as insufficient-data instead of failing it.
+    """
+
+    async def test_answered_probe_without_tools_is_still_an_attempt(self, stub_probes, monkeypatch: pytest.MonkeyPatch):
+        results = _modern_probe_results()
+        # The server answered tools/list, but with nothing usable in it.
+        results[PROBE_STATELESS_LIST] = ProbeResult(
+            PROBE_STATELESS_LIST, ProbeOutcome.SUPPORTED, {"result_type": "complete"}
+        )
+        stub_probes(results)
+        monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+        auditor = MCPAuditor()
+        assert await auditor.audit_modern_only(URL) is True
+
+        assert "tools" in auditor.audit_data.listings_attempted
+        assert auditor.audit_data.tools is None
+        # Declared in server/discover + no answer => the CRITICAL rule must fire.
+        failed = {r.rule_id for r in auditor.results if not r.passed}
+        skipped = {s.rule_id for s in auditor.skipped_rules}
+        assert "capability_tools_present" in failed
+        assert "capability_tools_present" not in skipped
+
+    async def test_unobservable_probe_is_not_an_attempt(self, stub_probes, monkeypatch: pytest.MonkeyPatch):
+        """A network error is not evidence about the server — skip, do not fail."""
+        results = _modern_probe_results()
+        results[PROBE_STATELESS_LIST] = ProbeResult(
+            PROBE_STATELESS_LIST, ProbeOutcome.ERROR, {"exception": "ConnectError"}
+        )
+        stub_probes(results)
+        monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+        auditor = MCPAuditor()
+        assert await auditor.audit_modern_only(URL) is True
+
+        assert "tools" not in auditor.audit_data.listings_attempted
+        assert "capability_tools_present" in {s.rule_id for s in auditor.skipped_rules}
+
+
 class TestAuditorReuseDoesNotLeakState:
     """Regression tests for per-run state reset (PR #21 review)."""
 

--- a/tests/test_protocol_version_rules.py
+++ b/tests/test_protocol_version_rules.py
@@ -70,9 +70,13 @@ def test_deprecated_version_rule_fails_for_deprecated_version(monkeypatch):
     assert result.details["deprecated_versions"] == ["2024-11-05"]
 
 
-def test_latest_version_rule_passes_for_newer_draft_version():
-    """A server on a spec revision newer than the latest final one is not "behind"."""
+def test_latest_version_rule_passes_for_newer_unreleased_version():
+    """A server ahead of the latest final revision is not "behind".
+
+    Uses a date past any published revision: 2026-07-28 became LATEST itself
+    when it was published, so it no longer exercises this branch.
+    """
     rule = LatestVersionRule()
-    result = rule.check(AuditData(protocol_version="2026-07-28"))
+    result = rule.check(AuditData(protocol_version="2099-01-01"))
     assert result.passed
     assert "newer" in result.message

--- a/tests/test_readiness_rules.py
+++ b/tests/test_readiness_rules.py
@@ -330,7 +330,7 @@ class TestReadinessScoringAxis:
 
         report = auditor.get_audit_report()
         assert report["spec"]["negotiated_version"] == "2025-11-25"
-        assert report["spec"]["latest_version"] == "2025-11-25"
+        assert report["spec"]["latest_version"] == "2026-07-28"
         assert report["spec"]["readiness_target"] == "2026-07-28"
         assert report["spec"]["era"] == "legacy"
         assert report["readiness"]["max_score"] > 0
@@ -454,3 +454,50 @@ class TestUncoveredBranches:
         tool = _tool(name="odd")
         tool.inputSchema = None
         assert ToolSchemaDialectReadinessRule().check(AuditData(tools=[tool])).passed
+
+
+class TestSepCitations:
+    """Every readiness rule must report the SEP that actually introduced its requirement.
+
+    Verified against the 2026-07-28 changelog on 2026-07-28. This table is the
+    guard that a `details["sep"]` truthiness check is not: `server/discover`
+    and the removal of protocol-level sessions were reported with each other's
+    SEP until it was caught by a launch-eve review.
+    """
+
+    EXPECTED_SEP = {
+        # server/discover, statelessness, session removal, subscriptions/listen,
+        # and the removed methods all land in SEP-2575 — except sessions.
+        "readiness_2026_server_discover": "SEP-2575",
+        "readiness_2026_stateless_request": "SEP-2575",
+        "readiness_2026_meta_validation": "SEP-2575",
+        "readiness_2026_unsupported_version_error": "SEP-2575",
+        "readiness_2026_removed_methods": "SEP-2575",
+        # "Sessionless MCP via Explicit State Handles" — removes Mcp-Session-Id.
+        "readiness_2026_no_session_id": "SEP-2567",
+        "readiness_2026_header_validation": "SEP-2243",
+        "readiness_2026_cache_metadata": "SEP-2549",
+        "readiness_2026_error_code_migration": "SEP-2164",
+        "readiness_2026_result_type": "SEP-2322",
+        "readiness_2026_deprecated_features": "SEP-2577",
+        "readiness_2026_tool_schema_dialect": "SEP-2106",
+    }
+
+    def test_every_readiness_rule_cites_the_right_sep(self):
+        from mcpscore.rules import create_all_rules
+        from mcpscore.rules.base import READINESS_GROUP
+
+        data = AuditData(
+            probes=modern_probes(),
+            capabilities=FakeServerCapabilities(logging=FakeLoggingCaps(enabled=True)),
+            tools=[_tool(name="ok")],
+        )
+        seen = {}
+        for rule in create_all_rules():
+            if rule.group_name != READINESS_GROUP or rule.skip_reason(data) is not None:
+                continue
+            seen[rule.rule_id] = (rule.check(data).details or {}).get("sep")
+
+        assert seen == {rule_id: self.EXPECTED_SEP[rule_id] for rule_id in seen}
+        # And no readiness rule ships without a citation at all.
+        assert set(seen) == set(self.EXPECTED_SEP), "readiness rule missing from the citation table"

--- a/tests/test_readiness_rules.py
+++ b/tests/test_readiness_rules.py
@@ -498,6 +498,7 @@ class TestSepCitations:
                 continue
             seen[rule.rule_id] = (rule.check(data).details or {}).get("sep")
 
-        assert seen == {rule_id: self.EXPECTED_SEP[rule_id] for rule_id in seen}
-        # And no readiness rule ships without a citation at all.
+        # Key-set first so a new readiness rule missing from EXPECTED_SEP fails
+        # with a clear assertion, not a KeyError on the dict comprehension below.
         assert set(seen) == set(self.EXPECTED_SEP), "readiness rule missing from the citation table"
+        assert seen == {rule_id: self.EXPECTED_SEP[rule_id] for rule_id in seen}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,6 @@
 from mcpscore.rules import (
     AllowedVersionRule,
-    CapabilityLoggingPresentRule,
+    CapabilityToolsPresentRule,
     RuleRegistry,
     create_all_rules,
 )
@@ -10,7 +10,7 @@ def test_registry_creates_all_rules():
     rules = list(create_all_rules())
     # ensure at least a couple of known rules are included
     assert any(isinstance(r, AllowedVersionRule) for r in rules)
-    assert any(isinstance(r, CapabilityLoggingPresentRule) for r in rules)
+    assert any(isinstance(r, CapabilityToolsPresentRule) for r in rules)
 
 
 def test_registry_unique_ids():

--- a/tests/test_retired_rules.py
+++ b/tests/test_retired_rules.py
@@ -1,0 +1,65 @@
+"""Regression tests for rules retired in 1.1.0.
+
+`capability_logging_present` and `capability_resources_subscribe` scored the
+*absence* of capabilities the spec sections they cited call optional, and the
+logging rule directly contradicted `readiness_2026_deprecated_features` (which
+fails a server for *declaring* `logging`, deprecated by SEP-2577). With
+readiness promoted into the main score for modern/dual-era servers, no server
+could pass both — every server in the acceptance corpus failed one of them.
+
+These tests fail against the pre-retirement code, which is the point.
+"""
+
+from dataclasses import replace
+
+from mcpscore.rules import AuditData, create_all_rules
+from mcpscore.rules.base import READINESS_GROUP
+
+RETIRED_RULE_IDS = frozenset({"capability_logging_present", "capability_resources_subscribe"})
+"""rule_id is a public contract: these are retired, never reused."""
+
+
+def _main_rules():
+    """Every registered rule that scores on the main axis."""
+    return [rule for rule in create_all_rules() if rule.group_name != READINESS_GROUP]
+
+
+def _capability_score(capabilities) -> int:
+    """Points a capabilities-shaped server earns from the main rules that can judge it."""
+    total = 0
+    audit_data = AuditData(capabilities=capabilities)
+    for rule in _main_rules():
+        if rule.skip_reason(audit_data) is not None:
+            continue
+        result = rule.check(audit_data)
+        if result.passed:
+            total += int(result.severity)  # RuleSeverity is an IntEnum of point weights
+    return total
+
+
+def test_retired_rule_ids_are_not_registered():
+    assert RETIRED_RULE_IDS.isdisjoint({rule.rule_id for rule in create_all_rules()})
+
+
+def test_omitting_the_deprecated_logging_capability_costs_nothing(capabilities_full):
+    """SEP-2577 deprecates Logging: omitting it must not cost points.
+
+    The contradiction this fixes: the retired rule failed a server for omitting
+    `logging` while `readiness_2026_deprecated_features` fails it for declaring
+    the same capability.
+    """
+    without_logging = replace(capabilities_full, logging=None)
+
+    assert _capability_score(without_logging) == _capability_score(capabilities_full)
+
+
+def test_omitting_the_optional_subscribe_capability_costs_nothing(capabilities_full):
+    """Omitting the optional `subscribe` capability must not cost points.
+
+    2025-11-25 Resources §Capabilities: "Both `subscribe` and `listChanged` are
+    optional — servers can support neither, either, or both." SEP-2575 then
+    removes `resources/subscribe` outright.
+    """
+    without_subscribe = replace(capabilities_full, resources=replace(capabilities_full.resources, subscribe=False))
+
+    assert _capability_score(without_subscribe) == _capability_score(capabilities_full)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -24,16 +24,16 @@ def test_exactly_one_current_version():
     assert current[0] is spec.LATEST
 
 
-def test_latest_is_2025_11_25():
-    assert spec.LATEST.version == "2025-11-25"
-    assert spec.LATEST.lifecycle is Lifecycle.STATEFUL
+def test_latest_is_2026_07_28_stateless():
+    """Published final 2026-07-28; the registry flipped that day."""
+    assert spec.LATEST.version == "2026-07-28"
+    assert spec.LATEST.lifecycle is Lifecycle.STATELESS
 
 
-def test_draft_is_2026_07_28_stateless():
-    assert spec.DRAFT is not None
-    assert spec.DRAFT.version == "2026-07-28"
-    assert spec.DRAFT.lifecycle is Lifecycle.STATELESS
-    assert spec.DRAFT.status is SpecStatus.DRAFT
+def test_no_draft_revision_today():
+    """No revision is in draft: 2026-07-28 went final and nothing has opened after it."""
+    assert spec.DRAFT is None
+    assert spec.get("2025-11-25").status is SpecStatus.SUPERSEDED
 
 
 def test_allowed_versions_match_public_enum():
@@ -42,8 +42,16 @@ def test_allowed_versions_match_public_enum():
 
 
 def test_allowed_versions_exclude_drafts():
-    assert spec.DRAFT is not None
-    assert spec.DRAFT.version not in spec.allowed_versions()
+    """A draft is a readiness target, never a version a server may negotiate.
+
+    Vacuous while no draft is open — kept as the guard for the next revision,
+    which is exactly when a published version must appear in this list: while
+    2026-07-28 was still DRAFT, a server correctly speaking it failed
+    `protocol_version_allowed` at CRITICAL.
+    """
+    drafts = [v.version for v in spec.SPEC_VERSIONS if v.status is SpecStatus.DRAFT]
+    assert not set(drafts) & set(spec.allowed_versions())
+    assert spec.LATEST.version in spec.allowed_versions()
 
 
 def test_no_deprecated_versions_today():

--- a/uv.lock
+++ b/uv.lock
@@ -378,7 +378,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "2.0.0rc1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -396,27 +396,27 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/ea/aa22bd3a6056fc9fb183ddb245545684cca2391286e1eb67946ab3ef418f/mcp-2.0.0rc1.tar.gz", hash = "sha256:664f719ea0ba33fa6a697fa1e32cadca6b6f7d7f958a8a8cda59622a0172d835", size = 1619591, upload-time = "2026-07-27T13:35:17.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/4c/02657d8e70dc828089e1a0f1326c44c3a1f9aba2d7b22df61feda71111fa/mcp-2.0.0rc1-py3-none-any.whl", hash = "sha256:43d8c181d3dac50aaa310e16fa14dae92ac844ffa3fcc3363b6a93d8b088ea0d", size = 340369, upload-time = "2026-07-27T13:35:13.997Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [[package]]
 name = "mcp-types"
-version = "2.0.0rc1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/7b/a405786c8ec58f40769fb27b4131edc6f175b407be73a821eff446568ead/mcp_types-2.0.0rc1.tar.gz", hash = "sha256:3c9ec7d0e356d9c73023c53b418179801257869d2f1647cb6d19a9072831cfcd", size = 66486, upload-time = "2026-07-27T13:35:18.386Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/01/c18c6c37df2ca487113e76b5a0fb001b285482b28dbde6488a832209ff68/mcp_types-2.0.0rc1-py3-none-any.whl", hash = "sha256:b40ce464006aacd6682049f6f3b573a2ce04af203fddd1716e8e1ae9226779bb", size = 69518, upload-time = "2026-07-27T13:35:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
 name = "mcpscore"
-version = "1.1.0rc1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },
@@ -437,7 +437,7 @@ dev = [
 requires-dist = [
     { name = "httpx2", specifier = ">=2.5.0" },
     { name = "jsonschema", specifier = ">=4.21" },
-    { name = "mcp", specifier = "==2.0.0rc1" },
+    { name = "mcp", specifier = "==2.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Audit scores and pass/fail behavior change for many servers (protocol latest, capability consistency, retired rules); CI thresholds tighten to 97%.
> 
> **Overview**
> **Ships stable 1.1.0** aligned with the final MCP **2026-07-28** revision: bumps **mcp SDK 2.0.0**, PyPI/npm **1.1.0**, and Production/Stable; **`MCPProtocolVersion.Latest`** and the spec registry now treat **2026-07-28** as current (fixing CRITICAL false positives on servers speaking that version while it was still draft).
> 
> **Scoring and rules change materially.** Tools/prompts/resources capability rules now enforce **declared-vs-served consistency** (with **`AuditData.listings_attempted`** so unattempted listings skip instead of failing); **`listChanged`** rules drop to **LOW** advisory; **`capability_resources_subscribe`** and **`capability_logging_present`** are **removed**. Readiness messages fix **swapped SEP-2567/SEP-2575** citations and soften **`readiness_2026_no_session_id`** to SHOULD-level wording.
> 
> **CI/docs:** coverage floor **97%** with new **`codecov.yml`**; README/docs reflect **52 rules** and final 2026-07-28 readiness framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48acdc2218693f652e3cff24a35c2bdcd7bda53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->