### PR TITLE
More rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Collect and fully paginate MCP resource templates, preserving partial evidence
+  and reporting incomplete listings when pagination fails, loops, or exceeds its
+  safety bound.
+- Three resource-template rules validate RFC 6570 URI-template syntax, unique
+  `uriTemplate` identifiers, and non-blank names without reading resources or
+  invoking tools.
+
 ## [1.2.0] - 2026-07-31
 
 Catalog-quality release: sixteen new rules across tools, resources, and

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-68 rules across four categories — the same four the report, the JSON output, and
+71 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 
@@ -55,10 +55,11 @@ enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/ru
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
-**Tools Quality** (29 rules) — tool names (presence, uniqueness, format), titles,
+**Tools Quality** (32 rules) — tool names (presence, uniqueness, format), titles,
 descriptions of tools and their input properties, and JSON Schema validity of input and
 output schemas, including the 2026-07-28 `x-mcp-header` constraints — plus the
-equivalent catalog checks for prompts and resources: valid and unique URIs, MIME types,
+equivalent catalog checks for prompts, resources, and resource templates: valid and
+unique URIs/URI templates, MIME types,
 annotations, and argument declarations, collected across the complete paginated
 listings. These decide whether an agent picks the right tool and calls it correctly.
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -98,6 +98,14 @@ Every rule mcpscore runs, generated from the rule registry
 | `resources_uris_unique` | Resources - Resource URIs must be unique | HIGH | 3 | all versions |
 | `resources_titles_present` | Resources - All resources should have a display title | LOW | 1 | 2025-06-18 – … |
 
+## Resource Templates
+
+| Rule ID | Name | Severity | Weight | Applies to |
+|---|---|---|---|---|
+| `resource_templates_uri_templates_valid` | Resource Templates - URI templates must be valid | HIGH | 3 | all versions |
+| `resource_templates_unique` | Resource Templates - URI templates must be unique | HIGH | 3 | all versions |
+| `resource_templates_names_present` | Resource Templates - All templates must have a name | MEDIUM | 2 | all versions |
+
 ## Prompts
 
 | Rule ID | Name | Severity | Weight | Applies to |

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
-    from mcp_types import InitializeResult, Prompt, Resource, Tool
+    from mcp_types import InitializeResult, Prompt, Resource, ResourceTemplate, Tool
 
     from .probes import ProbeResult
 
@@ -128,6 +128,7 @@ class MCPAuditor:
                 await self._collect_tools()
             if self.audit_data.capabilities.resources is not None:
                 await self._collect_resources()
+                await self._collect_resource_templates()
             if self.audit_data.capabilities.prompts is not None:
                 await self._collect_prompts()
         await self._collect_probes()
@@ -579,6 +580,21 @@ class MCPAuditor:
             return
         else:
             self.audit_data.prompts = prompts
+
+    async def _collect_resource_templates(self) -> None:
+        """Collect the complete resource-template catalog from the MCP server."""
+        if self.mcp_client is None:
+            logger.error("No MCP client to audit")
+            return
+
+        listing = "resource_templates"
+        self.audit_data.listings_attempted |= {listing}
+        templates: list[ResourceTemplate] | None = await self.mcp_client.list_resource_templates()
+        self._capture_listing_completeness(listing)
+        if templates is None:
+            logger.error("No resource templates to audit")
+            return
+        self.audit_data.resource_templates = templates
 
     def get_audit_report(self) -> dict:
         """Generate a machine-readable report of the full audit.

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -19,7 +19,7 @@ from mcp import (
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
-from mcp_types import PaginatedRequestParams, Prompt, Resource, Tool
+from mcp_types import ListResourceTemplatesResult, PaginatedRequestParams, Prompt, Resource, ResourceTemplate, Tool
 
 from .enums import ConnectionErrorReason, MCPTransportType
 
@@ -620,6 +620,18 @@ class MCPClient:
 
         return await self._list_all_pages(self.session.list_resources, "resources", "resources")
 
+    async def list_resource_templates(self) -> list[ResourceTemplate] | None:
+        """List every available resource template from the MCP server."""
+        if not self.session:
+            logger.error(ERROR_NO_ACTIVE_SESSION)
+            return None
+
+        return await self._list_all_pages(
+            self.session.list_resource_templates,
+            "resource_templates",
+            "resource_templates",
+        )
+
     async def list_prompts(self) -> list[Prompt] | None:
         """List and display all available prompts from the MCP server.
 
