### PR TITLE
Add more rules & pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Complete paginated collection for tools, resources, and prompts, with cursor
+  loop detection and a page safety bound. Listings that could not be fetched
+  completely are reported in a new top-level `incomplete_listings` field, and
+  uniqueness rules (including the existing `tools_names_unique`) skip as
+  insufficient-data instead of judging a partial catalog.
+- Two uniqueness rules verify that resource URIs and prompt names remain unique
+  across their complete paginated listings.
 - Three resource-catalog rules validate absolute resource URIs, non-blank
   resource names, and non-negative declared byte sizes.
 - Four catalog-validation rules check resource MIME types and annotations, plus

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -94,6 +94,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `resources_mime_types_valid` | Resources - Declared MIME types must be valid | MEDIUM | 2 | all versions |
 | `resources_annotations_valid` | Resources - Declared annotations must be valid | MEDIUM | 2 | all versions |
 | `resources_description_present` | Resources - All resources should have a description | MEDIUM | 2 | all versions |
+| `resources_uris_unique` | Resources - Resource URIs must be unique | HIGH | 3 | all versions |
 
 ## Prompts
 
@@ -103,6 +104,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `prompts_argument_names_present` | Prompts - All arguments must have a name | MEDIUM | 2 | all versions |
 | `prompts_description_present` | Prompts - All prompts should have a description | MEDIUM | 2 | all versions |
 | `prompts_arguments_documented` | Prompts - All prompt arguments should be documented | LOW | 1 | all versions |
+| `prompts_names_unique` | Prompts - Prompt names must be unique | HIGH | 3 | all versions |
 
 ## Readiness rules (separate score)
 

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -31,8 +31,8 @@ schema version:
 
 The report's top-level shape: `schema_version`, `mcpscore_version`,
 `generated_at`, `target`, `transport`, `score`, `max_score`,
-`authenticated`, `partial`, `partial_reason`, `summary`, `results[]`,
-`skipped_rules[]`, `spec`, `readiness`.
+`authenticated`, `partial`, `partial_reason`, `incomplete_listings[]`,
+`summary`, `results[]`, `skipped_rules[]`, `spec`, `readiness`.
 
 ### CLI interface
 

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -505,6 +505,18 @@ class MCPAuditor:
             self.audit_data.capabilities = init_result.capabilities
             self.audit_data.instructions = init_result.instructions
 
