### PR TITLE
Fix/partial audit when legacy fails non 401

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,17 @@
   diagnostics may differ; the commands are authoritative.
 - **`rule_id` is a stable public contract**: never rename or reuse one. New rules must
   cite the MCP spec section (or SEP) they enforce in their result `details`.
+- **Rule lifecycle — three states, and the choice between them matters:**
+  1. **Active** — runs everywhere.
+  2. **Version-scoped** — set `min_spec_version`/`max_spec_version` when a rule is
+     correct but only for some revisions. Use this for anything the spec removed
+     or deprecated: the rule keeps its ID and still judges servers on the
+     revisions where the requirement held. **Obsolescence is scoping, not deletion.**
+  3. **Retired** — delete the rule *only when it was wrong* (it asserted something
+     the spec does not require, or contradicted another rule), and add an entry to
+     `mcpscore/rules/retired.py`. That registry generates the "Retired rules" table
+     in `docs/rules.mdx`, so an old report or a stale CI waiver stays explainable.
+     A retired ID is never reused — a test enforces it.
 - Readiness rules (`group_name = "readiness"`) score on the readiness axis; since the
   1.1.0 promotion they ALSO count in the main score, but only for modern-lifecycle
   servers (era modern/dual-era) in full audits — never for legacy servers, never in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-29
+
+Follow-up to the 1.1.0 launch release, driven by a full sweep of the 9,723
+auditable endpoints in the official MCP registry.
+
 ### Added
 
 - **A registry of retired rule IDs** (`mcpscore/rules/retired.py`), rendered as a
@@ -22,7 +27,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its ID and gains a `min_spec_version`/`max_spec_version` range instead —
   obsolescence is scoping, not deletion.
 
+### Changed
+
+- **The `listChanged` advisories no longer judge features a server does not
+  offer.** `capability_prompts_list_changed` and `capability_resources_list_changed`
+  failed servers with no prompts or resources at all — 2,798 and 2,582 servers
+  respectively in the registry sweep. They now skip as `not-applicable` when
+  the capability is absent, and still apply where the feature exists (a server
+  with tools that does not announce tool-list changes is still advised). Median
+  effect: +0.9 points, 54% of servers.
+
 ### Fixed
+
+- **Auth-gated servers that refuse the legacy handshake now get their partial
+  audit.** The partial branch only triggered when the *session* ended in
+  401/403; a server with no legacy endpoint fails the handshake on something
+  else (405 from the SSE fallback is the common shape), so the probes' 401
+  observation — and the RFC 9728 metadata already fetched — were discarded and
+  the CLI reported "Error connecting". The 2026-07-29 registry sweep put a
+  number on it: **708 of 9,723 servers, 29% of all gated servers**. The engine
+  now keeps the probe observations when the modern-only attempt declines and
+  decides on that evidence; re-running those 708 produced **703 partial
+  audits** (mean auth posture 84.4%), the other 5 being genuinely unreachable.
+  The reported status is the gate's (401), not whatever ended the session.
 
 - **The release script's smoke test now refreshes uv's package cache.** It
   printed `uvx mcpscore==<version> …`, which fails with "your requirements are
@@ -650,7 +677,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/mcp-box/mcpscore/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/mcp-box/mcpscore/compare/v1.1.0rc1...v1.1.0
 [1.1.0rc1]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b6...v1.1.0rc1
 [1.1.0b6]: https://github.com/mcp-box/mcpscore/compare/v1.1.0b5...v1.1.0b6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A registry of retired rule IDs** (`mcpscore/rules/retired.py`), rendered as a
