### PR TITLE
Fixed the release script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: [--branch, main]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.8
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release script now waits for the index resolvers actually read.** It
+  polled `pypi.org/pypi/mcpscore/<version>/json`, which turns green before the
+  *simple index* has propagated — so 1.1.1 printed its smoke test while `uvx`
+  still reported "there is no version of mcpscore==1.1.1" for a release that
+  was already published. It now additionally waits until
+  `pypi.org/simple/mcpscore/` serves the version's files.
+
 ## [1.1.1] - 2026-07-29
 
 Follow-up to the 1.1.0 launch release, driven by a full sweep of the 9,723

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The local lint gate now runs the same hooks, at the same versions, as CI.**
+  `make lint` used the venv's ruff (floating `>=0.15.20`, resolving to 0.16.0)
+  while CI lints through pre-commit, pinned at 0.14.8 — so the two could not
+  agree. The gap was not theoretical: 0.14.8 requires a `# noqa: S310` on a
+  `urllib.request.Request(...)` line that 0.16.0 reports as an *unused* noqa
+  and `ruff --fix` silently deletes. The local gate went green having removed
+  exactly what CI demanded. Both are now pinned to 0.16.0 (`.pre-commit-config.yaml`
+  and an exact `ruff==` dev dependency, with a comment tying them together),
+  and `make lint` runs `pre-commit run --all-files` before its own working-tree
+  pass — the hooks catch what CI enforces, the ruff calls catch untracked files
+  the hooks cannot see.
+
 - **The release script now waits for the index resolvers actually read.** It
   polled `pypi.org/pypi/mcpscore/<version>/json`, which turns green before the
   *simple index* has propagated — so 1.1.1 printed its smoke test while `uvx`

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,17 @@ format: ## Auto-format code
 	uv run ruff check --fix
 	uv run ruff format
 
+.PHONY: precommit
+precommit: ## Run the pinned pre-commit hooks — the same gate CI's lint job runs
+	uv run pre-commit run --all-files
+
 .PHONY: lint
-lint: ## Lint code (no auto-fix)
+lint: precommit ## Lint code (no auto-fix): CI's hooks, then the working tree
+# `precommit` runs the hooks CI runs, at the pinned versions, over files git
+# TRACKS. The ruff calls below re-check the working tree, so an untracked file
+# is linted too. Both are needed: CI once failed on a `# noqa` that a newer,
+# unpinned local ruff had auto-removed, and CI once passed a file ruff had
+# never read because git did not track it.
 	uv run ruff check
 	uv run ruff format --check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,12 @@ dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
-    "ruff>=0.15.20",
+    # Exact, and kept equal to the ruff rev in .pre-commit-config.yaml:
+    # CI lints via pre-commit while `make lint` uses this one, so a version
+    # gap means the local gate cannot see what CI enforces. A floating pin
+    # (>=0.15.20) against pre-commit's 0.14.8 let `ruff --fix` strip a
+    # `# noqa: S310` that CI still required — green locally, red on push.
+    "ruff==0.16.0",
 ]
 
 [tool.uv]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -233,6 +233,41 @@ def create_release(version: str, notes: str, target: str) -> None:
     ok(f"GitHub Release v{version} created — publish workflow triggered")
 
 
+def wait_for_pypi_index(version: str) -> None:
+    """Poll PyPI's *simple index* until the release's files are resolvable.
+
+    Not `/pypi/<pkg>/<version>/json`: that metadata endpoint goes green before
+    the simple index has propagated, and the simple index is what `uv` and
+    `pip` resolve against. Waiting on the wrong one is why 1.1.1 printed a
+    smoke test that immediately failed with "there is no version of
+    mcpscore==1.1.1" for a release that was, in fact, published.
+    """
+    url = "https://pypi.org/simple/mcpscore/"
+    print(f"… waiting for the PyPI index to serve {version} (up to {REGISTRY_WAIT_SECONDS}s)")
+    deadline = time.monotonic() + REGISTRY_WAIT_SECONDS
+    request = urllib.request.Request(url, headers={"Accept": "application/vnd.pypi.simple.v1+json"})
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            with urllib.request.urlopen(  # noqa: S310 — fixed https registry URL
+                request, timeout=min(REGISTRY_REQUEST_TIMEOUT_SECONDS, remaining)
+            ) as response:
+                files = json.loads(response.read()).get("files", [])
+            if any(f"mcpscore-{version}-" in f.get("filename", "") for f in files):
+                ok(f"resolvable from the PyPI index ({version})")
+                return
+        except (TimeoutError, urllib.error.URLError, json.JSONDecodeError, KeyError):
+            # Expected while the index propagates; retry until the deadline.
+            pass
+        time.sleep(min(10, max(0, deadline - time.monotonic())))
+    fail(
+        f"PyPI served no files for {version} within {REGISTRY_WAIT_SECONDS}s ({url}) — "
+        f"check the workflow: https://github.com/{REPO}/actions/workflows/publish.yml"
+    )
+
+
 def wait_for_registry(registry: str, url: str, workflow: str) -> None:
     """Poll a registry until it reports the version, or fail after the deadline.
 
@@ -269,6 +304,9 @@ def wait_for_registry(registry: str, url: str, workflow: str) -> None:
 def wait_for_publish(version: str) -> None:
     """Wait for the release to appear on each targeted registry, then print a smoke test."""
     wait_for_registry("PyPI", f"https://pypi.org/pypi/mcpscore/{version}/json", "publish.yml")
+    # The metadata endpoint above can be green while resolvers still 404 —
+    # wait for the index they actually read before printing a smoke test.
+    wait_for_pypi_index(version)
     if is_prerelease(version):
         ok("npm skipped (pre-release publishes to PyPI only)")
         # --prerelease=allow: uv's pre-release exception covers only direct

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -4,6 +4,7 @@ The release script runs with real git/gh/network in production; here every
 external effect is stubbed so the decision logic is verified hermetically.
 """
 