+    def _capture_listing_completeness(self, listing: str) -> None:
+        """Record whether THIS audit's fetch of ``listing`` was complete.
+
+        Reads only the just-attempted listing from the client's cumulative
+        ``incomplete_listings`` set: a client reused across audits may carry
+        markers for listings this audit never fetched (e.g. the capability is
+        absent on this server), and those must not leak into the report or
+        skip uniqueness rules without cause.
+        """
+        if listing in getattr(self.mcp_client, "incomplete_listings", frozenset()):
+            self.audit_data.incomplete_listings |= {listing}
+
     async def _collect_tools(self) -> None:
         """Collect the list of Tools from the MCP server.
 
@@ -519,7 +531,7 @@ class MCPAuditor:
 
         self.audit_data.listings_attempted |= {"tools"}
         tools: list[Tool] | None = await self.mcp_client.list_tools()
-        self.audit_data.incomplete_listings = frozenset(getattr(self.mcp_client, "incomplete_listings", set()))
+        self._capture_listing_completeness("tools")
         if tools is None:
             logger.error("No Tools to audit")
             return
@@ -540,7 +552,7 @@ class MCPAuditor:
 
         self.audit_data.listings_attempted |= {"resources"}
         resources: list[Resource] | None = await self.mcp_client.list_resources()
-        self.audit_data.incomplete_listings = frozenset(getattr(self.mcp_client, "incomplete_listings", set()))
+        self._capture_listing_completeness("resources")
         if resources is None:
             logger.error("No Resources to audit")
             return
@@ -561,7 +573,7 @@ class MCPAuditor:
 
         self.audit_data.listings_attempted |= {"prompts"}
         prompts: list[Prompt] | None = await self.mcp_client.list_prompts()
-        self.audit_data.incomplete_listings = frozenset(getattr(self.mcp_client, "incomplete_listings", set()))
+        self._capture_listing_completeness("prompts")
         if prompts is None:
             logger.error("No prompts to audit")
             return

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -519,6 +519,7 @@ class MCPAuditor:
 
         self.audit_data.listings_attempted |= {"tools"}
         tools: list[Tool] | None = await self.mcp_client.list_tools()
+        self.audit_data.incomplete_listings = frozenset(getattr(self.mcp_client, "incomplete_listings", set()))
         if tools is None:
             logger.error("No Tools to audit")
             return
@@ -539,6 +540,7 @@ class MCPAuditor:
 
         self.audit_data.listings_attempted |= {"resources"}
         resources: list[Resource] | None = await self.mcp_client.list_resources()
+        self.audit_data.incomplete_listings = frozenset(getattr(self.mcp_client, "incomplete_listings", set()))
         if resources is None:
             logger.error("No Resources to audit")
             return
@@ -559,6 +561,7 @@ class MCPAuditor:
 
         self.audit_data.listings_attempted |= {"prompts"}
         prompts: list[Prompt] | None = await self.mcp_client.list_prompts()
+        self.audit_data.incomplete_listings = frozenset(getattr(self.mcp_client, "incomplete_listings", set()))
         if prompts is None:
             logger.error("No prompts to audit")
             return
@@ -577,6 +580,9 @@ class MCPAuditor:
               (see RuleResult.to_dict)
             - skipped_rules: Rules considered but not executed (with reason),
               e.g. rules outside the server's spec-version range
+            - incomplete_listings: Listings (tools/resources/prompts) whose
+              pagination did not complete, so completeness-dependent rules
+              were skipped
             - spec: Negotiated/latest/readiness-target spec versions and the
               observed lifecycle era (legacy / modern / dual-era)
             - readiness: Independent readiness score for the next spec
@@ -597,6 +603,10 @@ class MCPAuditor:
             # a full audit's — partial_reason says why.
             "partial": self.audit_data.partial,
             "partial_reason": self.audit_data.partial_reason,
+            # Listings whose pagination failed part-way (error, cursor loop, or
+            # page bound): their items were judged, but completeness-dependent
+            # rules were skipped as insufficient-data.
+            "incomplete_listings": sorted(self.audit_data.incomplete_listings),
             "summary": self.get_audit_summary(),
             "results": [res.to_dict() for res in self.results],
             "skipped_rules": [s.to_dict() for s in self.skipped_rules],

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -1,10 +1,11 @@
 import asyncio
+from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 import logging
 import sys
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx2
 from mcp import (
@@ -18,7 +19,7 @@ from mcp import (
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
-from mcp_types import Prompt, Resource, Tool
+from mcp_types import PaginatedRequestParams, Prompt, Resource, Tool
 
 from .enums import ConnectionErrorReason, MCPTransportType
 
@@ -31,6 +32,9 @@ ERROR_NO_ACTIVE_SESSION = "No active session, connect to the MCP server first!"
 
 HANDSHAKE_TIMEOUT_S = 30
 """Default timeout for the MCP initialize handshake performed during connect."""
+
+MAX_LISTING_PAGES = 100
+"""Safety bound for a single paginated MCP listing."""
 
 
 _REASON_MESSAGES: dict[ConnectionErrorReason, str] = {
@@ -158,6 +162,7 @@ class MCPClient:
         self.timeout: int | None = timeout
         self.headers: dict[str, str] | None = headers or None
         self._init_result: InitializeResult | None = None
+        self.incomplete_listings: set[str] = set()
 
         # Transport metadata (populated after connection)
         self.transport_type: MCPTransportType | None = None
@@ -598,13 +603,7 @@ class MCPClient:
             logger.error(ERROR_NO_ACTIVE_SESSION)
             return None
 
-        try:
-            response: ListToolsResult = await self.session.list_tools()
-            # TODO: Add support for nextCursor
-            return response.tools
-        except Exception:
-            logger.exception("Failed to list tools from the MCP server")
-            return None
+        return await self._list_all_pages(self.session.list_tools, "tools", "tools")
 
     async def list_resources(self) -> list[Resource] | None:
         """List and display all available resources from the MCP server.
