### PR TITLE
New rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `UnsupportedProtocolVersionError` shape, not just the -32022 code: the
   error's `data` must carry `supported` (a non-empty list of version strings
   to retry with) and `requested`, as the schema requires. A bare -32022 now
-  fails with a dedicated message.
+  fails with a dedicated message. Era detection is unaffected: the -32022
+  code alone still counts as modern-era evidence.
 
 ## [1.2.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Three resource-template rules validate RFC 6570 URI-template syntax, unique
   `uriTemplate` identifiers, and non-blank names without reading resources or
   invoking tools.
+- New HIGH readiness rule `readiness_2026_supported_versions`: a
+  `server/discover` DiscoverResult must name at least one supported protocol
+  version (all strings) — the schema requires `supportedVersions: string[]`
+  but has no minItems constraint, and an empty list makes version selection
+  impossible.
+
+### Changed
+
+- `readiness_2026_unsupported_version_error` now requires the full
+  `UnsupportedProtocolVersionError` shape, not just the -32022 code: the
+  error's `data` must carry `supported` (a non-empty list of version strings
+  to retry with) and `requested`, as the schema requires. A bare -32022 now
+  fails with a dedicated message.
 
 ## [1.2.0] - 2026-07-31
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -138,6 +138,7 @@ normative citations behind each rule.
 | `readiness_2026_tool_schema_dialect` | Readiness 2026-07-28 - tool schema dialect | LOW | 1 | all versions |
 | `readiness_2026_no_session_id` | Readiness 2026-07-28 - no session IDs | HIGH | 3 | all versions |
 | `readiness_2026_removed_methods` | Readiness 2026-07-28 - removed methods | MEDIUM | 2 | all versions |