+import json
 from pathlib import Path
 import subprocess
 import sys
@@ -322,8 +323,60 @@ class TestWaitForRegistry:
     def test_wait_for_publish_polls_both_registries(self, monkeypatch: pytest.MonkeyPatch):
         polled: list[str] = []
         monkeypatch.setattr(release, "wait_for_registry", lambda name, _url, _workflow: polled.append(name))
+        # Must be stubbed too, or the suite makes a real request to pypi.org and
+        # blocks for the full deadline on a version that does not exist.
+        monkeypatch.setattr(release, "wait_for_pypi_index", lambda version: polled.append(f"index:{version}"))
         release.wait_for_publish("1.2.3")
-        assert polled == ["PyPI", "npm"]
+        assert polled == ["PyPI", "index:1.2.3", "npm"]
+
+
+class TestWaitForPypiIndex:
+    """The metadata endpoint goes green before the index resolvers read.
+
+    1.1.1 was published, announced, and then `uvx mcpscore==1.1.1` reported "no
+    version of mcpscore==1.1.1" — the release had not reached the simple index
+    yet. The wait must key on the artifact list, not on metadata.
+    """
+
+    @staticmethod
+    def _index(*filenames: str):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps({"files": [{"filename": f} for f in filenames]}).encode()
+
+        return lambda _request, **_kwargs: FakeResponse()
+
+    def test_returns_once_the_version_has_files(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            release.urllib.request,
+            "urlopen",
+            self._index("mcpscore-1.2.3-py3-none-any.whl", "mcpscore-1.2.3.tar.gz"),
+        )
+        release.wait_for_pypi_index("1.2.3")  # must not raise
+
+    def test_a_different_version_is_not_a_match(self, monkeypatch: pytest.MonkeyPatch):
+        """The bug's shape: the index answers 200, just without this release."""
+        monkeypatch.setattr(release.urllib.request, "urlopen", self._index("mcpscore-1.1.0-py3-none-any.whl"))
+        clock = iter(range(0, 10_000, 60))
+        monkeypatch.setattr(release.time, "monotonic", lambda: next(clock))
+        monkeypatch.setattr(release.time, "sleep", lambda _seconds: None)
+        with pytest.raises(SystemExit):
+            release.wait_for_pypi_index("1.2.3")
+
+    def test_a_prefix_match_is_not_enough(self, monkeypatch: pytest.MonkeyPatch):
+        """`1.1.1` must not be satisfied by `1.1.10`'s artifacts."""
+        monkeypatch.setattr(release.urllib.request, "urlopen", self._index("mcpscore-1.1.10-py3-none-any.whl"))
+        clock = iter(range(0, 10_000, 60))
+        monkeypatch.setattr(release.time, "monotonic", lambda: next(clock))
+        monkeypatch.setattr(release.time, "sleep", lambda _seconds: None)
+        with pytest.raises(SystemExit):
+            release.wait_for_pypi_index("1.1.1")
 
 
 class TestMainDryRun:

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.15.20" },
+    { name = "ruff", specifier = "==0.16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes affect dev tooling, lockfile, and the maintainer release script only—not the MCP audit runtime or public API.
> 
> **Overview**
> **Aligns local lint with CI** so `make lint` and pre-commit use the same **ruff 0.16.0** (pre-commit was 0.14.8; dev deps were a floating pin). Adds a **`precommit`** Make target and runs **`pre-commit run --all-files`** before the existing working-tree `ruff` pass so tracked-hook rules match CI while untracked files still get checked.
> 
> **Fixes premature post-release smoke tests** by adding **`wait_for_pypi_index`**, which polls PyPI’s **simple index** for the release’s wheel/sdist filenames after the metadata JSON endpoint goes green—matching what `uv`/`pip` resolve. **`wait_for_publish`** now calls it before printing smoke-test commands; tests cover exact version matching and prefix false positives (e.g. `1.1.10` vs `1.1.1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b25befb81df09800af94ed460a91131ceb3584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->