@@ -637,7 +649,10 @@ class MCPClient:
 
     async def _list_all_pages(
         self,
-        fetch_page: Callable[..., Awaitable[ListToolsResult | ListResourcesResult | ListPromptsResult]],
+        fetch_page: Callable[
+            ...,
+            Awaitable[ListToolsResult | ListResourcesResult | ListPromptsResult | ListResourceTemplatesResult],
+        ],
         item_attribute: str,
         listing_name: str,
     ) -> list[Any] | None:

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -66,6 +66,11 @@ from .readiness import (
     UnsupportedVersionErrorReadinessRule,
 )
 from .registry import RuleRegistry, create_all_rules
+from .resource_templates import (
+    ResourceTemplatesNamesPresentRule,
+    ResourceTemplatesUniqueRule,
+    ResourceTemplatesUriTemplatesValidRule,
+)
 from .resources import (
     ResourcesAnnotationsValidRule,
     ResourcesDescriptionPresentRule,
@@ -145,6 +150,9 @@ __all__ = (
     "PromptsNamesUniqueRule",
     "PromptsTitlesPresentRule",
     "RemovedMethodsReadinessRule",
+    "ResourceTemplatesNamesPresentRule",
+    "ResourceTemplatesUniqueRule",
+    "ResourceTemplatesUriTemplatesValidRule",
     "ResourcesAnnotationsValidRule",
     "ResourcesDescriptionPresentRule",
     "ResourcesMimeTypesValidRule",

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -11,7 +11,7 @@ from mcpscore.spec import compare
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from mcp_types import Implementation, Prompt, Resource, ServerCapabilities, Tool
+    from mcp_types import Implementation, Prompt, Resource, ResourceTemplate, ServerCapabilities, Tool
 
     from ..enums import MCPTransportType
     from ..probes import ProbeResult
@@ -116,6 +116,7 @@ class AuditData:
     instructions: str | None = None
     tools: list[Tool] | None = None
     resources: list[Resource] | None = None
+    resource_templates: list[ResourceTemplate] | None = None
     prompts: list[Prompt] | None = None
 
     # Transport and connection information (for HTTP/SSE audits)
@@ -137,7 +138,7 @@ class AuditData:
     partial: bool = False
     partial_reason: str | None = None
 
-    # Which listings ("tools", "resources", "prompts") the auditor actually
+    # Which listings (tools, resources, resource_templates, prompts) the auditor actually
     # attempted. `tools=None` is ambiguous on its own — the listing may have
     # failed, or may never have been tried (the session path only lists a
     # feature the server declares; the modern-only probe path collects tools

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -18,7 +18,7 @@ class PromptsBaseRule(BaseRule):
     """
 
     group_name = "prompts"
-    group_order = 7
+    group_order = 8
 
     @requires_fields("prompts")
     def check(self, prompts: list[Prompt] | None) -> RuleResult:  # type: ignore[override]

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -1,0 +1,221 @@
+from abc import abstractmethod
+from collections import Counter
+import re
+
+from mcp_types import ResourceTemplate
+
+from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .registry import register_rule
+
+_PCT_ENCODED_RE = re.compile(r"%[0-9A-Fa-f]{2}")
+_VARNAME_RE = re.compile(r"(?:[A-Za-z0-9_]|%[0-9A-Fa-f]{2})+(?:\.(?:[A-Za-z0-9_]|%[0-9A-Fa-f]{2})+)*")
+_OPERATORS = "+#./;?&=,!@|"
+
+
+def is_valid_uri_template(value: str) -> bool:
+    """Return whether a string satisfies the RFC 6570 Level 4 grammar."""
+    if not value:
+        # The empty string is grammar-vacuous but identifies nothing — reject
+        # it like resources_uris_valid rejects an empty URI.
+        return False
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if character == "{":
+            closing = value.find("}", index + 1)
+            if closing < 0 or not _is_valid_expression(value[index + 1 : closing]):
+                return False
+            index = closing + 1
+            continue
+        if character == "}" or not _is_valid_literal(value, index):
+            return False
+        index += 3 if character == "%" else 1
+    return True
+
+
+def _is_valid_expression(expression: str) -> bool:
+    if not expression:
+        return False
+    variables = expression[1:] if expression[0] in _OPERATORS else expression
+    if not variables:
+        return False
+    return all(_is_valid_varspec(varspec) for varspec in variables.split(","))
+
+
+def _is_valid_varspec(varspec: str) -> bool:
+    if varspec.endswith("*"):
+        varname = varspec[:-1]
+    elif ":" in varspec:
+        varname, separator, prefix = varspec.partition(":")
+        if not separator or re.fullmatch(r"[1-9][0-9]{0,3}", prefix) is None:
+            return False
+    else:
+        varname = varspec
+    return _VARNAME_RE.fullmatch(varname) is not None
+
+
+def _is_valid_literal(value: str, index: int) -> bool:
+    codepoint = ord(value[index])
+    if value[index] == "%":
+        return _PCT_ENCODED_RE.match(value, index) is not None
+    return (
+        codepoint == 0x21
+        or 0x23 <= codepoint <= 0x24
+        or codepoint == 0x26
+        or 0x28 <= codepoint <= 0x3B
+        or codepoint == 0x3D
+        or 0x3F <= codepoint <= 0x5B
+        or codepoint in (0x5D, 0x5F)
+        or 0x61 <= codepoint <= 0x7A
+        or codepoint == 0x7E
+        or 0xA0 <= codepoint <= 0xD7FF
+        or 0xE000 <= codepoint <= 0xF8FF
+        or 0xF900 <= codepoint <= 0xFDCF
+        or 0xFDF0 <= codepoint <= 0xFFEF
+        or any(start <= codepoint <= end for start, end in _SUPPLEMENTARY_RANGES)
+    )
+
+
+_SUPPLEMENTARY_RANGES = tuple(
+    [(plane << 16, (plane << 16) + 0xFFFD) for plane in range(1, 14)]
+    + [(0xE1000, 0xEFFFD), (0xF0000, 0xFFFFD), (0x100000, 0x10FFFD)]
+)
+
+
+class ResourceTemplatesBaseRule(BaseRule):
+    """Base class for rules that validate the collected template catalog.
+
+    Per-item rules judge partial evidence too — a bad template on page one is
+    bad regardless of what an unfetched page holds. Only completeness-dependent
+    verdicts (uniqueness) skip on an incomplete listing, on the subclass.
+    """
+
+    group_name = "resource_templates"
+    group_order = 7
+
+    @requires_fields("resource_templates")
+    def check(self, templates: list[ResourceTemplate] | None) -> RuleResult:  # type: ignore[override]
+        """Execute the rule, treating an absent optional catalog as not applicable."""
+        if not templates:
+            return RuleResult(
+                rule_name=self.rule_name,
+                severity=self.severity,
+                passed=True,
+                message="✅ No resource templates to evaluate",
+                details={"resource_templates_count": 0},
+            )
+        return self._check_templates(templates)
+
+    @abstractmethod
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        """Validate the collected resource templates."""
+        ...
+
+
+@register_rule
+class ResourceTemplatesUriTemplatesValidRule(ResourceTemplatesBaseRule):
+    """High check: Verify that each uriTemplate follows RFC 6570 syntax."""
+
+    rule_id = "resource_templates_uri_templates_valid"
+    basis = "MCP 2026-07-28 Resources §Resource Templates (uriTemplate); RFC 6570 §2"
+    rule_order = 20
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - URI templates must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        invalid = [
+            {"name": template.name, "uri_template": template.uri_template}
+            for template in templates
+            if not is_valid_uri_template(template.uri_template)
+        ]
+        passed = not invalid
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                "✅ All resource URI templates are valid"
+                if passed
+                else f"❌ Number of invalid resource URI templates: {len(invalid)}"
+            ),
+            details={"invalid_uri_templates": invalid},
+        )
+
+
+@register_rule
+class ResourceTemplatesUniqueRule(ResourceTemplatesBaseRule):
+    """High check: Verify that uriTemplate identifiers are unique."""
+
+    rule_id = "resource_templates_unique"
+    basis = "MCP 2026-07-28 Resources §Resource Templates (uriTemplate identifies the template)"
+    rule_order = 21
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - URI templates must be unique"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when pagination did not produce the complete catalog.
+
+        Uniqueness judged on a partial listing can produce a false pass — the
+        duplicate may live on a page that was never fetched.
+        """
+        return SKIP_REASON_INSUFFICIENT_DATA if "resource_templates" in audit_data.incomplete_listings else None
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        counts = Counter(template.uri_template for template in templates)
+        duplicates = sorted(value for value, count in counts.items() if count > 1)
+        passed = not duplicates
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                "✅ All resource URI templates are unique"
+                if passed
+                else f"❌ Number of duplicate resource URI templates: {len(duplicates)}"
+            ),
+            details={"duplicate_uri_templates": duplicates},
+        )
+
+
+@register_rule
+class ResourceTemplatesNamesPresentRule(ResourceTemplatesBaseRule):
+    """Medium check: Verify that each template has a non-blank name."""
+
+    rule_id = "resource_templates_names_present"
+    basis = "MCP 2026-07-28 Resources §Resource Templates (name)"
+    rule_order = 22
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - All templates must have a name"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        unnamed = [template.uri_template for template in templates if not template.name.strip()]
+        passed = not unnamed
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                "✅ All resource templates have a name"
+                if passed
+                else f"❌ Number of resource templates without a name: {len(unnamed)}"
+            ),
+            details={"templates_without_name": unnamed},
+        )

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -109,7 +109,7 @@ class ResourceTemplatesBaseRule(BaseRule):
     @abstractmethod
     def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
         """Validate the collected resource templates."""
