### PR TITLE
Update categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-52 rules across four categories — the same four the report, the JSON output, and
+68 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 
@@ -55,10 +55,12 @@ enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/ru
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
-**Tools Quality** (13 rules) — tool names (presence, uniqueness, format), titles,
-descriptions, and JSON Schema validity of input and output schemas, plus the equivalent
-checks for prompts and resources. These decide whether an agent picks the right tool and
-calls it correctly.
+**Tools Quality** (29 rules) — tool names (presence, uniqueness, format), titles,
+descriptions of tools and their input properties, and JSON Schema validity of input and
+output schemas, including the 2026-07-28 `x-mcp-header` constraints — plus the
+equivalent catalog checks for prompts and resources: valid and unique URIs, MIME types,
+annotations, and argument declarations, collected across the complete paginated
+listings. These decide whether an agent picks the right tool and calls it correctly.
 
 **Security & Auth** (11 rules) — HTTPS/TLS with the actually negotiated version,
 certificate validity, and error responses checked for data leaks. For auth-gated servers,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, security, or data-handling changes.
> 
> **Overview**
> Updates the **What it scores** section so documentation matches the expanded audit rule set: total rules **52 → 68**, and **Tools Quality** **13 → 29**.
> 
> The Tools Quality blurb now covers input-property descriptions, 2026-07-28 `x-mcp-header` schema checks, and catalog validation for prompts/resources (URIs, MIME types, annotations, arguments) across **paginated** listings—not just tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c678c142876ca81c14efe2dcac6e66bb41ae27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->