+  "Retired rules" table in the [rules reference](https://docs.mcpscore.dev/rules/).
+  A `rule_id` is a public contract — it appears in stored reports and in CI
+  configuration that waives specific rules — so an ID that stops running now has
+  a permanent record of when it went and why, instead of silently vanishing from
+  the docs. Retired IDs are never reused; a test enforces both that and the
+  registry matching the live rule set.
+
+  The accompanying policy (`AGENTS.md`): a rule is retired only when it was
+  *wrong*. A rule that is correct but applies to particular spec revisions keeps
+  its ID and gains a `min_spec_version`/`max_spec_version` range instead —
+  obsolescence is scoping, not deletion.
+
 ### Fixed
 
 - **The release script's smoke test now refreshes uv's package cache.** It

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -114,3 +114,21 @@ normative citations behind each rule.
 | `readiness_2026_tool_schema_dialect` | Readiness 2026-07-28 - tool schema dialect | LOW | 1 | all versions |
 | `readiness_2026_no_session_id` | Readiness 2026-07-28 - no session IDs | HIGH | 3 | all versions |
 | `readiness_2026_removed_methods` | Readiness 2026-07-28 - removed methods | MEDIUM | 2 | all versions |
+
+## Retired rules
+
+These `rule_id`s no longer run. They are listed because a rule ID is a public
+contract: it appears in JSON reports you may have stored and in CI
+configuration that may still reference it. **Retired IDs are never reused.**
+
+A rule is retired only when it was *wrong*. A rule that was correct but applies
+only to certain spec revisions is not retired — it keeps its ID and gains a
+version range in the **Applies to** column above.
+
+If a report of yours shows one of these, its result was accurate for the
+mcpscore version that produced it; the check simply no longer exists.
+
+| Rule ID | Retired in | Last severity | Why |
+|---|---|---|---|
+| `capability_resources_subscribe` | 1.1.0 | HIGH | Scored the absence of an optional capability — 2025-11-25 Resources §Capabilities calls `subscribe` optional — and 2026-07-28 removes `resources/subscribe` outright (SEP-2575). |
+| `capability_logging_present` | 1.1.0 | MEDIUM | Scored the absence of an optional capability, and contradicted `readiness_2026_deprecated_features`, which fails a server for *declaring* `logging` (deprecated by SEP-2577). No server could pass both. |

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -370,7 +370,17 @@ async def async_main() -> None:
                     # flag: only an Authorization credential counts — a 401
                     # with only tracing/custom headers is a missing credential,
                     # not a rejected one.
-                    if has_authorization_credential(headers):
+                    #
+                    # "Rejected" additionally requires that the *session* was
+                    # the thing refused. The probe that reports a gate runs
+                    # `anonymous=True` — it strips the Authorization header —
+                    # so its 401 says the endpoint is gated and nothing at all
+                    # about the caller's token. When the session died of
+                    # something else (405 on the SSE fallback), the credential
+                    # was never exercised, and telling the user it was rejected
+                    # sends them to re-issue a token that is probably fine.
+                    credentials_rejected = session_gated and has_authorization_credential(headers)
+                    if credentials_rejected:
                         logger.info(
                             "Server rejected the provided credentials — "
                             "running a partial audit of the observable surface."
@@ -379,6 +389,24 @@ async def async_main() -> None:
                         partial_reason = (
                             f"Server rejected the provided credentials (HTTP {status}); scored the unauthenticated "
                             "surface only — check that the token or headers are valid for this server."
+                        )
+                    elif not session_gated and has_authorization_credential(headers):
+                        # Gated per an anonymous probe, but the session failed
+                        # separately — say so, and do not blame the credential.
+                        session_status = failure.status_code if failure is not None else None
+                        detail = f" (HTTP {session_status})" if session_status else ""
+                        logger.info(
+                            "Server requires authentication, and the session could not be established%s — "
+                            "running a partial audit of the observable surface.",
+                            detail,
+                        )
+                        logger.info(
+                            "(Your credentials were not exercised: the connection failed before they were used.)"
+                        )
+                        partial_reason = (
+                            f"Server requires authentication (HTTP {status}); the session could not be "
+                            f"established{detail}, so the supplied credentials were never exercised — scored the "
+                            "unauthenticated surface only."
                         )
                     else:
                         logger.info(

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, NoReturn
 from mcpscore import MCPAuditor, MCPClient
 from mcpscore.enums import ConnectionErrorReason
 from mcpscore.mcp_auditor import has_authorization_credential
+from mcpscore.probes import observed_auth_status
 
 if TYPE_CHECKING:
     from mcpscore import MCPTransportType
@@ -342,13 +343,29 @@ async def async_main() -> None:
                     return
 
                 failure = client.last_connection_error
-                if failure is not None and failure.reason in (
+                session_gated = failure is not None and failure.reason in (
                     ConnectionErrorReason.UNAUTHORIZED,
                     ConnectionErrorReason.FORBIDDEN,
-                ):
-                    status = failure.status_code or (
-                        401 if failure.reason is ConnectionErrorReason.UNAUTHORIZED else 403
-                    )
+                )
+                # A gated server does not always *fail* with 401: when it serves
+                # no legacy endpoint the handshake dies on something else (405
+                # on the SSE fallback is the common shape) and only the probes
+                # see the challenge. Trust that observation too, or ~29% of
+                # gated servers report as unreachable while we hold their
+                # WWW-Authenticate and RFC 9728 metadata.
+                probed_status = observed_auth_status(auditor.last_probes)
+                if session_gated or probed_status is not None:
+                    # Report the status of the *gate*, not of whatever ended the
+                    # session: a server whose SSE fallback answers 405 is still
+                    # gated at 401, and saying "requires authentication (HTTP
+                    # 405)" would send the reader hunting the wrong problem.
+                    if session_gated:
+                        assert failure is not None  # noqa: S101 — session_gated implies it
+                        status = failure.status_code or (
+                            403 if failure.reason is ConnectionErrorReason.FORBIDDEN else 401
+                        )
+                    else:
+                        status = probed_status or 401
                     # Key off the same predicate as the report's authenticated
                     # flag: only an Authorization credential counts — a 401
                     # with only tracing/custom headers is a missing credential,

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -7,6 +7,8 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     from mcp_types import InitializeResult, Prompt, Resource, Tool
 
+    from .probes import ProbeResult
+
 from pydantic import ValidationError
 
 from .enums import MCPTransportType
@@ -89,6 +91,11 @@ class MCPAuditor:
         self.readiness_max: int = 0
         self.readiness_results: list[RuleResult] = []
 
+        self.last_probes: dict[str, ProbeResult] | None = None
+        """Probe observations from the most recent modern-only attempt, kept even
+        when that attempt declined — they are the evidence that a server which
+        refused the legacy handshake is auth-gated rather than unreachable."""
+
         self.era: Era | None = None
         """Lifecycle era(s) the server was observed to support (set during audit)."""
 
@@ -170,6 +177,7 @@ class MCPAuditor:
             return False
 
         probes = await run_all_probes(url, headers=self.headers)
+        self.last_probes = probes
         if not has_modern_support(probes):
             return False
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -444,6 +444,21 @@ async def _probe_unauthenticated(client: httpx2.AsyncClient, url: str) -> ProbeR
     return ProbeResult(PROBE_UNAUTHENTICATED, ProbeOutcome.SUPPORTED, details)
 
 
+def observed_auth_status(probes: dict[str, ProbeResult] | None) -> int | None:
+    """HTTP status of an auth gate the probes observed, or None if they saw no gate.
+
+    The unauthenticated probe records whatever the server answered, so this is
+    the evidence that a server is gated even when the *session* failed for an
+    unrelated reason — a legacy SSE fallback answering ``405``, say. Without it
+    a gated server that rejects the legacy handshake looks simply unreachable.
+    """
+    result = (probes or {}).get(PROBE_UNAUTHENTICATED)
+    if result is None:
+        return None
+    status = result.details.get("http_status")
+    return status if status in (401, 403) else None
+
+
 def _well_known_urls(url: str) -> list[str]:
     """RFC 9728 §3 well-known locations for a protected resource URL.
 

--- a/mcpscore/rules/capabilities.py
+++ b/mcpscore/rules/capabilities.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 
 from .base import (
     SKIP_REASON_INSUFFICIENT_DATA,
+    SKIP_REASON_NOT_APPLICABLE,
     AuditData,
     BaseRule,
     RuleResult,
@@ -194,8 +195,40 @@ class CapabilityToolsPresentRule(CapabilityDeclarationRule):
         return self._evaluate(capabilities, items)
 
 
+class CapabilityListChangedRule(CapabilityBaseRule):
+    """Base class for the advisory `listChanged` rules.
+
+    `listChanged` is optional per the spec; these rules are mcpscore quality
+    opinions, scored LOW — an agent that caches a tool list and never hears
+    about changes silently works from a stale copy.
+
+    **Only judges a feature the server actually offers.** A tools-only server
+    has nothing to say about `prompts.listChanged`, and failing it for that was
+    the same optionality error the presence rules carried until 1.1.0: the
+    2026-07-29 registry sweep found 2,798 servers failing
+    `capability_prompts_list_changed` with no prompts at all, and 2,582 the
+    same for resources. Undeclared feature -> the advisory skips.
+    """
+
+    feature: str = ""
+    """Capability attribute this advisory is about (e.g. "prompts")."""
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when the server does not offer this feature at all."""
+        capabilities = audit_data.capabilities
+        if capabilities is None:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        if getattr(capabilities, self.feature, None) is None:
+            return SKIP_REASON_NOT_APPLICABLE
+        return None
+
+
 @register_rule
-class CapabilityToolsListChangedRule(CapabilityBaseRule):
+class CapabilityToolsListChangedRule(CapabilityListChangedRule):
     """Advisory: the tools capability declares listChanged so clients can refresh a stale list.
 
     Optional per the spec — an mcpscore quality opinion, scored LOW: without
@@ -205,14 +238,11 @@ class CapabilityToolsListChangedRule(CapabilityBaseRule):
     rule_id = "capability_tools_list_changed"
     basis = "mcpscore recommendation; MCP 2025-11-25 Tools §Capabilities defines listChanged as optional"
     rule_order = 2
+    feature = "tools"
 
     @property
     def rule_name(self) -> str:
         return "Capabilities - Tools listChanged Implemented"
-
-    @property
-    def severity(self) -> RuleSeverity:
-        return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
         """Advisory check: verify that capabilities.tools declares listChanged.
@@ -264,7 +294,7 @@ class CapabilityPromptsPresentRule(CapabilityDeclarationRule):
 
 
 @register_rule
-class CapabilityPromptsListChangedRule(CapabilityBaseRule):
+class CapabilityPromptsListChangedRule(CapabilityListChangedRule):
     """Advisory: the prompts capability declares listChanged so clients can refresh a stale list.
 
     Optional per the spec — an mcpscore quality opinion, scored LOW: without
@@ -274,14 +304,11 @@ class CapabilityPromptsListChangedRule(CapabilityBaseRule):
     rule_id = "capability_prompts_list_changed"
     basis = "mcpscore recommendation; MCP 2025-11-25 Prompts §Capabilities defines listChanged as optional"
     rule_order = 4
+    feature = "prompts"
 
     @property
     def rule_name(self) -> str:
         return "Capabilities - Prompts listChanged Implemented"
-
-    @property
-    def severity(self) -> RuleSeverity:
-        return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
         """Advisory check: verify that capabilities.prompts declares listChanged.
@@ -333,7 +360,7 @@ class CapabilityResourcesPresentRule(CapabilityDeclarationRule):
 
 
 @register_rule
-class CapabilityResourcesListChangedRule(CapabilityBaseRule):
+class CapabilityResourcesListChangedRule(CapabilityListChangedRule):
     """Advisory: the resources capability declares listChanged so clients can refresh a stale list.
 
     Optional per the spec — an mcpscore quality opinion, scored LOW: without
@@ -343,14 +370,11 @@ class CapabilityResourcesListChangedRule(CapabilityBaseRule):
     rule_id = "capability_resources_list_changed"
     basis = "mcpscore recommendation; MCP 2025-11-25 Resources §Capabilities defines listChanged as optional"
     rule_order = 6
+    feature = "resources"
 
     @property
     def rule_name(self) -> str:
         return "Capabilities - Resources listChanged Implemented"
-
-    @property
-    def severity(self) -> RuleSeverity:
-        return RuleSeverity.LOW
 
     def _check_capabilities(self, capabilities: ServerCapabilities) -> RuleResult:
         """Advisory check: verify that capabilities.resources declares listChanged.

--- a/mcpscore/rules/retired.py
+++ b/mcpscore/rules/retired.py
@@ -1,0 +1,74 @@
+"""Registry of retired rule_ids.
+
+A `rule_id` is a public contract: it appears in every JSON report, in CI
+configuration that waives or asserts specific rules, and in stored audit
+history. When a rule stops running, the id must not simply vanish — someone
+reading an old report, or a CI job whose waiver silently stopped matching,
+needs to find out what happened to it.
+
+This registry is that record. It feeds the "Retired rules" table in
+`docs/rules.mdx` (see `scripts/generate_rules_doc.py`).
+
+**When to retire versus version-scope** — the distinction matters:
+
+- The rule was **wrong** (it asserted something the spec does not require, or
+  contradicted another rule): retire it. Keeping an incorrect judgement alive
+  in any form means continuing to publish it.
+- The rule was **right but the feature is era-bound** (the spec removed or
+  deprecated what it checked): do NOT retire it. Set `max_spec_version` so it
+  still judges servers on the revisions where the requirement held and is
+  skipped elsewhere — `BaseRule.applies_to` exists for exactly this, and the
+  rules reference shows the range. Deleting such a rule would silently stop
+  auditing servers that are still subject to it.
+
+Retired ids are **never reused**: a future rule that means something different
+must take a new id, or a consumer's waiver would start matching a check it
+never agreed to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetiredRule:
+    """A rule_id that no longer runs, and why.
+
+    Attributes:
+        rule_id: The retired identifier. Never reused.
+        version: mcpscore release that retired it.
+        severity: Severity it carried when it last ran, so an old report's
+            arithmetic can still be understood.
+        reason: One line, written for someone holding an old report.
+
+    """
+
+    rule_id: str
+    version: str
+    severity: str
+    reason: str
+
+
+RETIRED_RULES: tuple[RetiredRule, ...] = (
+    RetiredRule(
+        rule_id="capability_resources_subscribe",
+        version="1.1.0",
+        severity="HIGH",
+        reason=(
+            "Scored the absence of an optional capability — 2025-11-25 Resources §Capabilities calls "
+            "`subscribe` optional — and 2026-07-28 removes `resources/subscribe` outright (SEP-2575)."
+        ),
+    ),
+    RetiredRule(
+        rule_id="capability_logging_present",
+        version="1.1.0",
+        severity="MEDIUM",
+        reason=(
+            "Scored the absence of an optional capability, and contradicted "
+            "`readiness_2026_deprecated_features`, which fails a server for *declaring* `logging` "
+            "(deprecated by SEP-2577). No server could pass both."
+        ),
+    ),
+)
+"""Every retired rule_id, oldest first. Append only — entries are permanent."""

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-box/mcpscore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Audit an MCP server and get a scored, actionable quality report in seconds. Node wrapper for the Python mcpscore CLI.",
   "bin": {
     "mcpscore": "bin/mcpscore.js"
@@ -33,7 +33,7 @@
     "developer-tools"
   ],
   "mcpscore": {
-    "pythonVersion": "1.1.0"
+    "pythonVersion": "1.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.1.0"
+version = "1.1.1"
 description = "Audit an MCP server and get a scored, actionable quality report in seconds."
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/scripts/generate_rules_doc.py
+++ b/scripts/generate_rules_doc.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from mcpscore.rules import create_all_rules
 from mcpscore.rules.base import READINESS_GROUP, BaseRule
+from mcpscore.rules.retired import RETIRED_RULES
 from mcpscore.spec import DRAFT, LATEST
 
 HEADER = """\
@@ -49,6 +50,33 @@ def _applies_to(rule: BaseRule) -> str:
     return f"{low} – {high}"
 
 
+RETIRED_HEADER = """\
+## Retired rules
+
+These `rule_id`s no longer run. They are listed because a rule ID is a public
+contract: it appears in JSON reports you may have stored and in CI
+configuration that may still reference it. **Retired IDs are never reused.**
+
+A rule is retired only when it was *wrong*. A rule that was correct but applies
+only to certain spec revisions is not retired — it keeps its ID and gains a
+version range in the **Applies to** column above.
+
+If a report of yours shows one of these, its result was accurate for the
+mcpscore version that produced it; the check simply no longer exists.
+
+"""
+
+
+def _retired_table() -> list[str]:
+    """Render the retired-rule registry, or nothing when it is empty."""
+    if not RETIRED_RULES:
+        return []
+    lines = [RETIRED_HEADER, "| Rule ID | Retired in | Last severity | Why |\n", "|---|---|---|---|\n"]
+    lines.extend(f"| `{r.rule_id}` | {r.version} | {r.severity} | {r.reason} |\n" for r in RETIRED_RULES)
+    lines.append("\n")
+    return lines
+
+
 def generate() -> str:
     groups: dict[str, list[BaseRule]] = defaultdict(list)
     for rule in sorted(create_all_rules(), key=lambda r: r.sort_order):
@@ -68,6 +96,7 @@ def generate() -> str:
             for rule in rules
         )
         lines.append("\n")
+    lines.extend(_retired_table())
     # Single trailing newline at EOF (keeps the end-of-file-fixer hook happy).
     return "".join(lines).rstrip("\n") + "\n"
 

--- a/tests/test_capabilities_rules.py
+++ b/tests/test_capabilities_rules.py
@@ -4,7 +4,7 @@ from mcp_types import ResourcesCapability
 from pydantic import BaseModel
 
 from mcpscore.rules import AuditData, RuleSeverity
-from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
 from mcpscore.rules.capabilities import (
     CapabilityPromptsListChangedRule,
     CapabilityPromptsPresentRule,
@@ -187,3 +187,40 @@ class TestListingNeverAttempted:
         """The default is 'not attempted', so no rule can fail on absent data."""
         for rule_cls, _ in DECLARATION_RULES:
             assert rule_cls().skip_reason(AuditData()) == SKIP_REASON_INSUFFICIENT_DATA
+
+
+class TestListChangedAdvisoryScope:
+    """The advisory only judges a feature the server actually offers.
+
+    From the 2026-07-29 registry sweep: 2,798 servers failed
+    `capability_prompts_list_changed` with no prompts at all, and 2,582 failed
+    the resources one with no resources — penalised for not announcing changes
+    to something they do not have.
+    """
+
+    def test_absent_feature_is_not_applicable(self, capabilities_missing):
+        for rule_cls in (
+            CapabilityToolsListChangedRule,
+            CapabilityPromptsListChangedRule,
+            CapabilityResourcesListChangedRule,
+        ):
+            assert rule_cls().skip_reason(AuditData(capabilities=capabilities_missing)) == SKIP_REASON_NOT_APPLICABLE
+
+    def test_declared_feature_is_still_judged(self, capabilities_full):
+        """The signal we keep: the feature exists, so the advice applies."""
+        data = AuditData(capabilities=capabilities_full)
+        for rule_cls in (
+            CapabilityToolsListChangedRule,
+            CapabilityPromptsListChangedRule,
+            CapabilityResourcesListChangedRule,
+        ):
+            assert rule_cls().skip_reason(data) is None
+            assert rule_cls().check(data).passed
+
+    def test_declared_but_disabled_still_fails(self, capabilities_full):
+        caps = replace(capabilities_full, tools=replace(capabilities_full.tools, list_changed=False))
+        rule = CapabilityToolsListChangedRule()
+        data = AuditData(capabilities=caps)
+
+        assert rule.skip_reason(data) is None
+        assert not rule.check(data).passed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1156,6 +1156,47 @@ class TestAuthCliFlow:
         assert "rejected" not in reason
         assert "rejected" not in caplog.text
 
+    async def test_probe_observed_gate_triggers_partial_audit(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        """A gate the *probes* saw is enough, even when the session died otherwise.
+
+        The shape behind 708 of 9,723 registry servers (2026-07-29 sweep): no
+        legacy endpoint, so the handshake fails on 405 rather than 401, while
+        the probes hold the challenge. Before this, they reported as
+        unreachable.
+        """
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+        from mcpscore.probes import PROBE_UNAUTHENTICATED, ProbeOutcome, ProbeResult
+
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://gated.example/mcp"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        # 405 from the SSE fallback — not an auth reason.
+        mock_client.last_connection_error = ConnectionFailure(reason=ConnectionErrorReason.HTTP_ERROR, status_code=405)
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+        mock_auditor.last_probes = {
+            PROBE_UNAUTHENTICATED: ProbeResult(
+                PROBE_UNAUTHENTICATED,
+                ProbeOutcome.SUPPORTED,
+                {"http_status": 401, "www_authenticate": "Bearer"},
+            )
+        }
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        mock_auditor.audit_partial.assert_awaited_once()
+        reason = mock_auditor.audit_partial.await_args.kwargs["reason"]
+        # The gate's status, not the 405 that ended the session.
+        assert "HTTP 401" in reason
+        assert "405" not in reason
+
     async def test_non_auth_failure_still_exits_2(
         self,
         monkeypatch: MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1197,6 +1197,69 @@ class TestAuthCliFlow:
         assert "HTTP 401" in reason
         assert "405" not in reason
 
+    async def test_probe_observed_gate_does_not_blame_the_credential(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        """A token is not "rejected" when the session never carried it.
+
+        The gate is observed by an anonymous probe (it strips Authorization),
+        so a 401 there says the endpoint is gated and nothing about the
+        caller's token. With the session dying on 405, saying "rejected
+        credentials" would send the user to re-issue a working token.
+        """
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+        from mcpscore.probes import PROBE_UNAUTHENTICATED, ProbeOutcome, ProbeResult
+
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://gated.example/mcp", "--token", "probably-fine"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.last_connection_error = ConnectionFailure(reason=ConnectionErrorReason.HTTP_ERROR, status_code=405)
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+        mock_auditor.last_probes = {
+            PROBE_UNAUTHENTICATED: ProbeResult(
+                PROBE_UNAUTHENTICATED, ProbeOutcome.SUPPORTED, {"http_status": 401, "www_authenticate": "Bearer"}
+            )
+        }
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        reason = mock_auditor.audit_partial.await_args.kwargs["reason"]
+        assert "rejected" not in reason.lower()
+        assert "never exercised" in reason
+        assert "HTTP 401" in reason  # the gate
+        assert "405" in reason  # why the session failed, for diagnosis
+
+    async def test_session_401_with_a_token_is_still_a_rejection(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        """The genuine rejection case must keep its wording."""
+        from mcpscore.mcp_client import ConnectionErrorReason, ConnectionFailure
+
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://gated.example/mcp", "--token", "stale"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_client.last_connection_error = ConnectionFailure(
+            reason=ConnectionErrorReason.UNAUTHORIZED, status_code=401
+        )
+        mock_auditor.audit_modern_only = AsyncMock(return_value=False)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        reason = mock_auditor.audit_partial.await_args.kwargs["reason"]
+        assert "rejected the provided credentials" in reason
+
     async def test_non_auth_failure_still_exits_2(
         self,
         monkeypatch: MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,10 @@ def mock_auditor() -> MagicMock:
     auditor.audit = AsyncMock(return_value=(85, 100))
     auditor.audit_modern_only = AsyncMock(return_value=False)
     auditor.get_audit_report = MagicMock(return_value=_report_payload())
+    # Instance attributes are not on the spec, so they must be set explicitly or
+    # every access raises AttributeError. `last_probes` mirrors a fresh auditor:
+    # no probe observations, i.e. no evidence of an auth gate.
+    auditor.last_probes = None
     return auditor
 
 

--- a/tests/test_modern_only_audit.py
+++ b/tests/test_modern_only_audit.py
@@ -317,7 +317,7 @@ class TestAuditorReuseDoesNotLeakState:
 
 # --- Partial audit (auth-gated servers) --------------------------------------
 
-from mcpscore.probes import PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED  # noqa: E402
+from mcpscore.probes import PROBE_AUTH_METADATA, PROBE_UNAUTHENTICATED, observed_auth_status  # noqa: E402
 
 
 def _auth_gated_probe_results() -> dict[str, ProbeResult]:
@@ -468,3 +468,53 @@ async def test_partial_audit_never_promotes_readiness(stub_probes, monkeypatch: 
     readiness_ids = {r["rule_id"] for r in report["readiness"]["results"]}
     main_ids = {r["rule_id"] for r in report["results"]}
     assert not (readiness_ids & main_ids)
+
+
+class TestProbeEvidenceSurvivesDecline:
+    """`audit_modern_only` keeps its observations even when it declines.
+
+    Regression for the registry sweep of 2026-07-29: 708 of 9,723 registry
+    servers are auth-gated but fail the *legacy* handshake on something other
+    than 401 (typically 405 from the SSE fallback). The probes saw the 401
+    challenge and even fetched the RFC 9728 metadata, but the observations were
+    discarded on the way out, so the CLI reported "Error connecting" instead of
+    the partial audit — on 29% of all gated servers.
+    """
+
+    async def test_probes_are_retained_when_modern_support_is_absent(
+        self, stub_probes, monkeypatch: pytest.MonkeyPatch
+    ):
+        results = not_applicable_results(reason="legacy-only server")
+        results[PROBE_UNAUTHENTICATED] = ProbeResult(
+            PROBE_UNAUTHENTICATED,
+            ProbeOutcome.SUPPORTED,
+            {"http_status": 401, "www_authenticate": 'Bearer resource_metadata="https://x.example/.well-known"'},
+        )
+        stub_probes(results)
+        monkeypatch.setattr(MCPAuditor, "_probe_tls_version", staticmethod(_fake_tls))
+
+        auditor = MCPAuditor()
+        assert await auditor.audit_modern_only(URL) is False
+        assert auditor.last_probes is not None
+        assert observed_auth_status(auditor.last_probes) == 401
+
+
+class TestObservedAuthStatus:
+    def test_reports_the_gate_status(self):
+        probes = {
+            PROBE_UNAUTHENTICATED: ProbeResult(PROBE_UNAUTHENTICATED, ProbeOutcome.SUPPORTED, {"http_status": 403})
+        }
+        assert observed_auth_status(probes) == 403
+
+    def test_ignores_non_gate_statuses(self):
+        for status in (200, 404, 405, 500):
+            probes = {
+                PROBE_UNAUTHENTICATED: ProbeResult(
+                    PROBE_UNAUTHENTICATED, ProbeOutcome.SUPPORTED, {"http_status": status}
+                )
+            }
+            assert observed_auth_status(probes) is None, status
+
+    def test_no_probes_is_no_evidence(self):
+        assert observed_auth_status(None) is None
+        assert observed_auth_status({}) is None

--- a/tests/test_retired_rules.py
+++ b/tests/test_retired_rules.py
@@ -14,6 +14,7 @@ from dataclasses import replace
 
 from mcpscore.rules import AuditData, create_all_rules
 from mcpscore.rules.base import READINESS_GROUP
+from mcpscore.rules.retired import RETIRED_RULES
 
 RETIRED_RULE_IDS = frozenset({"capability_logging_present", "capability_resources_subscribe"})
 """rule_id is a public contract: these are retired, never reused."""
@@ -63,3 +64,28 @@ def test_omitting_the_optional_subscribe_capability_costs_nothing(capabilities_f
     without_subscribe = replace(capabilities_full, resources=replace(capabilities_full.resources, subscribe=False))
 
     assert _capability_score(without_subscribe) == _capability_score(capabilities_full)
+
+
+class TestRetiredRegistry:
+    """The registry is the public record of retired IDs — it must stay honest.
+
+    It feeds the "Retired rules" table in docs/rules.mdx, which is what someone
+    holding an old report or a stale CI waiver reads to find out what happened.
+    """
+
+    def test_registry_matches_the_ids_this_release_retired(self):
+        assert {r.rule_id for r in RETIRED_RULES} == RETIRED_RULE_IDS
+
+    def test_no_retired_id_is_ever_reused(self):
+        """A new rule reusing a retired ID would silently match old CI waivers."""
+        live = {rule.rule_id for rule in create_all_rules()}
+        assert live.isdisjoint({r.rule_id for r in RETIRED_RULES})
+
+    def test_entries_are_unique_and_explained(self):
+        ids = [r.rule_id for r in RETIRED_RULES]
+        assert len(ids) == len(set(ids)), "an ID may be retired only once"
+        for entry in RETIRED_RULES:
+            assert entry.version, entry.rule_id
+            assert entry.severity, entry.rule_id
+            # The reason is read by someone holding a report, not by us.
+            assert len(entry.reason) > 40, entry.rule_id

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the CLI partial-audit decision path and scoring skips for thousands of registry servers; behavior is heavily tested but affects connection outcomes and reported scores.
> 
> **Overview**
> **Release 1.1.1** — registry-driven follow-ups after auditing ~9.7k MCP registry endpoints.
> 
> **Auth-gated partial audits** no longer require the legacy session to end in 401/403. When `audit_modern_only` runs probes but declines (no modern support), the CLI keeps `last_probes` and uses new `observed_auth_status()` on the anonymous unauthenticated probe. If that shows 401/403, it runs a partial audit instead of exit 2. Messaging uses the **gate** status (not e.g. 405 from SSE fallback), and “credentials rejected” only applies when the session itself was refused—not when a token was never exercised.
> 
> **Capability `listChanged` advisories** (`prompts`/`resources`, and shared `CapabilityListChangedRule`) now **skip as not-applicable** when that capability is absent, instead of failing tools-only servers.
> 
> **Retired `rule_id` registry** (`mcpscore/rules/retired.py`) documents IDs removed when rules were wrong; `generate_rules_doc.py` emits a **Retired rules** section in `docs/rules.mdx`. `AGENTS.md` clarifies active vs version-scoped vs retired lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce060f5160e5b6f89c62123596303e2853ff3a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->