### PR TITLE
Add new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Three resource-catalog rules validate absolute resource URIs, non-blank
   resource names, and non-negative declared byte sizes.
+- Four catalog-validation rules check resource MIME types and annotations, plus
+  unique and non-blank argument names within prompts.
+- Four MCP 2026 tool-schema rules validate `x-mcp-header` names, uniqueness,
+  primitive parameter types, and static reachability without invoking tools.
 
 ## [1.1.1] - 2026-07-29
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -73,6 +73,10 @@ Every rule mcpscore runs, generated from the rule registry
 | `tools_output_schema_valid` | Tools - All tools must have a valid output schema | HIGH | 3 | all versions |
 | `tools_annotations_present` | Tools - All tools should declare behavior annotations | MEDIUM | 2 | all versions |
 | `tools_execution_consistent` | Tools - Task Execution Backed by Tasks Capability | MEDIUM | 2 | 2025-11-25 – … |
+| `tools_mcp_headers_valid_names` | Tools - MCP header names must be valid | HIGH | 3 | 2026-07-28 – … |
+| `tools_mcp_headers_unique` | Tools - MCP header names must be unique | HIGH | 3 | 2026-07-28 – … |
+| `tools_mcp_headers_primitive_types` | Tools - MCP headers must annotate supported primitive types | HIGH | 3 | 2026-07-28 – … |
+| `tools_mcp_headers_statically_reachable` | Tools - MCP header parameters must be statically reachable | HIGH | 3 | 2026-07-28 – … |
 
 ## Transport
 
@@ -87,12 +91,16 @@ Every rule mcpscore runs, generated from the rule registry
 | `resources_uris_valid` | Resources - All resource URIs must be valid | HIGH | 3 | all versions |
 | `resources_names_present` | Resources - All resources must have a name | MEDIUM | 2 | all versions |
 | `resources_sizes_valid` | Resources - Declared sizes must be valid | MEDIUM | 2 | all versions |
+| `resources_mime_types_valid` | Resources - Declared MIME types must be valid | MEDIUM | 2 | all versions |
+| `resources_annotations_valid` | Resources - Declared annotations must be valid | MEDIUM | 2 | all versions |
 | `resources_description_present` | Resources - All resources should have a description | MEDIUM | 2 | all versions |
 
 ## Prompts
 
 | Rule ID | Name | Severity | Weight | Applies to |
 |---|---|---|---|---|
+| `prompts_argument_names_unique` | Prompts - Argument names must be unique | HIGH | 3 | all versions |
+| `prompts_argument_names_present` | Prompts - All arguments must have a name | MEDIUM | 2 | all versions |
 | `prompts_description_present` | Prompts - All prompts should have a description | MEDIUM | 2 | all versions |
 | `prompts_arguments_documented` | Prompts - All prompt arguments should be documented | LOW | 1 | all versions |
 

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -39,6 +39,8 @@ from .capabilities import (
     CapabilityToolsPresentRule,
 )
 from .prompts import (
+    PromptsArgumentNamesPresentRule,
+    PromptsArgumentNamesUniqueRule,
     PromptsArgumentsDocumentedRule,
     PromptsDescriptionPresentRule,
 )