-        ...
+        raise NotImplementedError
 
 
 @register_rule

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -93,6 +93,13 @@ class ResourceTemplatesBaseRule(BaseRule):
     group_name = "resource_templates"
     group_order = 7
 
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when an attempted listing produced no evidence to judge."""
+        listing = "resource_templates"
+        unavailable = audit_data.resource_templates is None and listing in audit_data.listings_attempted
+        empty_partial = not audit_data.resource_templates and listing in audit_data.incomplete_listings
+        return SKIP_REASON_INSUFFICIENT_DATA if unavailable or empty_partial else None
+
     @requires_fields("resource_templates")
     def check(self, templates: list[ResourceTemplate] | None) -> RuleResult:  # type: ignore[override]
         """Execute the rule, treating an absent optional catalog as not applicable."""
@@ -170,7 +177,11 @@ class ResourceTemplatesUniqueRule(ResourceTemplatesBaseRule):
         Uniqueness judged on a partial listing can produce a false pass — the
         duplicate may live on a page that was never fetched.
         """
-        return SKIP_REASON_INSUFFICIENT_DATA if "resource_templates" in audit_data.incomplete_listings else None
+        return (
+            SKIP_REASON_INSUFFICIENT_DATA
+            if super().skip_reason(audit_data) is not None or "resource_templates" in audit_data.incomplete_listings
+            else None
+        )
 
     def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
         counts = Counter(template.uri_template for template in templates)

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -545,6 +545,33 @@ async def test_collect_prompts_with_none_response(caplog):
     assert auditor.audit_data.prompts is None
 
 