+| `readiness_2026_supported_versions` | Readiness 2026-07-28 - supported versions listed | HIGH | 3 | all versions |
 
 ## Retired rules
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -384,7 +384,10 @@ async def _probe_unknown_version(client: httpx2.AsyncClient, url: str) -> ProbeR
     """Send a modern request naming a fabricated protocol version.
 
     Modern servers MUST reject it with ``-32022`` (UnsupportedProtocolVersion)
-    whose ``data`` lists ``supported`` and ``requested`` versions.
+    whose ``data`` lists ``supported`` and ``requested`` versions. SUPPORTED
+    requires the full error shape: the ``data`` block is what tells a client
+    which version to retry with, so a bare ``-32022`` records
+    ``data_well_formed: false`` and stays UNSUPPORTED.
     """
     response = await _post(
         client,
@@ -395,11 +398,21 @@ async def _probe_unknown_version(client: httpx2.AsyncClient, url: str) -> ProbeR
     details = _base_details(response)
     error = response.error
     if error is not None and response.error_code == ERROR_UNSUPPORTED_PROTOCOL_VERSION:
-        data = error.get("data")
-        if isinstance(data, dict):
-            details["supported"] = data.get("supported")
-            details["requested"] = data.get("requested")
-        return ProbeResult(PROBE_UNKNOWN_VERSION, ProbeOutcome.SUPPORTED, details)
+        raw_data = error.get("data")
+        data = raw_data if isinstance(raw_data, dict) else {}
+        supported = data.get("supported")
+        requested = data.get("requested")
+        details["supported"] = supported
+        details["requested"] = requested
+        well_formed = (
+            isinstance(supported, list)
+            and bool(supported)
+            and all(isinstance(v, str) for v in supported)
+            and isinstance(requested, str)
+        )
+        details["data_well_formed"] = well_formed
+        outcome = ProbeOutcome.SUPPORTED if well_formed else ProbeOutcome.UNSUPPORTED
+        return ProbeResult(PROBE_UNKNOWN_VERSION, outcome, details)
     return ProbeResult(PROBE_UNKNOWN_VERSION, ProbeOutcome.UNSUPPORTED, details)
 
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -748,10 +748,17 @@ def detect_era(session_protocol_version: str | None, probes: dict[str, ProbeResu
         (e.g. stdio servers, where probes do not run)
 
     """
+    # Recognition of the modern error is about the CODE: a server answering
+    # -32022 speaks the modern vocabulary even when the error's data block is
+    # malformed (the probe then reports UNSUPPORTED for the readiness rule,
+    # which judges the shape — that must not demote the server's era).
+    unknown = (probes or {}).get(PROBE_UNKNOWN_VERSION)
     modern = has_modern_support(probes) or (
-        probes is not None
-        and PROBE_UNKNOWN_VERSION in probes
-        and probes[PROBE_UNKNOWN_VERSION].outcome is ProbeOutcome.SUPPORTED
+        unknown is not None
+        and (
+            unknown.outcome is ProbeOutcome.SUPPORTED
+            or unknown.details.get("error_code") == ERROR_UNSUPPORTED_PROTOCOL_VERSION
+        )
     )
     legacy = session_protocol_version is not None
 

--- a/mcpscore/rules/readiness.py
+++ b/mcpscore/rules/readiness.py
@@ -138,6 +138,70 @@ class ServerDiscoverReadinessRule(ProbeBackedReadinessRule):
 
 
 @register_rule
+class SupportedVersionsReadinessRule(ProbeBackedReadinessRule):
+    """The DiscoverResult names at least one supported protocol version.
+
+    The schema requires ``supportedVersions: string[]`` on every DiscoverResult
+    and the client "should choose a version from this list for use in
+    subsequent requests" — an empty list satisfies the type but makes version
+    selection impossible, so it is judged a defect here (the schema has no
+    minItems constraint yet). Skips when there is no DiscoverResult to
+    inspect: the CRITICAL gateway rule already carries that verdict.
+    """
+
+    rule_id = "readiness_2026_supported_versions"
+    rule_order = 13
+    probe_id = PROBE_DISCOVER
+
+    @property
+    def rule_name(self) -> str:
+        return f"Readiness {READINESS_TARGET} - supported versions listed"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip (beyond the base gating) when the discover probe found no DiscoverResult."""
+        if reason := super().skip_reason(audit_data):
+            return reason
+        if self._probe(audit_data).outcome is not ProbeOutcome.SUPPORTED:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        return None
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        probe = self._probe(audit_data)
+        versions = probe.details.get("supported_versions")
+        versions = versions if isinstance(versions, list) else []
+        non_strings = [v for v in versions if not isinstance(v, str)]
+        passed = bool(versions) and not non_strings
+        if passed:
+            message = f"✅ server/discover names {len(versions)} supported protocol version(s): {versions}"
+        elif not versions:
+            message = (
+                "❌ server/discover returns an empty supportedVersions list — clients choose their "
+                "protocol version from this list, so an empty one makes version selection impossible"
+            )
+        else:
+            message = (
+                f"❌ supportedVersions contains non-string entries {non_strings} — the schema "
+                "requires a list of protocol version strings"
+            )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={
+                "sep": "SEP-2575",
+                "schema_field": "DiscoverResult.supportedVersions",
+                "target_version": READINESS_TARGET,
+                "supported_versions": versions,
+            },
+        )
+
+
+@register_rule
 class StatelessRequestReadinessRule(ProbeBackedReadinessRule):
     """Gateway check: the server accepts a stateless request with per-request ``_meta`` (SEP-2575)."""
 
@@ -304,7 +368,12 @@ class CacheMetadataReadinessRule(ReadinessBaseRule):
 
 @register_rule
 class UnsupportedVersionErrorReadinessRule(ProbeBackedReadinessRule):
-    """Unknown protocol versions are rejected with -32022 naming the supported versions."""
+    """Unknown protocol versions are rejected with -32022 naming the supported versions.
+
+    The error code alone is not enough: the schema requires the error's
+    ``data`` to carry ``supported`` (the versions to retry with) and
+    ``requested``, so a bare -32022 fails with its own message.
+    """
 
     rule_id = "readiness_2026_unsupported_version_error"
     rule_order = 6
@@ -324,6 +393,11 @@ class UnsupportedVersionErrorReadinessRule(ProbeBackedReadinessRule):
         if passed:
             message = (
                 f"✅ Unknown protocol versions are rejected with -32022 (supported: {probe.details.get('supported')})"
+            )
+        elif probe.details.get("data_well_formed") is False:
+            message = (
+                "❌ -32022 is emitted but its data block is missing or malformed — the error must "
+                "carry data.supported (a non-empty list of versions to retry with) and data.requested"
             )
         else:
             message = (

--- a/mcpscore/rules/readiness.py
+++ b/mcpscore/rules/readiness.py
@@ -196,6 +196,7 @@ class SupportedVersionsReadinessRule(ProbeBackedReadinessRule):
                 "sep": "SEP-2575",
                 "schema_field": "DiscoverResult.supportedVersions",
                 "target_version": READINESS_TARGET,
+                **probe.details,
                 "supported_versions": versions,
             },
         )

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -142,6 +142,7 @@ async def test_modern_server_supports_all_probed_behaviors():
     unknown = results[PROBE_UNKNOWN_VERSION].details
     assert unknown["supported"] == ["2026-07-28"]
     assert unknown["requested"] == "2099-01-01"
+    assert unknown["data_well_formed"] is True
 
     assert results[PROBE_MISSING_RESOURCE].details["legacy_code_emitted"] is False
 
@@ -686,22 +687,56 @@ async def test_error_without_message_field_is_handled():
     assert "error_message" not in details
 
 
-async def test_unknown_version_error_with_non_dict_data():
+def _unknown_version_handler(data: object) -> object:
+    """Build a handler answering every request with -32022 carrying the given error data.
+
+    ``data`` is spliced into the error verbatim; the sentinel ``_OMIT`` leaves
+    the data member out entirely (a bare -32022).
+    """
+
     def handler(request: httpx2.Request) -> httpx2.Response:
         body = json.loads(request.content)
-        return httpx2.Response(
-            400,
-            json={
-                "jsonrpc": "2.0",
-                "id": body.get("id"),
-                "error": {"code": ERROR_UNSUPPORTED_PROTOCOL_VERSION, "message": "nope", "data": "not-a-dict"},
-            },
-        )
+        error: dict = {"code": ERROR_UNSUPPORTED_PROTOCOL_VERSION, "message": "nope"}
+        if data is not _OMIT:
+            error["data"] = data
+        return httpx2.Response(400, json={"jsonrpc": "2.0", "id": body.get("id"), "error": error})
 
-    results = await _run(handler)
+    return handler
+
+
+_OMIT = object()
+
+
+async def test_unknown_version_error_with_non_dict_data():
+    # The error code alone is not enough (schema requires data.supported +
+    # data.requested); before the tightening this outcome was SUPPORTED.
+    results = await _run(_unknown_version_handler("not-a-dict"))
     unknown = results[PROBE_UNKNOWN_VERSION]
-    assert unknown.outcome is ProbeOutcome.SUPPORTED
-    assert "supported" not in unknown.details
+    assert unknown.outcome is ProbeOutcome.UNSUPPORTED
+    assert unknown.details["supported"] is None
+    assert unknown.details["data_well_formed"] is False
+
+
+async def test_unknown_version_error_without_data():
+    results = await _run(_unknown_version_handler(_OMIT))
+    unknown = results[PROBE_UNKNOWN_VERSION]
+    assert unknown.outcome is ProbeOutcome.UNSUPPORTED
+    assert unknown.details["data_well_formed"] is False
+
+
+async def test_unknown_version_error_with_empty_supported_list():
+    results = await _run(_unknown_version_handler({"supported": [], "requested": "2099-01-01"}))
+    unknown = results[PROBE_UNKNOWN_VERSION]
+    assert unknown.outcome is ProbeOutcome.UNSUPPORTED
+    assert unknown.details["data_well_formed"] is False
+
+
+async def test_unknown_version_error_without_requested_echo():
+    results = await _run(_unknown_version_handler({"supported": ["2026-07-28"]}))
+    unknown = results[PROBE_UNKNOWN_VERSION]
+    assert unknown.outcome is ProbeOutcome.UNSUPPORTED
+    assert unknown.details["supported"] == ["2026-07-28"]
+    assert unknown.details["data_well_formed"] is False
 
 
 async def test_run_all_probes_creates_its_own_client_when_none_given(monkeypatch):

--- a/tests/test_readiness_rules.py
+++ b/tests/test_readiness_rules.py
@@ -32,6 +32,7 @@ from mcpscore.rules.readiness import (
     ResultTypeReadinessRule,
     ServerDiscoverReadinessRule,
     StatelessRequestReadinessRule,
+    SupportedVersionsReadinessRule,
     ToolSchemaDialectReadinessRule,
     UnsupportedVersionErrorReadinessRule,
 )
@@ -144,6 +145,18 @@ class TestDetailProbeRules:
         assert rule.skip_reason(data) is None
         assert not rule.check(data).passed
 
+    def test_unsupported_version_error_flags_missing_data(self):
+        probes = modern_probes(
+            probe_unknown_version=ProbeResult(
+                PROBE_UNKNOWN_VERSION,
+                ProbeOutcome.UNSUPPORTED,
+                {"http_status": 400, "supported": None, "requested": None, "data_well_formed": False},
+            )
+        )
+        result = UnsupportedVersionErrorReadinessRule().check(AuditData(probes=probes))
+        assert not result.passed
+        assert "data block is missing or malformed" in result.message
+
     def test_error_code_migration_flags_legacy_code(self):
         probes = modern_probes(
             probe_missing_resource=ProbeResult(
@@ -155,6 +168,54 @@ class TestDetailProbeRules:
         result = ErrorCodeMigrationReadinessRule().check(AuditData(probes=probes))
         assert not result.passed
         assert "-32002" in result.message
+
+
+class TestSupportedVersionsRule:
+    def test_pass_against_modern_server(self):
+        data = AuditData(probes=modern_probes())
+        rule = SupportedVersionsReadinessRule()
+        assert rule.skip_reason(data) is None
+        result = rule.check(data)
+        assert result.passed
+        assert result.details["supported_versions"] == ["2026-07-28"]
+
+    def test_fail_when_list_is_empty(self):
+        probes = modern_probes(
+            probe_discover=ProbeResult(
+                PROBE_DISCOVER, ProbeOutcome.SUPPORTED, {"http_status": 200, "supported_versions": []}
+            )
+        )
+        data = AuditData(probes=probes)
+        rule = SupportedVersionsReadinessRule()
+        assert rule.skip_reason(data) is None
+        result = rule.check(data)
+        assert not result.passed
+        assert "empty" in result.message
+
+    def test_fail_on_non_string_entries(self):
+        probes = modern_probes(
+            probe_discover=ProbeResult(
+                PROBE_DISCOVER,
+                ProbeOutcome.SUPPORTED,
+                {"http_status": 200, "supported_versions": ["2026-07-28", 20260728]},
+            )
+        )
+        result = SupportedVersionsReadinessRule().check(AuditData(probes=probes))
+        assert not result.passed
+        assert "non-string" in result.message
+
+    def test_skip_when_discover_answered_without_result(self):
+        # Stateless gateway keeps modern support, but there is no DiscoverResult
+        # to inspect — the gateway rule carries that verdict, this one skips.
+        probes = modern_probes(
+            probe_discover=ProbeResult(PROBE_DISCOVER, ProbeOutcome.UNSUPPORTED, {"http_status": 404})
+        )
+        rule = SupportedVersionsReadinessRule()
+        assert rule.skip_reason(AuditData(probes=probes)) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_skip_without_modern_support(self):
+        rule = SupportedVersionsReadinessRule()
+        assert rule.skip_reason(AuditData(probes=legacy_probes())) == SKIP_REASON_REQUIRES_MODERN_SUPPORT
 
 
 class TestCacheMetadataRule:
@@ -469,6 +530,7 @@ class TestSepCitations:
         # server/discover, statelessness, session removal, subscriptions/listen,
         # and the removed methods all land in SEP-2575 — except sessions.
         "readiness_2026_server_discover": "SEP-2575",
+        "readiness_2026_supported_versions": "SEP-2575",
         "readiness_2026_stateless_request": "SEP-2575",
         "readiness_2026_meta_validation": "SEP-2575",
         "readiness_2026_unsupported_version_error": "SEP-2575",

--- a/tests/test_readiness_rules.py
+++ b/tests/test_readiness_rules.py
@@ -352,6 +352,17 @@ class TestEraDetection:
         )
         assert detect_era(None, probes) is Era.MODERN
 
+    def test_modern_via_bare_error_code_with_malformed_data(self):
+        # A bare -32022 fails the readiness rule's shape check (UNSUPPORTED),
+        # but the code itself is modern vocabulary — era must not demote.
+        probes = legacy_probes()
+        probes[PROBE_UNKNOWN_VERSION] = ProbeResult(
+            PROBE_UNKNOWN_VERSION,
+            ProbeOutcome.UNSUPPORTED,
+            {"http_status": 400, "error_code": -32022, "data_well_formed": False},
+        )
+        assert detect_era(None, probes) is Era.MODERN
+
     def test_no_evidence(self):
         assert detect_era(None, not_applicable_results(reason="stdio")) is None
         assert detect_era(None, None) is None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Readiness-axis and probe scoring changes only; era detection is explicitly preserved. Servers that emitted bare -32022 may fail an additional readiness check.
> 
> **Overview**
> Adds **HIGH** readiness rule `readiness_2026_supported_versions`, which fails when `server/discover` returns an empty `supportedVersions` list or non-string entries (schema allows empty arrays but clients cannot pick a version).
> 
> **Tightens** `readiness_2026_unsupported_version_error` and the unknown-version probe: **-32022** alone is no longer enough—the error `data` must include a non-empty `supported` string list and `requested`. The probe records `data_well_formed` and stays **UNSUPPORTED** when that shape is wrong, with a dedicated failure message on the rule.
> 
> **Era detection** still treats **-32022** as modern-era evidence even when `data` is malformed, so stricter readiness scoring does not downgrade lifecycle classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79711cb76ee1345b7444d675918443a557821679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->