### PR TITLE
Resource catalog rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Three resource-catalog rules validate absolute resource URIs, non-blank
+  resource names, and non-negative declared byte sizes.
+
 ## [1.1.1] - 2026-07-29
 
 Follow-up to the 1.1.0 launch release, driven by a full sweep of the 9,723

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -84,6 +84,9 @@ Every rule mcpscore runs, generated from the rule registry
 
 | Rule ID | Name | Severity | Weight | Applies to |
 |---|---|---|---|---|
+| `resources_uris_valid` | Resources - All resource URIs must be valid | HIGH | 3 | all versions |
+| `resources_names_present` | Resources - All resources must have a name | MEDIUM | 2 | all versions |
+| `resources_sizes_valid` | Resources - Declared sizes must be valid | MEDIUM | 2 | all versions |
 | `resources_description_present` | Resources - All resources should have a description | MEDIUM | 2 | all versions |
 
 ## Prompts

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -64,6 +64,9 @@ from .readiness import (
 from .registry import RuleRegistry, create_all_rules
 from .resources import (
     ResourcesDescriptionPresentRule,
+    ResourcesNamesPresentRule,
+    ResourcesSizesValidRule,
+    ResourcesUrisValidRule,
 )
 from .security import (
     ErrorDataLeakRule,
@@ -126,6 +129,9 @@ __all__ = (
     "PromptsDescriptionPresentRule",
     "RemovedMethodsReadinessRule",
     "ResourcesDescriptionPresentRule",
+    "ResourcesNamesPresentRule",
+    "ResourcesSizesValidRule",
+    "ResourcesUrisValidRule",
     "ResultTypeReadinessRule",
     "RuleRegistry",
     "RuleResult",

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -1,9 +1,15 @@
 from abc import abstractmethod
+import re
+from urllib.parse import urlsplit
 
 from mcp_types import Resource
 
 from .base import BaseRule, RuleResult, RuleSeverity, requires_fields
 from .registry import register_rule
+
+_URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
+_URI_CHARACTER_RE = re.compile(r"^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+$")
+_INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 
 
 class ResourcesBaseRule(BaseRule):
@@ -55,12 +61,136 @@ class ResourcesBaseRule(BaseRule):
 
 
 @register_rule
+class ResourcesUrisValidRule(ResourcesBaseRule):
+    """High check: Verify that every resource has a valid absolute URI."""
+
+    rule_id = "resources_uris_valid"
+    basis = "MCP 2026-07-28 Resources §Resource (uri is the resource's unique identifier)"
+    rule_order = 1
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources - All resource URIs must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_resources(self, resources: list[Resource]) -> RuleResult:
+        """Verify that every resource URI is absolute and syntactically valid."""
+        invalid_resource_uris = [
+            {"name": resource.name, "uri": resource.uri}
+            for resource in resources
+            if not _is_valid_absolute_uri(resource.uri)
+        ]
+        passed = not invalid_resource_uris
+        message = (
+            "✅ All resource URIs are valid"
+            if passed
+            else f"❌ Number of resources with invalid URIs: {len(invalid_resource_uris)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"invalid_resource_uris": invalid_resource_uris},
+        )
+
+
+def _is_valid_absolute_uri(value: str) -> bool:
+    """Return whether a value is an absolute URI with a valid scheme."""
+    # urlsplit accepts almost any string, so the character regex does the real
+    # RFC 3986 charset enforcement (spaces, control chars, raw non-ASCII).
+    if not value or _URI_CHARACTER_RE.fullmatch(value) is None or _INVALID_PERCENT_ESCAPE_RE.search(value) is not None:
+        return False
+    try:
+        parsed = urlsplit(value)
+        _ = parsed.port  # urlsplit is lazy: only this access validates the port
+    except ValueError:
+        return False
+    return bool(parsed.scheme and _URI_SCHEME_RE.fullmatch(parsed.scheme))
+
+
+@register_rule
+class ResourcesNamesPresentRule(ResourcesBaseRule):
+    """Medium check: Verify that every resource has a non-blank name."""
+
+    rule_id = "resources_names_present"
+    basis = "MCP 2026-07-28 Resources §Resource (name)"
+    rule_order = 2
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources - All resources must have a name"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_resources(self, resources: list[Resource]) -> RuleResult:
+        """Verify that every resource name contains visible text."""
+        resources_without_name = [resource.uri for resource in resources if not resource.name.strip()]
+        passed = not resources_without_name
+        message = (
+            "✅ All resources have a name"
+            if passed
+            else f"❌ Number of resources without a name: {len(resources_without_name)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"resources_without_name": resources_without_name},
+        )
+
+
+@register_rule
+class ResourcesSizesValidRule(ResourcesBaseRule):
+    """Medium check: Verify that supplied resource sizes are non-negative."""
+
+    rule_id = "resources_sizes_valid"
+    basis = "MCP 2026-07-28 Resources §Resource (size is the optional size in bytes)"
+    rule_order = 3
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources - Declared sizes must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_resources(self, resources: list[Resource]) -> RuleResult:
+        """Verify that every supplied byte size is non-negative."""
+        resources_with_invalid_size = [
+            {"name": resource.name, "size": resource.size}
+            for resource in resources
+            if resource.size is not None and resource.size < 0
+        ]
+        passed = not resources_with_invalid_size
+        message = (
+            "✅ All declared resource sizes are valid"
+            if passed
+            else f"❌ Number of resources with invalid sizes: {len(resources_with_invalid_size)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"resources_with_invalid_size": resources_with_invalid_size},
+        )
+
+
+@register_rule
 class ResourcesDescriptionPresentRule(ResourcesBaseRule):
     """Medium check: Verify that all declared resources have a description."""
 
     rule_id = "resources_description_present"
     basis = "MCP 2025-11-25 Resources §Resource (description)"
-    rule_order = 1
+    rule_order = 4
 
     @property
     def rule_name(self) -> str:

--- a/tests/test_resources_rules.py
+++ b/tests/test_resources_rules.py
@@ -2,12 +2,100 @@
 
 from mcp_types import Resource
 
-from mcpscore.rules import AuditData, ResourcesDescriptionPresentRule, RuleSeverity
+from mcpscore.rules import (
+    AuditData,
+    ResourcesDescriptionPresentRule,
+    ResourcesNamesPresentRule,
+    ResourcesSizesValidRule,
+    ResourcesUrisValidRule,
+    RuleSeverity,
+)
 
 
-def _resource(name: str, description: str | None) -> Resource:
-    # model_validate coerces the str uri to AnyUrl (the constructor wants AnyUrl).
-    return Resource.model_validate({"name": name, "uri": f"file:///{name}", "description": description})
+def _resource(
+    name: str,
+    description: str | None = "Description",
+    *,
+    uri: str | None = None,
+    size: int | None = None,
+) -> Resource:
+    return Resource(name=name, uri=uri if uri is not None else f"file:///{name}", description=description, size=size)
+
+
+class TestResourcesUrisValidRule:
+    def test_rule_properties(self) -> None:
+        rule = ResourcesUrisValidRule()
+        assert rule.rule_id == "resources_uris_valid"
+        assert rule.severity == RuleSeverity.HIGH
+        assert rule.group_name == "resources"
+
+    def test_absolute_standard_and_custom_uris_pass(self) -> None:
+        result = ResourcesUrisValidRule().check(
+            AuditData(
+                resources=[
+                    _resource("file", uri="file:///project/readme.md"),
+                    _resource("web", uri="https://example.com/resource"),
+                    _resource("custom", uri="example+db:records/42"),
+                ]
+            )
+        )
+        assert result.passed is True
+        assert result.details == {"invalid_resource_uris": []}
+
+    def test_relative_malformed_and_unescaped_character_uris_fail(self) -> None:
+        result = ResourcesUrisValidRule().check(
+            AuditData(
+                resources=[
+                    _resource("relative", uri="docs/readme.md"),
+                    _resource("port", uri="https://example.com:bad/resource"),
+                    _resource("control", uri="file:///readme\n.md"),
+                    _resource("space", uri="file:///project/my file.md"),
+                    _resource("escape", uri="file:///project/%ZZ"),
+                ]
+            )
+        )
+        assert result.passed is False
+        assert result.details is not None
+        assert {item["name"] for item in result.details["invalid_resource_uris"]} == {
+            "relative",
+            "port",
+            "control",
+            "space",
+            "escape",
+        }
+
+
+class TestResourcesNamesPresentRule:
+    def test_non_blank_names_pass(self) -> None:
+        result = ResourcesNamesPresentRule().check(AuditData(resources=[_resource("README"), _resource("Schema")]))
+        assert result.passed is True
+        assert result.details == {"resources_without_name": []}
+
+    def test_blank_names_fail_and_report_uris(self) -> None:
+        result = ResourcesNamesPresentRule().check(
+            AuditData(
+                resources=[
+                    _resource("", uri="file:///empty"),
+                    _resource("   ", uri="file:///blank"),
+                ]
+            )
+        )
+        assert result.passed is False
+        assert result.details == {"resources_without_name": ["file:///empty", "file:///blank"]}
+
+
+class TestResourcesSizesValidRule:
+    def test_absent_zero_and_positive_sizes_pass(self) -> None:
+        result = ResourcesSizesValidRule().check(
+            AuditData(resources=[_resource("unknown"), _resource("empty", size=0), _resource("data", size=42)])
+        )
+        assert result.passed is True
+        assert result.details == {"resources_with_invalid_size": []}
+
+    def test_negative_size_fails(self) -> None:
+        result = ResourcesSizesValidRule().check(AuditData(resources=[_resource("bad", size=-1)]))
+        assert result.passed is False
+        assert result.details == {"resources_with_invalid_size": [{"name": "bad", "size": -1}]}
 
 
 class TestResourcesDescriptionPresentRule:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive audit rules on declared resource metadata only; no auth, transport, or scoring-engine changes beyond a higher max score for servers that list resources.
> 
> **Overview**
> Adds **three resource-quality audit rules** that run when a server declares resources (same optional-capability pattern as existing resource rules: no resources → pass as not applicable).
> 
> **`resources_uris_valid` (HIGH)** rejects relative URIs, bad ports, control characters, spaces, and invalid percent-escapes via RFC 3986-style checks on top of `urlsplit`.
> 
> **`resources_names_present` (MEDIUM)** requires every resource name to be non-blank after stripping.
> 
> **`resources_sizes_valid` (MEDIUM)** fails when an optional `size` is present but negative; absent or zero/positive sizes pass.
> 
> The rules are registered and exported, documented in `docs/rules.mdx`, noted in the changelog, and **`resources_description_present`** is reordered to `rule_order` 4. Tests cover pass/fail cases and the URI helper edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2956b923b9a76a8c012f36f8501ce3b5a6ddbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->