### PR TITLE
Improved releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release script's smoke test now refreshes uv's package cache.** It
+  printed `uvx mcpscore==<version> …`, which fails with "your requirements are
+  unsatisfiable" on any machine that had resolved mcpscore before: uv caches the
+  PyPI index, so a version published seconds earlier is invisible to it. The
+  hint now passes `--refresh-package mcpscore`. Also notes that `npx
+  @mcp-box/mcpscore@<version>` delegates to `uvx` and shares the same cache.
+
 ## [1.1.0] - 2026-07-28
 
 First stable release. Ships the day the MCP `2026-07-28` revision went final.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -274,14 +274,26 @@ def wait_for_publish(version: str) -> None:
         # --prerelease=allow: uv's pre-release exception covers only direct
         # requirements, and this package's SDK pin (mcp==2.0.0bN) is transitive
         # from uvx's point of view.
-        print(f"\nSmoke test:\n  uvx --prerelease=allow mcpscore=={version} https://mcp.deepwiki.com/mcp")
+        # --refresh-package: see the note on the stable smoke test below.
+        print(
+            f"\nSmoke test:\n"
+            f"  uvx --refresh-package mcpscore --prerelease=allow "
+            f"mcpscore=={version} https://mcp.deepwiki.com/mcp"
+        )
         return
     # npm requires the scope slash URL-encoded (%2F) — canonical registry form.
     npm_path = NPM_PACKAGE.replace("/", "%2F")
     wait_for_registry("npm", f"https://registry.npmjs.org/{npm_path}/{version}", "publish-npm.yml")
+    # --refresh-package: uv caches the PyPI index, so a version published
+    # seconds ago is invisible to a machine that resolved this package before —
+    # the smoke test fails with "your requirements are unsatisfiable" for a
+    # release that is in fact live. Refreshing one package is enough; --no-cache
+    # also works but re-downloads every dependency.
+    # `npx` delegates to `uvx mcpscore==<pin>` (npm/bin/mcpscore.js) and so hits
+    # the same index cache — run the uvx line first to refresh it.
     print(
         f"\nSmoke test:\n"
-        f"  uvx mcpscore=={version} https://mcp.deepwiki.com/mcp\n"
+        f"  uvx --refresh-package mcpscore mcpscore=={version} https://mcp.deepwiki.com/mcp\n"
         f"  npx {NPM_PACKAGE}@{version} https://mcp.deepwiki.com/mcp"
     )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release tooling and documentation only; no runtime audit or packaging logic changes.
> 
> **Overview**
> Fixes **false-failing post-release smoke tests** when `uv` still has a stale PyPI index for `mcpscore` right after publish.
> 
> `wait_for_publish` in `scripts/release.py` now prints `uvx --refresh-package mcpscore …` for both stable and pre-release smoke lines (pre-release keeps `--prerelease=allow`). Inline comments explain why, and that **`npx @mcp-box/mcpscore@<version>`** ultimately uses `uvx` and benefits from running the `uvx` line first. The **[Unreleased]** changelog entry documents the same behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73677ebe9a2d36ad67313914398b94495324c959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->