@@ -619,13 +618,7 @@ class MCPClient:
             logger.error(ERROR_NO_ACTIVE_SESSION)
             return None
 
-        try:
-            response: ListResourcesResult = await self.session.list_resources()
-            # TODO: Add support for nextCursor
-            return response.resources
-        except Exception:
-            logger.exception("Failed to list resources from the MCP server")
-            return None
+        return await self._list_all_pages(self.session.list_resources, "resources", "resources")
 
     async def list_prompts(self) -> list[Prompt] | None:
         """List and display all available prompts from the MCP server.
@@ -640,13 +633,46 @@ class MCPClient:
             logger.error(ERROR_NO_ACTIVE_SESSION)
             return None
 
-        try:
-            response: ListPromptsResult = await self.session.list_prompts()
-            # TODO: Add support for nextCursor
-            return response.prompts
-        except Exception:
-            logger.exception("Failed to list prompts from the MCP server")
-            return None
+        return await self._list_all_pages(self.session.list_prompts, "prompts", "prompts")
+
+    async def _list_all_pages(
+        self,
+        fetch_page: Callable[..., Awaitable[ListToolsResult | ListResourcesResult | ListPromptsResult]],
+        item_attribute: str,
+        listing_name: str,
+    ) -> list[Any] | None:
+        """Collect a complete MCP listing while guarding against broken cursors."""
+        items: list[Any] = []
+        seen_cursors: set[str] = set()
+        cursor: str | None = None
+        self.incomplete_listings.discard(listing_name)
+
+        for page_number in range(MAX_LISTING_PAGES):
+            try:
+                response = (
+                    await fetch_page()
+                    if page_number == 0
+                    else await fetch_page(params=PaginatedRequestParams(cursor=cursor))
+                )
+            except Exception:
+                self.incomplete_listings.add(listing_name)
+                logger.exception("Failed to list %s from the MCP server", listing_name)
+                return items or None
+
+            items.extend(getattr(response, item_attribute))
+            next_cursor = response.next_cursor
+            if next_cursor is None:
+                return items
+            if next_cursor in seen_cursors:
+                self.incomplete_listings.add(listing_name)
+                logger.error("Stopped listing %s after the server repeated cursor %r", listing_name, next_cursor)
+                return items
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        self.incomplete_listings.add(listing_name)
+        logger.error("Stopped listing %s after %d pages", listing_name, MAX_LISTING_PAGES)
+        return items
 
     async def cleanup(self) -> None:
         """Clean up client resources and close all connections.

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -657,7 +657,10 @@ class MCPClient:
             except Exception:
                 self.incomplete_listings.add(listing_name)
                 logger.exception("Failed to list %s from the MCP server", listing_name)