@@ -63,7 +65,9 @@ from .readiness import (
 )
 from .registry import RuleRegistry, create_all_rules
 from .resources import (
+    ResourcesAnnotationsValidRule,
     ResourcesDescriptionPresentRule,
+    ResourcesMimeTypesValidRule,
     ResourcesNamesPresentRule,
     ResourcesSizesValidRule,
     ResourcesUrisValidRule,
@@ -87,6 +91,10 @@ from .tools import (
     ToolsDescriptionPresentRule,
     ToolsExecutionConsistentRule,
     ToolsInputSchemaValidRule,
+    ToolsMcpHeadersPrimitiveTypesRule,
+    ToolsMcpHeadersStaticallyReachableRule,
+    ToolsMcpHeadersUniqueRule,
+    ToolsMcpHeadersValidNamesRule,
     ToolsNamePresentRule,
     ToolsNamesUniqueRule,
     ToolsNamesValidFormatRule,
@@ -125,10 +133,14 @@ __all__ = (
     "MalformedRequestHandlingRule",
     "MetaValidationReadinessRule",
     "NoSessionIdReadinessRule",
+    "PromptsArgumentNamesPresentRule",
+    "PromptsArgumentNamesUniqueRule",
     "PromptsArgumentsDocumentedRule",
     "PromptsDescriptionPresentRule",
     "RemovedMethodsReadinessRule",
+    "ResourcesAnnotationsValidRule",
     "ResourcesDescriptionPresentRule",
+    "ResourcesMimeTypesValidRule",
     "ResourcesNamesPresentRule",
     "ResourcesSizesValidRule",
     "ResourcesUrisValidRule",
@@ -153,6 +165,10 @@ __all__ = (
     "ToolsDescriptionPresentRule",
     "ToolsExecutionConsistentRule",
     "ToolsInputSchemaValidRule",
+    "ToolsMcpHeadersPrimitiveTypesRule",
+    "ToolsMcpHeadersStaticallyReachableRule",
+    "ToolsMcpHeadersUniqueRule",
+    "ToolsMcpHeadersValidNamesRule",
     "ToolsNamePresentRule",
     "ToolsNamesUniqueRule",
     "ToolsNamesValidFormatRule",

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -55,12 +55,95 @@ class PromptsBaseRule(BaseRule):
 
 
 @register_rule
+class PromptsArgumentNamesUniqueRule(PromptsBaseRule):
+    """High check: Verify that argument names are unique within each prompt.
+
+    The spec text imposes no explicit uniqueness requirement on argument
+    names; the rule enforces the mechanism instead: ``prompts/get`` passes
+    arguments as a JSON object keyed by name, so only one of two same-named
+    declarations can ever be addressed.
+    """
+
+    rule_id = "prompts_argument_names_unique"
+    basis = "MCP 2026-07-28 Prompts §Getting a Prompt (prompts/get arguments are keyed by name)"
+    rule_order = 1
+
+    @property
+    def rule_name(self) -> str:
+        return "Prompts - Argument names must be unique"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_prompts(self, prompts: list[Prompt]) -> RuleResult:
+        """Find duplicate argument names within each prompt."""
+        duplicate_arguments: list[str] = []
+        for prompt in prompts:
+            seen: set[str] = set()
+            for argument in prompt.arguments or []:
+                if argument.name in seen:
+                    duplicate_arguments.append(f"{prompt.name}.{argument.name}")
+                seen.add(argument.name)
+
+        passed = not duplicate_arguments
+        message = (
+            "✅ All prompt argument names are unique"
+            if passed
+            else f"❌ Number of duplicate prompt arguments: {len(duplicate_arguments)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"duplicate_arguments": duplicate_arguments},
+        )
+
+
+@register_rule
+class PromptsArgumentNamesPresentRule(PromptsBaseRule):
+    """Medium check: Verify that every prompt argument has a non-blank name."""
+
+    rule_id = "prompts_argument_names_present"
+    basis = "MCP 2026-07-28 Prompts §Prompt (arguments)"
+    rule_order = 2
+
+    @property
+    def rule_name(self) -> str:
+        return "Prompts - All arguments must have a name"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_prompts(self, prompts: list[Prompt]) -> RuleResult:
+        """Find prompt arguments whose names contain no visible text."""
+        prompts_with_unnamed_arguments = [
+            prompt.name for prompt in prompts if any(not argument.name.strip() for argument in (prompt.arguments or []))
+        ]
+        passed = not prompts_with_unnamed_arguments
+        message = (
+            "✅ All prompt arguments have a name"
+            if passed
+            else f"❌ Number of prompts with unnamed arguments: {len(prompts_with_unnamed_arguments)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"prompts_with_unnamed_arguments": prompts_with_unnamed_arguments},
+        )
+
+
+@register_rule
 class PromptsDescriptionPresentRule(PromptsBaseRule):
     """Medium check: Verify that all declared prompts have a description."""
 
     rule_id = "prompts_description_present"
     basis = "MCP 2025-11-25 Prompts §Prompt (description)"
-    rule_order = 1
+    rule_order = 3
 
     @property
     def rule_name(self) -> str:
@@ -111,7 +194,7 @@ class PromptsArgumentsDocumentedRule(PromptsBaseRule):
 
     rule_id = "prompts_arguments_documented"
     basis = "MCP 2025-11-25 Prompts §Prompt (arguments: name, description, required)"
-    rule_order = 2
+    rule_order = 4
 
     @property
     def rule_name(self) -> str:

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from datetime import datetime
 import re
 from urllib.parse import urlsplit
 
@@ -10,6 +11,13 @@ from .registry import register_rule
 _URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
 _URI_CHARACTER_RE = re.compile(r"^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+$")
 _INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_MEDIA_TYPE_ATOM_PATTERN = r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+"
+_MEDIA_TYPE_QUOTED_VALUE = r'"(?:[\t !#-\[\]-~]|\\[\t -~])*"'
+_MEDIA_TYPE_RE = re.compile(
+    rf"^{_MEDIA_TYPE_ATOM_PATTERN}/{_MEDIA_TYPE_ATOM_PATTERN}"
+    rf"(?:[ \t]*;[ \t]*{_MEDIA_TYPE_ATOM_PATTERN}="
+    rf"(?:{_MEDIA_TYPE_ATOM_PATTERN}|{_MEDIA_TYPE_QUOTED_VALUE}))*$"
+)
 
 
 class ResourcesBaseRule(BaseRule):
@@ -185,12 +193,101 @@ class ResourcesSizesValidRule(ResourcesBaseRule):
 
 
 @register_rule
+class ResourcesMimeTypesValidRule(ResourcesBaseRule):
+    """Medium check: Verify that supplied resource MIME types are valid."""
+
+    rule_id = "resources_mime_types_valid"
+    basis = "MCP 2026-07-28 Resources §Resource (mimeType)"
+    rule_order = 4
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources - Declared MIME types must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_resources(self, resources: list[Resource]) -> RuleResult:
+        """Verify that every supplied MIME type has a type and subtype."""
+        resources_with_invalid_mime_type = [
+            {"name": resource.name, "mime_type": resource.mime_type}
+            for resource in resources
+            if resource.mime_type is not None and _MEDIA_TYPE_RE.fullmatch(resource.mime_type) is None
+        ]
+        passed = not resources_with_invalid_mime_type
+        message = (
+            "✅ All declared resource MIME types are valid"
+            if passed
+            else f"❌ Number of resources with invalid MIME types: {len(resources_with_invalid_mime_type)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"resources_with_invalid_mime_type": resources_with_invalid_mime_type},
+        )
+
+
+@register_rule
+class ResourcesAnnotationsValidRule(ResourcesBaseRule):
+    """Medium check: Verify that resource annotations are valid."""
+
+    rule_id = "resources_annotations_valid"
+    basis = "MCP 2026-07-28 Resources §Annotations (audience, priority, lastModified)"
+    rule_order = 5
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources - Declared annotations must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_resources(self, resources: list[Resource]) -> RuleResult:
+        """Verify annotation values not already constrained by the SDK model."""
+        resources_with_invalid_annotations = [
+            resource.name
+            for resource in resources
+            if resource.annotations is not None
+            and resource.annotations.last_modified is not None
+            and not _is_iso_8601(resource.annotations.last_modified)
+        ]
+        passed = not resources_with_invalid_annotations
+        message = (
+            "✅ All declared resource annotations are valid"
+            if passed
+            else f"❌ Number of resources with invalid annotations: {len(resources_with_invalid_annotations)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"resources_with_invalid_annotations": resources_with_invalid_annotations},
+        )
+
+
+def _is_iso_8601(value: str) -> bool:
+    """Return whether a value is a non-blank ISO 8601 date or timestamp."""
+    if not value or value != value.strip():
+        return False
+    try:
+        datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+@register_rule
 class ResourcesDescriptionPresentRule(ResourcesBaseRule):
     """Medium check: Verify that all declared resources have a description."""
 
     rule_id = "resources_description_present"
     basis = "MCP 2025-11-25 Resources §Resource (description)"
-    rule_order = 4
+    rule_order = 6
 
     @property
     def rule_name(self) -> str:

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -334,6 +334,56 @@ class ToolsDescriptionPresentRule(ToolsBaseRule):
 
 
 _VALID_JSON_TYPES = {"string", "number", "integer", "boolean", "array", "object", "null"}
+_HTTP_FIELD_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+# Deliberately strict: a JSON Schema type array (e.g. ["string", "null"]) also
+# fails, even though the transport spec's client-behavior table contemplates
+# null parameter values. The spec's constraint text names only the three bare
+# primitives, so clients reading it literally will reject annotated union
+# types too — flagging them matches the strictest conforming client.
+_MCP_HEADER_PRIMITIVE_TYPES = {"integer", "string", "boolean"}
+
+
+def _mcp_header_annotations(schema: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collect every x-mcp-header annotation and its static reachability."""
+    annotations: list[dict[str, Any]] = []
+
+    def walk(node: Any, path: str, *, reachable: bool, properties_allowed: bool) -> None:
+        if isinstance(node, dict):
+            if "x-mcp-header" in node:
+                annotations.append(
+                    {
+                        "header": node["x-mcp-header"],
+                        "path": path,
+                        "type": node.get("type"),
+                        "reachable": reachable,
+                    }
+                )
+
+            for key, value in node.items():
+                if key == "properties" and isinstance(value, dict):
+                    for property_name, property_schema in value.items():
+                        property_path = f"{path}.properties.{property_name}"
+                        walk(
+                            property_schema,
+                            property_path,
+                            reachable=properties_allowed,
+                            properties_allowed=properties_allowed,
+                        )
+                elif isinstance(value, (dict, list)):
+                    walk(value, f"{path}.{key}", reachable=False, properties_allowed=False)
+        elif isinstance(node, list):
+            for index, item in enumerate(node):
+                walk(item, f"{path}[{index}]", reachable=False, properties_allowed=False)
+
+    walk(schema, "$", reachable=False, properties_allowed=True)
+    return annotations
+
+
+def _tool_mcp_header_annotations(tools: list[Tool]) -> list[dict[str, Any]]:
+    """Collect x-mcp-header annotations with their tool names."""
+    return [
+        {"tool": tool.name, **annotation} for tool in tools for annotation in _mcp_header_annotations(tool.input_schema)
+    ]
 
 
 def is_valid_schema(schema: dict[str, Any] | None) -> bool:
@@ -490,6 +540,164 @@ class ToolsOutputSchemaValidRule(ToolsBaseRule):
             message=message,
             details={"tools_with_invalid_output_schema": tools_with_invalid_output_schema},
         )
+
+
+class ToolsMcpHeadersBaseRule(ToolsBaseRule):
+    """Base class for 2026 x-mcp-header definition rules."""
+
+    min_spec_version = "2026-07-28"
+
+
+@register_rule
+class ToolsMcpHeadersValidNamesRule(ToolsMcpHeadersBaseRule):
+    """High check: Verify x-mcp-header values use HTTP field-name syntax."""
+
+    rule_id = "tools_mcp_headers_valid_names"
+    basis = "MCP 2026-07-28 Tools §Tool Definitions (x-mcp-header constraints)"
+    rule_order = 11
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools - MCP header names must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_tools(self, tools: list[Tool]) -> RuleResult:
+        """Find empty, non-string, or syntactically invalid header names."""
+        invalid_headers = [
+            annotation
+            for annotation in _tool_mcp_header_annotations(tools)
+            if not isinstance(annotation["header"], str) or _HTTP_FIELD_NAME_RE.fullmatch(annotation["header"]) is None
+        ]
+        return _mcp_header_result(
+            self,
+            invalid_headers,
+            "invalid_headers",
+            "All MCP header names are valid",
+            "MCP headers with invalid names",
+        )
+
+
+@register_rule
+class ToolsMcpHeadersUniqueRule(ToolsMcpHeadersBaseRule):
+    """High check: Verify x-mcp-header values are case-insensitively unique."""
+
+    rule_id = "tools_mcp_headers_unique"
+    basis = "MCP 2026-07-28 Tools §Tool Definitions (x-mcp-header constraints)"
+    rule_order = 12
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools - MCP header names must be unique"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_tools(self, tools: list[Tool]) -> RuleResult:
+        """Find duplicate header names within each tool input schema."""
+        annotations = _tool_mcp_header_annotations(tools)
+        counts = Counter(
+            (annotation["tool"], annotation["header"].casefold())
+            for annotation in annotations
+            if isinstance(annotation["header"], str)
+        )
+        duplicate_headers = [
+            annotation
+            for annotation in annotations
+            if isinstance(annotation["header"], str)
+            and counts[(annotation["tool"], annotation["header"].casefold())] > 1
+        ]
+        return _mcp_header_result(
+            self,
+            duplicate_headers,
+            "duplicate_headers",
+            "All MCP header names are unique",
+            "duplicate MCP header annotations",
+        )
+
+
+@register_rule
+class ToolsMcpHeadersPrimitiveTypesRule(ToolsMcpHeadersBaseRule):
+    """High check: Verify x-mcp-header appears only on allowed primitives."""
+
+    rule_id = "tools_mcp_headers_primitive_types"
+    basis = "MCP 2026-07-28 Tools §Tool Definitions (x-mcp-header primitive types)"
+    rule_order = 13
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools - MCP headers must annotate supported primitive types"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_tools(self, tools: list[Tool]) -> RuleResult:
+        """Find annotations on number, object, array, or untyped schemas."""
+        invalid_types = [
+            annotation
+            for annotation in _tool_mcp_header_annotations(tools)
+            if annotation["type"] not in _MCP_HEADER_PRIMITIVE_TYPES
+        ]
+        return _mcp_header_result(
+            self,
+            invalid_types,
+            "headers_with_invalid_types",
+            "All MCP headers annotate supported primitive types",
+            "MCP headers on unsupported types",
+        )
+
+
+@register_rule
+class ToolsMcpHeadersStaticallyReachableRule(ToolsMcpHeadersBaseRule):
+    """High check: Verify annotated properties are statically reachable."""
+
+    rule_id = "tools_mcp_headers_statically_reachable"
+    basis = "MCP 2026-07-28 Tools §Tool Definitions (x-mcp-header static reachability)"
+    rule_order = 14
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools - MCP header parameters must be statically reachable"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_tools(self, tools: list[Tool]) -> RuleResult:
+        """Find annotations reached through anything except properties chains."""
+        unreachable_headers = [
+            annotation for annotation in _tool_mcp_header_annotations(tools) if not annotation["reachable"]
+        ]
+        return _mcp_header_result(
+            self,
+            unreachable_headers,
+            "unreachable_headers",
+            "All MCP header parameters are statically reachable",
+            "statically unreachable MCP header parameters",
+        )
+
+
+def _mcp_header_result(
+    rule: BaseRule,
+    failures: list[dict[str, Any]],
+    details_key: str,
+    pass_message: str,
+    failure_label: str,
+) -> RuleResult:
+    """Build a consistent result for an x-mcp-header rule."""
+    passed = not failures
+    message = f"✅ {pass_message}" if passed else f"❌ Number of {failure_label}: {len(failures)}"
+    return RuleResult(
+        rule_name=rule.rule_name,
+        severity=rule.severity,
+        passed=passed,
+        message=message,
+        details={details_key: failures},
+    )
 
 
 # The behavior-describing hints from the MCP tool `annotations` object. The

--- a/tests/test_prompts_rules.py
+++ b/tests/test_prompts_rules.py
@@ -4,6 +4,8 @@ from mcp_types import Prompt, PromptArgument
 
 from mcpscore.rules import (
     AuditData,
+    PromptsArgumentNamesPresentRule,
+    PromptsArgumentNamesUniqueRule,
     PromptsArgumentsDocumentedRule,
     PromptsDescriptionPresentRule,
     RuleSeverity,
@@ -41,6 +43,62 @@ class TestPromptsDescriptionPresentRule:
         assert result.passed is False
         assert result.details is not None
         assert result.details["prompts_without_description"] == ["bad"]
+
+
+class TestPromptsArgumentNamesUniqueRule:
+    def test_unique_names_and_separate_prompt_scopes_pass(self) -> None:
+        result = PromptsArgumentNamesUniqueRule().check(
+            AuditData(
+                prompts=[
+                    _prompt("first", arguments=[PromptArgument(name="topic"), PromptArgument(name="format")]),
+                    _prompt("second", arguments=[PromptArgument(name="topic")]),
+                ]
+            )
+        )
+        assert result.passed is True
+        assert result.details == {"duplicate_arguments": []}
+
+    def test_duplicate_name_within_prompt_fails(self) -> None:
+        result = PromptsArgumentNamesUniqueRule().check(
+            AuditData(
+                prompts=[
+                    _prompt(
+                        "review",
+                        arguments=[PromptArgument(name="code"), PromptArgument(name="code")],
+                    )
+                ]
+            )
+        )
+        assert result.passed is False
+        assert result.details == {"duplicate_arguments": ["review.code"]}
+
+
+class TestPromptsArgumentNamesPresentRule:
+    def test_named_arguments_and_prompt_without_arguments_pass(self) -> None:
+        result = PromptsArgumentNamesPresentRule().check(
+            AuditData(
+                prompts=[
+                    _prompt("none"),
+                    _prompt("named", arguments=[PromptArgument(name="topic")]),
+                ]
+            )
+        )
+        assert result.passed is True
+        assert result.details == {"prompts_with_unnamed_arguments": []}
+
+    def test_blank_argument_name_fails_once_per_prompt(self) -> None:
+        result = PromptsArgumentNamesPresentRule().check(
+            AuditData(
+                prompts=[
+                    _prompt(
+                        "bad",
+                        arguments=[PromptArgument(name=""), PromptArgument(name="  ")],
+                    )
+                ]
+            )
+        )
+        assert result.passed is False
+        assert result.details == {"prompts_with_unnamed_arguments": ["bad"]}
 
 
 class TestPromptsArgumentsDocumentedRule:

--- a/tests/test_resources_rules.py
+++ b/tests/test_resources_rules.py
@@ -1,10 +1,12 @@
 """Tests for resource-quality rules."""
 
-from mcp_types import Resource
+from mcp_types import Annotations, Resource
 
 from mcpscore.rules import (
     AuditData,
+    ResourcesAnnotationsValidRule,
     ResourcesDescriptionPresentRule,
+    ResourcesMimeTypesValidRule,
     ResourcesNamesPresentRule,
     ResourcesSizesValidRule,
     ResourcesUrisValidRule,
@@ -18,8 +20,17 @@ def _resource(
     *,
     uri: str | None = None,
     size: int | None = None,
+    mime_type: str | None = None,
+    annotations: Annotations | None = None,
 ) -> Resource:
-    return Resource(name=name, uri=uri if uri is not None else f"file:///{name}", description=description, size=size)
+    return Resource(
+        name=name,
+        uri=uri if uri is not None else f"file:///{name}",
+        description=description,
+        size=size,
+        mime_type=mime_type,
+        annotations=annotations,
+    )
 
 
 class TestResourcesUrisValidRule:
@@ -96,6 +107,62 @@ class TestResourcesSizesValidRule:
         result = ResourcesSizesValidRule().check(AuditData(resources=[_resource("bad", size=-1)]))
         assert result.passed is False
         assert result.details == {"resources_with_invalid_size": [{"name": "bad", "size": -1}]}
+
+
+class TestResourcesMimeTypesValidRule:
+    def test_absent_and_valid_mime_types_pass(self) -> None:
+        result = ResourcesMimeTypesValidRule().check(
+            AuditData(
+                resources=[
+                    _resource("unknown"),
+                    _resource("text", mime_type="text/plain"),
+                    _resource("vendor", mime_type="application/vnd.example+json"),
+                    _resource("parameter", mime_type='text/plain; charset="utf-8"'),
+                ]
+            )
+        )
+        assert result.passed is True
+        assert result.details == {"resources_with_invalid_mime_type": []}
+
+    def test_invalid_mime_types_fail(self) -> None:
+        result = ResourcesMimeTypesValidRule().check(
+            AuditData(
+                resources=[
+                    _resource("missing-subtype", mime_type="text"),
+                    _resource("parameter", mime_type="text/plain; charset"),
+                    _resource("blank", mime_type=""),
+                ]
+            )
+        )
+        assert result.passed is False
+        assert result.details is not None
+        assert {item["name"] for item in result.details["resources_with_invalid_mime_type"]} == {
+            "missing-subtype",
+            "parameter",
+            "blank",
+        }
+
+
+class TestResourcesAnnotationsValidRule:
+    def test_absent_and_iso_8601_last_modified_pass(self) -> None:
+        result = ResourcesAnnotationsValidRule().check(
+            AuditData(
+                resources=[
+                    _resource("none"),
+                    _resource("date", annotations=Annotations(last_modified="2026-07-30")),
+                    _resource("timestamp", annotations=Annotations(last_modified="2026-07-30T10:15:30Z")),
+                ]
+            )
+        )
+        assert result.passed is True
+        assert result.details == {"resources_with_invalid_annotations": []}
+
+    def test_invalid_last_modified_fails(self) -> None:
+        result = ResourcesAnnotationsValidRule().check(
+            AuditData(resources=[_resource("bad", annotations=Annotations(last_modified="30 July 2026"))])
+        )
+        assert result.passed is False
+        assert result.details == {"resources_with_invalid_annotations": ["bad"]}
 
 
 class TestResourcesDescriptionPresentRule:

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -28,6 +28,10 @@ from mcpscore.rules.tools import (
     ToolsDescriptionPresentRule,
     ToolsExecutionConsistentRule,
     ToolsInputSchemaValidRule,
+    ToolsMcpHeadersPrimitiveTypesRule,
+    ToolsMcpHeadersStaticallyReachableRule,
+    ToolsMcpHeadersUniqueRule,
+    ToolsMcpHeadersValidNamesRule,
     ToolsNamePresentRule,
     ToolsNamesUniqueRule,
     ToolsNamesValidFormatRule,
@@ -889,6 +893,162 @@ class TestToolsOutputSchemaValidRule:
         assert result.passed is False
         assert result.details is not None
         assert len(result.details["tools_with_invalid_output_schema"]) == 1
+
+
+def _header_tool(name: str, input_schema: dict[str, Any]) -> Tool:
+    return Tool(name=name, input_schema=input_schema)
+
+
+class TestToolsMcpHeadersValidNamesRule:
+    def test_valid_and_absent_annotations_pass(self) -> None:
+        tools = [
+            _header_tool(
+                "valid",
+                {
+                    "type": "object",
+                    "properties": {
+                        "region": {"type": "string", "x-mcp-header": "Region"},
+                        "plain": {"type": "string"},
+                    },
+                },
+            ),
+            _header_tool("absent", {"type": "object", "properties": {}}),
+        ]
+        result = ToolsMcpHeadersValidNamesRule().check(AuditData(tools=tools))
+        assert result.passed is True
+        assert result.details == {"invalid_headers": []}
+
+    @pytest.mark.parametrize("header", ["", "not a token", "line\nbreak", 42])
+    def test_invalid_header_name_fails(self, header: object) -> None:
+        tool = _header_tool(
+            "bad",
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string", "x-mcp-header": header}},
+            },
+        )
+        result = ToolsMcpHeadersValidNamesRule().check(AuditData(tools=[tool]))
+        assert result.passed is False
+        assert result.details is not None
+        assert result.details["invalid_headers"][0]["path"] == "$.properties.value"
+
+
+class TestToolsMcpHeadersUniqueRule:
+    def test_names_are_case_insensitively_unique_within_a_tool(self) -> None:
+        tool = _header_tool(
+            "duplicate",
+            {
+                "type": "object",
+                "properties": {
+                    "first": {"type": "string", "x-mcp-header": "Region"},
+                    "second": {"type": "string", "x-mcp-header": "region"},
+                },
+            },
+        )
+        result = ToolsMcpHeadersUniqueRule().check(AuditData(tools=[tool]))
+        assert result.passed is False
+        assert result.details is not None
+        assert len(result.details["duplicate_headers"]) == 2
+
+    def test_same_header_name_in_different_tools_passes(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"region": {"type": "string", "x-mcp-header": "Region"}},
+        }
+        result = ToolsMcpHeadersUniqueRule().check(
+            AuditData(tools=[_header_tool("first", schema), _header_tool("second", schema)])
+        )
+        assert result.passed is True
+
+
+class TestToolsMcpHeadersPrimitiveTypesRule:
+    @pytest.mark.parametrize("parameter_type", ["string", "boolean", "integer"])
+    def test_allowed_primitive_type_passes(self, parameter_type: str) -> None:
+        tool = _header_tool(
+            "valid",
+            {
+                "type": "object",
+                "properties": {"value": {"type": parameter_type, "x-mcp-header": "Value"}},
+            },
+        )
+        assert ToolsMcpHeadersPrimitiveTypesRule().check(AuditData(tools=[tool])).passed
+
+    @pytest.mark.parametrize("parameter_type", ["number", "object", "array", None])
+    def test_unsupported_or_missing_type_fails(self, parameter_type: str | None) -> None:
+        property_schema: dict[str, Any] = {"x-mcp-header": "Value"}
+        if parameter_type is not None:
+            property_schema["type"] = parameter_type
+        tool = _header_tool(
+            "invalid",
+            {"type": "object", "properties": {"value": property_schema}},
+        )
+        result = ToolsMcpHeadersPrimitiveTypesRule().check(AuditData(tools=[tool]))
+        assert result.passed is False
+        assert result.details is not None
+        assert result.details["headers_with_invalid_types"][0]["type"] == parameter_type
+
+
+class TestToolsMcpHeadersStaticallyReachableRule:
+    def test_nested_properties_chain_passes(self) -> None:
+        tool = _header_tool(
+            "nested",
+            {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "object",
+                        "properties": {
+                            "region": {"type": "string", "x-mcp-header": "Region"},
+                        },
+                    }
+                },
+            },
+        )
+        assert ToolsMcpHeadersStaticallyReachableRule().check(AuditData(tools=[tool])).passed
+
+    @pytest.mark.parametrize(
+        ("schema", "expected_path"),
+        [
+            (
+                {"type": "object", "x-mcp-header": "Root", "properties": {}},
+                "$",
+            ),
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "type": "array",
+                            "items": {"type": "string", "x-mcp-header": "Item"},
+                        }
+                    },
+                },
+                "$.properties.values.items",
+            ),
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "oneOf": [
+                                {"type": "string", "x-mcp-header": "Variant"},
+                            ]
+                        }
+                    },
+                },
+                "$.properties.value.oneOf[0]",
+            ),
+        ],
+    )
+    def test_annotations_outside_properties_chain_fail(
+        self,
+        schema: dict[str, Any],
+        expected_path: str,
+    ) -> None:
+        result = ToolsMcpHeadersStaticallyReachableRule().check(AuditData(tools=[_header_tool("invalid", schema)]))
+        assert result.passed is False
+        assert result.details is not None
+        assert result.details["unreachable_headers"][0]["path"] == expected_path
 
 
 class TestToolsExecutionConsistentRule:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive read-only catalog validation with version-gated tool rules; no changes to auth, transport, or scoring engine behavior beyond a higher max score when new rules apply.
> 
> **Overview**
> Adds **eight new audit rules** to the main score: resource MIME type and annotation checks, prompt argument name presence/uniqueness, and four **MCP 2026-07-28** tool input-schema checks for `x-mcp-header` (HTTP field-name syntax, case-insensitive uniqueness per tool, allowed primitive types only, and static reachability via `properties` chains).
> 
> The header rules share schema-walking helpers in `tools.py` and apply only from spec **2026-07-28** onward; catalog rules apply to all versions. Existing prompt/resource rules are reordered; **CHANGELOG** and **`docs/rules.mdx`** list the new rule IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc3e05a517111e6a5e0487820e61627b8a9ac59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->