+async def test_collect_resource_templates_with_none_client(caplog):
+    """Template collection returns safely when no client is configured."""
+    auditor = MCPAuditor()
+    auditor.mcp_client = None
+
+    await auditor._collect_resource_templates()
+
+    assert "No MCP client to audit" in caplog.text
+
+
+async def test_collect_resource_templates_with_incomplete_none_response(caplog):
+    """A failed first template page remains unavailable and explicitly incomplete."""
+
+    class NoneResourceTemplatesClient(MCPClient):
+        async def list_resource_templates(self):
+            self.incomplete_listings.add("resource_templates")
+
+    auditor = MCPAuditor()
+    auditor.mcp_client = NoneResourceTemplatesClient()
+
+    await auditor._collect_resource_templates()
+
+    assert "No resource templates to audit" in caplog.text
+    assert auditor.audit_data.resource_templates is None
+    assert auditor.audit_data.incomplete_listings == {"resource_templates"}
+
+
 async def test_get_audit_summary_with_mixed_results():
     """Test audit summary generation with mixed pass/fail results.
 

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -25,6 +25,7 @@ class DummyClient(MCPClient):
         init_result: Any | None,
         tools: list[Any] | None = None,
         resources: list[Any] | None = None,
+        resource_templates: list[Any] | None = None,
         prompts: list[Any] | None = None,
         url: str | None = None,
         transport_type: str = "streamable-http",
@@ -33,6 +34,7 @@ class DummyClient(MCPClient):
         self._init_result = init_result
         self._tools = tools
         self._resources = resources
+        self._resource_templates = resource_templates
         self._prompts = prompts
         self.url = url
         self.transport_type = transport_type  # type: ignore[assignment]
@@ -46,6 +48,9 @@ class DummyClient(MCPClient):
 
     async def list_resources(self):
         return self._resources
+
+    async def list_resource_templates(self):
+        return self._resource_templates
 
     async def list_prompts(self):
         return self._prompts
@@ -186,12 +191,14 @@ async def test_auditor_with_resources_capability():
             self.name = "Test Resource"
 
     resources = [Resource()]
+    resource_templates = [object()]
     auditor = MCPAuditor()
     auditor.rules = []
 
-    await auditor.audit(DummyClient(InitResult(), resources=resources))
+    await auditor.audit(DummyClient(InitResult(), resources=resources, resource_templates=resource_templates))
 
     assert auditor.audit_data.resources == resources
+    assert auditor.audit_data.resource_templates == resource_templates
 
 
 async def test_auditor_with_prompts_capability():
@@ -307,6 +314,7 @@ async def test_auditor_with_no_capabilities():
     # When capabilities is None, collection methods are not called, so fields remain None
     assert auditor.audit_data.tools is None
     assert auditor.audit_data.resources is None
+    assert auditor.audit_data.resource_templates is None
     assert auditor.audit_data.prompts is None
 
 

--- a/tests/test_mcp_client_session.py
+++ b/tests/test_mcp_client_session.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from mcp import InitializeResult, ListPromptsResult, ListResourcesResult, ListToolsResult
-from mcp_types import Prompt, Resource, Tool
+from mcp_types import ListResourceTemplatesResult, Prompt, Resource, ResourceTemplate, Tool
 import pytest
 
 from mcpscore.mcp_client import ERROR_NO_ACTIVE_SESSION, MCPClient
@@ -176,6 +176,21 @@ class TestMCPClientSessionOperations:
         assert result == []
         assert len(result) == 0
 
+    async def test_list_resource_templates_no_session(self, mcp_client, caplog):
+        """Resource-template listing requires an active session."""
+        assert await mcp_client.list_resource_templates() is None
+        assert ERROR_NO_ACTIVE_SESSION in caplog.text
+
+    async def test_list_resource_templates_success(self, mock_connected_client):
+        """Resource templates are returned from a complete first page."""
+        templates = [ResourceTemplate(name="users", uriTemplate="users/{id}")]
+        mock_connected_client.session.list_resource_templates.return_value = ListResourceTemplatesResult(
+            resourceTemplates=templates
+        )
+
+        assert await mock_connected_client.list_resource_templates() == templates
+        mock_connected_client.session.list_resource_templates.assert_called_once()
+
     @pytest.mark.parametrize(
         ("method_name", "result_type", "item_field", "first_item", "second_item"),
         [
@@ -199,6 +214,13 @@ class TestMCPClientSessionOperations:
                 "prompts",
                 Prompt(name="first"),
                 Prompt(name="second"),
+            ),
+            (
+                "list_resource_templates",
+                ListResourceTemplatesResult,
+                "resource_templates",
+                ResourceTemplate(name="first", uriTemplate="file:///{path}"),
+                ResourceTemplate(name="second", uriTemplate="https://example.com/{id}"),
             ),
         ],
     )

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -95,3 +95,19 @@ def test_only_the_uniqueness_rule_skips_incomplete_catalogs() -> None:
     assert ResourceTemplatesNamesPresentRule().skip_reason(data) is None
     # A bad template on a fetched page is a finding even when pages are missing.
     assert ResourceTemplatesUriTemplatesValidRule().check(data).passed is False
+
+
+def test_all_template_rules_skip_when_listing_produced_no_evidence() -> None:
+    """A failed listing is unavailable, not an empty catalog that passes."""
+    for templates in (None, []):
+        data = AuditData(
+            resource_templates=templates,
+            listings_attempted=frozenset({"resource_templates"}),
+            incomplete_listings=frozenset({"resource_templates"}),
+        )
+        for rule in (
+            ResourceTemplatesUriTemplatesValidRule(),
+            ResourceTemplatesUniqueRule(),
+            ResourceTemplatesNamesPresentRule(),
+        ):
+            assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -30,6 +30,7 @@ def test_uri_template_validator_rejects_invalid_grammar() -> None:
         "https://example.com/{",
         "https://example.com/}",
         "https://example.com/{}",
+        "https://example.com/{+}",
         "https://example.com/{name:0}",
         "https://example.com/{name:10000}",
         "https://example.com/{name**}",

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -87,11 +87,11 @@ def test_template_rules_pass_when_capability_has_no_templates() -> None:
 def test_only_the_uniqueness_rule_skips_incomplete_catalogs() -> None:
     """Per-item rules judge partial evidence; only uniqueness needs the full catalog."""
     data = AuditData(
-        resource_templates=[_template("users", "users/{id}")],
+        resource_templates=[_template("users", "users/{bad-name}")],
         incomplete_listings=frozenset({"resource_templates"}),
     )
     assert ResourceTemplatesUniqueRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
     assert ResourceTemplatesUriTemplatesValidRule().skip_reason(data) is None
     assert ResourceTemplatesNamesPresentRule().skip_reason(data) is None
     # A bad template on a fetched page is a finding even when pages are missing.
-    assert ResourceTemplatesUriTemplatesValidRule().check(data).passed is True
+    assert ResourceTemplatesUriTemplatesValidRule().check(data).passed is False

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -1,0 +1,96 @@
+from mcp_types import ResourceTemplate
+
+from mcpscore.rules import (
+    AuditData,
+    ResourceTemplatesNamesPresentRule,
+    ResourceTemplatesUniqueRule,
+    ResourceTemplatesUriTemplatesValidRule,
+)
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
+from mcpscore.rules.resource_templates import is_valid_uri_template
+
+
+def _template(name: str, uri_template: str) -> ResourceTemplate:
+    return ResourceTemplate(name=name, uriTemplate=uri_template)
+
+
+def test_uri_template_validator_accepts_rfc_6570_levels() -> None:
+    valid = [
+        "https://example.com/~{username}/",
+        "https://example.com/{+path}/here",
+        "https://example.com{/segments*}{?query,limit:3}",
+        "file:///{folder.name}/{file%2Did}",
+    ]
+    assert all(is_valid_uri_template(value) for value in valid)
+
+
+def test_uri_template_validator_rejects_invalid_grammar() -> None:
+    invalid = [
+        "",  # grammar-vacuous but identifies nothing
+        "https://example.com/{",
+        "https://example.com/}",
+        "https://example.com/{}",
+        "https://example.com/{name:0}",
+        "https://example.com/{name:10000}",
+        "https://example.com/{name**}",
+        "https://example.com/{bad-name}",
+        "https://example.com/{one,,two}",
+        "https://example.com/%GG",
+        "https://example.com/a b",
+    ]
+    assert not any(is_valid_uri_template(value) for value in invalid)
+
+
+def test_uri_template_rule_reports_invalid_templates() -> None:
+    result = ResourceTemplatesUriTemplatesValidRule().check(
+        AuditData(
+            resource_templates=[
+                _template("users", "https://example.com/users/{id}"),
+                _template("broken", "https://example.com/{bad-name}"),
+            ]
+        )
+    )
+    assert not result.passed
+    assert result.details == {
+        "invalid_uri_templates": [{"name": "broken", "uri_template": "https://example.com/{bad-name}"}]
+    }
+
+
+def test_unique_rule_reports_duplicate_identifiers() -> None:
+    duplicate = "https://example.com/users/{id}"
+    result = ResourceTemplatesUniqueRule().check(
+        AuditData(resource_templates=[_template("one", duplicate), _template("two", duplicate)])
+    )
+    assert not result.passed
+    assert result.details == {"duplicate_uri_templates": [duplicate]}
+
+
+def test_names_rule_rejects_blank_names() -> None:
+    result = ResourceTemplatesNamesPresentRule().check(
+        AuditData(resource_templates=[_template("users", "users/{id}"), _template("  ", "files/{id}")])
+    )
+    assert not result.passed
+    assert result.details == {"templates_without_name": ["files/{id}"]}
+
+
+def test_template_rules_pass_when_capability_has_no_templates() -> None:
+    for rule in (
+        ResourceTemplatesUriTemplatesValidRule(),
+        ResourceTemplatesUniqueRule(),
+        ResourceTemplatesNamesPresentRule(),
+    ):
+        assert rule.check(AuditData(resource_templates=[])).passed
+        assert rule.check(AuditData(resource_templates=None)).passed
+
+
+def test_only_the_uniqueness_rule_skips_incomplete_catalogs() -> None:
+    """Per-item rules judge partial evidence; only uniqueness needs the full catalog."""
+    data = AuditData(
+        resource_templates=[_template("users", "users/{id}")],
+        incomplete_listings=frozenset({"resource_templates"}),
+    )
+    assert ResourceTemplatesUniqueRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+    assert ResourceTemplatesUriTemplatesValidRule().skip_reason(data) is None
+    assert ResourceTemplatesNamesPresentRule().skip_reason(data) is None
+    # A bad template on a fetched page is a finding even when pages are missing.
+    assert ResourceTemplatesUriTemplatesValidRule().check(data).passed is True


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive listing collection and static catalog validation; scoring max increases by three rule weights for servers with resources capability, with skip semantics aligned to existing paginated listings.
> 
> **Overview**
> Adds **resource template** support to the audit pipeline: when a server declares the resources capability, the auditor now fetches the full `resource_templates` listing (same paginated `_list_all_pages` path as tools/resources/prompts), stores it on `AuditData`, and records `listings_attempted` / `incomplete_listings` for that catalog.
> 
> Introduces **three new rules** (71 total, +3): RFC 6570 **uriTemplate** syntax, **unique** `uriTemplate` identifiers (skipped if pagination is incomplete), and **non-blank names**. Catalog-only checks—no resource reads or tool calls. Per-item rules still run on partial pages; uniqueness follows the existing resources/prompts pattern.
> 
> Docs and changelog are updated (rules reference section, README rule counts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4810e9388a34616f3a32788bb8ac8c3a550db2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->