-                return items or None
+                # None means the listing yielded nothing at all; once any page
+                # succeeded the collected items — even zero of them — are
+                # partial evidence and must not degrade to "unavailable".
+                return None if page_number == 0 else items
 
             items.extend(getattr(response, item_attribute))
             next_cursor = response.next_cursor

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -43,6 +43,7 @@ from .prompts import (
     PromptsArgumentNamesUniqueRule,
     PromptsArgumentsDocumentedRule,
     PromptsDescriptionPresentRule,
+    PromptsNamesUniqueRule,
 )
 from .protocol_version import (
     AllowedVersionRule,
@@ -70,6 +71,7 @@ from .resources import (
     ResourcesMimeTypesValidRule,
     ResourcesNamesPresentRule,
     ResourcesSizesValidRule,
+    ResourcesUrisUniqueRule,
     ResourcesUrisValidRule,
 )
 from .security import (
@@ -137,12 +139,14 @@ __all__ = (
     "PromptsArgumentNamesUniqueRule",
     "PromptsArgumentsDocumentedRule",
     "PromptsDescriptionPresentRule",
+    "PromptsNamesUniqueRule",
     "RemovedMethodsReadinessRule",
     "ResourcesAnnotationsValidRule",
     "ResourcesDescriptionPresentRule",
     "ResourcesMimeTypesValidRule",
     "ResourcesNamesPresentRule",
     "ResourcesSizesValidRule",
+    "ResourcesUrisUniqueRule",
     "ResourcesUrisValidRule",
     "ResultTypeReadinessRule",
     "RuleRegistry",

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -145,6 +145,10 @@ class AuditData:
     # attempted instead of reading silence as failure.
     listings_attempted: frozenset[str] = frozenset()
 
+    # Listings for which the client returned only partial evidence because
+    # pagination failed, repeated a cursor, or exceeded its safety bound.
+    incomplete_listings: frozenset[str] = frozenset()
+
 
 # Decorators to specify what data a rule needs
 def requires_protocol_version(func: Callable) -> Callable:

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -1,8 +1,9 @@
 from abc import abstractmethod
+from collections import Counter
 
 from mcp_types import Prompt
 
-from .base import BaseRule, RuleResult, RuleSeverity, requires_fields
+from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
 from .registry import register_rule
 
 
@@ -235,4 +236,43 @@ class PromptsArgumentsDocumentedRule(PromptsBaseRule):
             passed=passed,
             message=message,
             details={"undocumented_arguments": undocumented_arguments},
+        )
+
+
+@register_rule
+class PromptsNamesUniqueRule(PromptsBaseRule):
+    """High check: Verify that each listed prompt has a unique name."""
+
+    rule_id = "prompts_names_unique"
+    basis = "MCP 2026-07-28 Prompts §Prompt (name: Unique identifier for the prompt)"
+    rule_order = 5
+
+    @property
+    def rule_name(self) -> str:
+        return "Prompts - Prompt names must be unique"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when pagination did not produce the complete prompt list."""
+        return SKIP_REASON_INSUFFICIENT_DATA if "prompts" in audit_data.incomplete_listings else None
+
+    def _check_prompts(self, prompts: list[Prompt]) -> RuleResult:
+        """Find prompt names declared more than once."""
+        counts = Counter(prompt.name for prompt in prompts)
+        duplicate_names = sorted(name for name, count in counts.items() if count > 1)
+        passed = not duplicate_names
+        message = (
+            "✅ All prompt names are unique"
+            if passed
+            else f"❌ Number of duplicate prompt names: {len(duplicate_names)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"duplicate_names": duplicate_names},
         )

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -1,11 +1,12 @@
 from abc import abstractmethod
+from collections import Counter
 from datetime import datetime
 import re
 from urllib.parse import urlsplit
 
 from mcp_types import Resource
 
-from .base import BaseRule, RuleResult, RuleSeverity, requires_fields
+from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
 from .registry import register_rule
 
 _URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
@@ -325,4 +326,43 @@ class ResourcesDescriptionPresentRule(ResourcesBaseRule):
             passed=passed,
             message=message,
             details={"resources_without_description": resources_without_description},
+        )
+
+
+@register_rule
+class ResourcesUrisUniqueRule(ResourcesBaseRule):
+    """High check: Verify that each listed resource has a unique URI."""
+
+    rule_id = "resources_uris_unique"
+    basis = "MCP 2026-07-28 Resources §Resource (uri: Unique identifier for the resource)"
+    rule_order = 7
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources - Resource URIs must be unique"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when pagination did not produce the complete resource list."""
+        return SKIP_REASON_INSUFFICIENT_DATA if "resources" in audit_data.incomplete_listings else None
+
+    def _check_resources(self, resources: list[Resource]) -> RuleResult:
+        """Find resource URIs declared more than once."""
+        counts = Counter(resource.uri for resource in resources)
+        duplicate_uris = sorted(uri for uri, count in counts.items() if count > 1)
+        passed = not duplicate_uris
+        message = (
+            "✅ All resource URIs are unique"
+            if passed
+            else f"❌ Number of duplicate resource URIs: {len(duplicate_uris)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"duplicate_uris": duplicate_uris},
         )

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -168,6 +168,14 @@ class ToolsNamesUniqueRule(ToolsBaseRule):
     def severity(self) -> RuleSeverity:
         return RuleSeverity.CRITICAL
 
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when pagination did not produce the complete tool list.
+
+        Uniqueness judged on a partial listing can produce a false pass —
+        the duplicate may live on a page that was never fetched.
+        """
+        return SKIP_REASON_INSUFFICIENT_DATA if "tools" in audit_data.incomplete_listings else None
+
     def _check_tools(self, tools: list[Tool]) -> RuleResult:
         """Critical check: Verify that all tools names are unique.
 

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -83,6 +83,17 @@ class ToolsAtLeastOneRule(ToolsBaseRule):
     def severity(self) -> RuleSeverity:
         return RuleSeverity.CRITICAL
 
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when an incomplete listing collected zero tools.
+
+        An empty partial listing cannot prove the server has no tools — the
+        tools may live on a page that was never fetched. A non-empty partial
+        listing proves presence, so the rule still judges (and passes) it.
+        """
+        if "tools" in audit_data.incomplete_listings and not audit_data.tools:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
+
     def _check_tools(self, tools: list[Tool]) -> RuleResult:
         """Critical check: Verify the MCP server provides at least one tool.
 

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -746,6 +746,19 @@ async def test_get_audit_report():
     assert all(res["rule_id"] == "dummy_rule" for res in report["results"])
     assert report["results"][0]["passed"] is True
     assert report["results"][1]["passed"] is False
+    assert report["incomplete_listings"] == []
+
+
+async def test_report_surfaces_incomplete_listings():
+    """A broken pagination is explicit report evidence, not just a skip reason."""
+    auditor = MCPAuditor()
+    auditor.rules = [DummyRule(passed=True, severity=RuleSeverity.HIGH)]
+
+    await auditor.audit(DummyClient(None))
+    auditor.audit_data.incomplete_listings = frozenset({"tools", "prompts"})
+    report = auditor.get_audit_report()
+
+    assert report["incomplete_listings"] == ["prompts", "tools"]
 
 
 class CitedRule(DummyRule):

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -749,6 +749,23 @@ async def test_get_audit_report():
     assert report["incomplete_listings"] == []
 
 
+async def test_stale_client_markers_do_not_leak_into_unattempted_listings():
+    """A reused client's leftover incomplete markers must not indict listings this audit never fetched.
+
+    MCPClient.incomplete_listings accumulates for the client's lifetime; only
+    the listing a collect step just attempted may be read from it. (PR #63
+    Bugbot finding: capability-absent listings inherited stale markers.)
+    """
+    auditor = MCPAuditor()
+    client = DummyClient(None, tools=[])
+    client.incomplete_listings = {"resources"}  # stale marker from a previous audit on this client
+    auditor.mcp_client = client
+
+    await auditor._collect_tools()
+
+    assert "resources" not in auditor.audit_data.incomplete_listings
+
+
 async def test_report_surfaces_incomplete_listings():
     """A broken pagination is explicit report evidence, not just a skip reason."""
     auditor = MCPAuditor()

--- a/tests/test_mcp_client_session.py
+++ b/tests/test_mcp_client_session.py
@@ -254,6 +254,33 @@ class TestMCPClientSessionOperations:
         assert result == [first]
         assert mock_connected_client.incomplete_listings == {"resources"}
 
+    async def test_empty_partial_listing_is_a_list_not_none(self, mock_connected_client):
+        """A successful-but-empty page followed by an error is partial evidence, not 'unavailable'.
+
+        `None` would make every tool rule fail as "Tools object is not
+        available"; an empty list with the incomplete marker lets rules skip
+        or judge appropriately. (PR #63 Bugbot finding.)
+        """
+        mock_connected_client.session.list_tools.side_effect = [
+            ListToolsResult(tools=[], nextCursor="next"),
+            RuntimeError("page failed"),
+        ]
+
+        result = await mock_connected_client.list_tools()
+
+        assert result == []
+        assert result is not None
+        assert mock_connected_client.incomplete_listings == {"tools"}
+
+    async def test_first_page_failure_still_returns_none(self, mock_connected_client):
+        """A listing that never produced a page keeps the historical None semantics."""
+        mock_connected_client.session.list_tools.side_effect = RuntimeError("boom")
+
+        result = await mock_connected_client.list_tools()
+
+        assert result is None
+        assert mock_connected_client.incomplete_listings == {"tools"}
+
     async def test_page_budget_stops_unbounded_prompt_listing(self, mock_connected_client, monkeypatch, caplog):
         """A server that always advances its cursor is still bounded."""
         monkeypatch.setattr("mcpscore.mcp_client.MAX_LISTING_PAGES", 2)

--- a/tests/test_mcp_client_session.py
+++ b/tests/test_mcp_client_session.py
@@ -6,6 +6,7 @@ from mcp import InitializeResult, ListPromptsResult, ListResourcesResult, ListTo
 from mcp_types import Prompt, Resource, Tool
 import pytest
 
+import mcpscore.mcp_client as mcp_client_module
 from mcpscore.mcp_client import ERROR_NO_ACTIVE_SESSION, MCPClient
 
 
@@ -175,3 +176,95 @@ class TestMCPClientSessionOperations:
 
         assert result == []
         assert len(result) == 0
+
+    @pytest.mark.parametrize(
+        ("method_name", "result_type", "item_field", "first_item", "second_item"),
+        [
+            (
+                "list_tools",
+                ListToolsResult,
+                "tools",
+                Tool(name="first", input_schema={"type": "object"}),
+                Tool(name="second", input_schema={"type": "object"}),
+            ),
+            (
+                "list_resources",
+                ListResourcesResult,
+                "resources",
+                Resource(uri="file:///first", name="first"),
+                Resource(uri="file:///second", name="second"),
+            ),
+            (
+                "list_prompts",
+                ListPromptsResult,
+                "prompts",
+                Prompt(name="first"),
+                Prompt(name="second"),
+            ),
+        ],
+    )
+    async def test_listing_collects_all_pages(
+        self,
+        mock_connected_client,
+        method_name,
+        result_type,
+        item_field,
+        first_item,
+        second_item,
+    ):
+        """Every supported listing follows nextCursor and aggregates its pages."""
+        session_method = getattr(mock_connected_client.session, method_name)
+        session_method.side_effect = [
+            result_type(**{item_field: [first_item], "nextCursor": ""}),
+            result_type(**{item_field: [second_item]}),
+        ]
+
+        result = await getattr(mock_connected_client, method_name)()
+
+        assert result == [first_item, second_item]
+        assert session_method.call_count == 2
+        assert session_method.call_args_list[0].args == ()
+        assert session_method.call_args_list[1].kwargs["params"].cursor == ""
+        assert mock_connected_client.incomplete_listings == set()
+
+    async def test_repeated_cursor_stops_tools_listing_and_marks_it_incomplete(self, mock_connected_client, caplog):
+        """A looping server cannot make pagination run forever."""
+        first = Tool(name="first", input_schema={"type": "object"})
+        second = Tool(name="second", input_schema={"type": "object"})
+        mock_connected_client.session.list_tools.side_effect = [
+            ListToolsResult(tools=[first], nextCursor="again"),
+            ListToolsResult(tools=[second], nextCursor="again"),
+        ]
+
+        result = await mock_connected_client.list_tools()
+
+        assert result == [first, second]
+        assert mock_connected_client.incomplete_listings == {"tools"}
+        assert "repeated cursor" in caplog.text
+
+    async def test_later_page_failure_returns_partial_listing(self, mock_connected_client):
+        """Evidence from successful pages remains usable but is labelled incomplete."""
+        first = Resource(uri="file:///first", name="first")
+        mock_connected_client.session.list_resources.side_effect = [
+            ListResourcesResult(resources=[first], nextCursor="next"),
+            RuntimeError("page failed"),
+        ]
+
+        result = await mock_connected_client.list_resources()
+
+        assert result == [first]
+        assert mock_connected_client.incomplete_listings == {"resources"}
+
+    async def test_page_budget_stops_unbounded_prompt_listing(self, mock_connected_client, monkeypatch, caplog):
+        """A server that always advances its cursor is still bounded."""
+        monkeypatch.setattr(mcp_client_module, "MAX_LISTING_PAGES", 2)
+        mock_connected_client.session.list_prompts.side_effect = [
+            ListPromptsResult(prompts=[Prompt(name="one")], nextCursor="second"),
+            ListPromptsResult(prompts=[Prompt(name="two")], nextCursor="third"),
+        ]
+
+        result = await mock_connected_client.list_prompts()
+
+        assert [prompt.name for prompt in result] == ["one", "two"]
+        assert mock_connected_client.incomplete_listings == {"prompts"}
+        assert "after 2 pages" in caplog.text

--- a/tests/test_mcp_client_session.py
+++ b/tests/test_mcp_client_session.py
@@ -6,7 +6,6 @@ from mcp import InitializeResult, ListPromptsResult, ListResourcesResult, ListTo
 from mcp_types import Prompt, Resource, Tool
 import pytest
 
-import mcpscore.mcp_client as mcp_client_module
 from mcpscore.mcp_client import ERROR_NO_ACTIVE_SESSION, MCPClient
 
 
@@ -257,7 +256,7 @@ class TestMCPClientSessionOperations:
 
     async def test_page_budget_stops_unbounded_prompt_listing(self, mock_connected_client, monkeypatch, caplog):
         """A server that always advances its cursor is still bounded."""
-        monkeypatch.setattr(mcp_client_module, "MAX_LISTING_PAGES", 2)
+        monkeypatch.setattr("mcpscore.mcp_client.MAX_LISTING_PAGES", 2)
         mock_connected_client.session.list_prompts.side_effect = [
             ListPromptsResult(prompts=[Prompt(name="one")], nextCursor="second"),
             ListPromptsResult(prompts=[Prompt(name="two")], nextCursor="third"),

--- a/tests/test_prompts_rules.py
+++ b/tests/test_prompts_rules.py
@@ -8,8 +8,10 @@ from mcpscore.rules import (
     PromptsArgumentNamesUniqueRule,
     PromptsArgumentsDocumentedRule,
     PromptsDescriptionPresentRule,
+    PromptsNamesUniqueRule,
     RuleSeverity,
 )
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
 
 
 def _prompt(
@@ -43,6 +45,23 @@ class TestPromptsDescriptionPresentRule:
         assert result.passed is False
         assert result.details is not None
         assert result.details["prompts_without_description"] == ["bad"]
+
+
+class TestPromptsNamesUniqueRule:
+    def test_unique_names_pass(self) -> None:
+        result = PromptsNamesUniqueRule().check(AuditData(prompts=[_prompt("one"), _prompt("two")]))
+        assert result.passed is True
+        assert result.details == {"duplicate_names": []}
+
+    def test_duplicate_name_fails_once(self) -> None:
+        result = PromptsNamesUniqueRule().check(AuditData(prompts=[_prompt("same"), _prompt("same"), _prompt("same")]))
+        assert result.passed is False
+        assert result.details == {"duplicate_names": ["same"]}
+
+    def test_incomplete_listing_skips(self) -> None:
+        rule = PromptsNamesUniqueRule()
+        data = AuditData(prompts=[_prompt("one")], incomplete_listings=frozenset({"prompts"}))
+        assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
 
 
 class TestPromptsArgumentNamesUniqueRule:

--- a/tests/test_resources_rules.py
+++ b/tests/test_resources_rules.py
@@ -9,9 +9,11 @@ from mcpscore.rules import (
     ResourcesMimeTypesValidRule,
     ResourcesNamesPresentRule,
     ResourcesSizesValidRule,
+    ResourcesUrisUniqueRule,
     ResourcesUrisValidRule,
     RuleSeverity,
 )
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
 
 
 def _resource(
@@ -74,6 +76,31 @@ class TestResourcesUrisValidRule:
             "space",
             "escape",
         }
+
+
+class TestResourcesUrisUniqueRule:
+    def test_unique_uris_pass(self) -> None:
+        result = ResourcesUrisUniqueRule().check(AuditData(resources=[_resource("one"), _resource("two")]))
+        assert result.passed is True
+        assert result.details == {"duplicate_uris": []}
+
+    def test_duplicate_uri_fails_once(self) -> None:
+        result = ResourcesUrisUniqueRule().check(
+            AuditData(
+                resources=[
+                    _resource("one", uri="file:///same"),
+                    _resource("two", uri="file:///same"),
+                    _resource("three", uri="file:///same"),
+                ]
+            )
+        )
+        assert result.passed is False
+        assert result.details == {"duplicate_uris": ["file:///same"]}
+
+    def test_incomplete_listing_skips(self) -> None:
+        rule = ResourcesUrisUniqueRule()
+        data = AuditData(resources=[_resource("one")], incomplete_listings=frozenset({"resources"}))
+        assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
 
 
 class TestResourcesNamesPresentRule:

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -510,6 +510,13 @@ class TestToolsNamesUniqueRule:
         assert rule.severity == RuleSeverity.CRITICAL
         assert "unique" in rule.rule_name.lower()
 
+    def test_incomplete_listing_skips(self, valid_tool: Tool) -> None:
+        """A partial tool list cannot prove uniqueness — the duplicate may be on an unfetched page."""
+        rule = ToolsNamesUniqueRule()
+        data = AuditData(tools=[valid_tool], incomplete_listings=frozenset({"tools"}))
+        assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+        assert rule.skip_reason(AuditData(tools=[valid_tool])) is None
+
     def test_with_unique_names(self, valid_tool: Tool) -> None:
         """Pass: All tool names are unique."""
         rule = ToolsNamesUniqueRule()

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -426,6 +426,26 @@ class TestToolsAtLeastOneRule:
         assert rule.rule_id == "tools_at_least_one"
         assert rule.rule_order == 1
         assert rule.severity == RuleSeverity.CRITICAL
+
+    def test_empty_incomplete_listing_skips(self) -> None:
+        """An empty partial listing cannot prove the server has no tools."""
+        rule = ToolsAtLeastOneRule()
+        data = AuditData(tools=[], incomplete_listings=frozenset({"tools"}))
+        assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_nonempty_incomplete_listing_still_judges(self, valid_tool: Tool) -> None:
+        """A non-empty partial listing proves presence — judge it, don't skip."""
+        rule = ToolsAtLeastOneRule()
+        data = AuditData(tools=[valid_tool], incomplete_listings=frozenset({"tools"}))
+        assert rule.skip_reason(data) is None
+        assert rule.check(data).passed is True
+
+    def test_empty_complete_listing_still_fails(self) -> None:
+        """A complete empty listing is a genuine failure, not insufficient data."""
+        rule = ToolsAtLeastOneRule()
+        data = AuditData(tools=[])
+        assert rule.skip_reason(data) is None
+        assert rule.check(data).passed is False
         assert "at least one tool" in rule.rule_name.lower()
 
     def test_with_one_tool(self, valid_tool: Tool) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how catalogs are collected and scored for large or misbehaving servers; uniqueness and tool-presence outcomes can shift when pagination is partial, though skips are explicit in `incomplete_listings`.
> 
> **Overview**
> **Tools, resources, and prompts listings now follow `nextCursor` pagination** instead of a single page. The client aggregates pages with repeated-cursor detection and a 100-page cap; partial fetches are flagged on the client and surfaced in JSON reports as **`incomplete_listings`**.
> 
> When a listing is incomplete, **catalog-uniqueness checks skip as insufficient-data** (including existing `tools_names_unique`) so partial data cannot falsely pass; `tools_at_least_one` skips only when the partial tools list is empty. The auditor copies incompleteness only for listings it actually fetched so stale client state cannot leak across audits.
> 
> **New HIGH rules:** `resources_uris_unique` and `prompts_names_unique`. Docs and the stability contract document the new report field and rule IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa16d2d06c861102ace50efb87432f03a8f8ce1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->