### PR TITLE
Feat/generic stdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--stdio`: audit local MCP servers written in any language.** The flag
+  launches an arbitrary stdio command — a compiled Go binary,
+  `java -jar server.jar`, `dotnet run --project …` — and audits it exactly
+  like a `.py`/`.js` target. It consumes the rest of the command line (the
+  server's own flags included), runs the command directly with no shell, and
+  pairs with the new repeatable `--env NAME=VALUE` for server configuration
+  (merged over the SDK's minimal default environment; values are never
+  logged). Library consumers get the same via the new `StdioCommand`
+  dataclass accepted by `MCPClient.detect_and_connect`. The positional
+  `.py`/`.js`/URL target is unchanged.
+
 - Collect and fully paginate MCP resource templates, preserving partial evidence
   and reporting incomplete listings when pagination fails, loops, or exceeds its
   safety bound.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `java -jar server.jar`, `dotnet run --project …` — and audits it exactly
   like a `.py`/`.js` target. It consumes the rest of the command line (the
   server's own flags included), runs the command directly with no shell, and
-  pairs with the new repeatable `--env NAME=VALUE` for server configuration
+  pairs with the new repeatable `--env` for server configuration
   (merged over the SDK's minimal default environment; values are never
-  logged). Library consumers get the same via the new `StdioCommand`
+  logged or reported). `--env NAME=VALUE` sets a value inline for
+  non-sensitive config; the value-less `--env NAME` copies the value from
+  mcpscore's own environment, keeping secrets off every command line. Library consumers get the same via the new `StdioCommand`
   dataclass accepted by `MCPClient.detect_and_connect`. The positional
   `.py`/`.js`/URL target is unchanged.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 - **Multiple transports**: STDIO (local servers), Streamable HTTP, and SSE (remote servers)
 - **Auto-detection**: Picks the right transport automatically — tries Streamable HTTP first, falls back to SSE for URLs
 - **Real handshake verification**: A connection only counts once the server completes the MCP `initialize` handshake — pointing it at a non-MCP endpoint fails cleanly
-- **Multi-language**: Audits both Python (`.py`) and Node.js (`.js`) MCP servers via STDIO
+- **Any-language**: Audits MCP servers in any language via STDIO — `.py`/`.js` files directly, everything else (Go, Java, C#, Rust, ...) via `--stdio <command>`
 - **Severity-based reporting**: Rules categorized as CRITICAL, HIGH, MEDIUM, or LOW
 - **Library-friendly**: Fully typed (`py.typed`); use `MCPClient` + `MCPAuditor` programmatically
 
@@ -77,8 +77,10 @@ also count toward the main score; for everyone else the axis stays informative.
 ## Requirements
 
 - Python 3.11+
-- Node.js on `PATH` if auditing a Node.js MCP server
-- A Python interpreter on `PATH` if auditing a Python MCP server
+- The server's own runtime on `PATH` when auditing a local server: Node.js for
+  `.js` targets, a Python interpreter for `.py` targets, and for `--stdio`
+  whatever the command names (a JRE for `java -jar`, the .NET SDK for
+  `dotnet run`, nothing extra for a compiled Go/Rust binary)
 
 ## Installation
 
@@ -205,7 +207,7 @@ server. Full details, including the HTML form and how freshness works, are in th
 **Connection fails**
 
 - Check the path or URL is correct and reachable
-- For local servers, make sure Python or Node.js is on `PATH`
+- For local servers, make sure the runtime is on `PATH` (Python/Node.js for `.py`/`.js` targets; whatever `--stdio` names for other languages)
 - "Not a valid MCP server (handshake failed)" means the endpoint responded but did not complete the MCP `initialize` handshake — verify the URL points at an actual MCP endpoint (often `/mcp`)
 
 **Protocol version errors**

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ mcpscore path/to/your/server.py
 # Local Node.js MCP server (STDIO)
 mcpscore path/to/your/server.js
 
+# Local server in any language — --stdio runs an arbitrary command
+# (put mcpscore options before it; it consumes the rest of the line)
+mcpscore --stdio ./my-go-server
+mcpscore --stdio java -jar server.jar
+
 # Remote MCP server (auto-detects Streamable HTTP or SSE)
 mcpscore https://example.com/mcp
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ mcpscore path/to/your/server.js
 mcpscore --stdio ./my-go-server
 mcpscore --stdio java -jar server.jar
 
+# Server env: --env NAME=VALUE for plain config; value-less --env NAME
+# copies from your environment — use that form for secrets
+API_KEY=... mcpscore --env API_KEY --stdio ./my-go-server
+
 # Remote MCP server (auto-detects Streamable HTTP or SSE)
 mcpscore https://example.com/mcp
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -51,6 +51,13 @@ issues before your users do.
 mcpscore path/to/server.py
 mcpscore path/to/server.js
 
+# Local servers in any language: --stdio runs an arbitrary command
+# (it consumes the rest of the line, so put mcpscore options first;
+# pass secrets via --env — the command line appears in the report)
+mcpscore --stdio ./my-go-server
+mcpscore --stdio java -jar server.jar
+mcpscore --env API_KEY=... --stdio dotnet run --project ./server
+
 # Remote servers (Streamable HTTP / SSE, auto-detected —
 # including modern-only servers on the 2026 stateless lifecycle)
 mcpscore https://example.com/mcp

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -52,11 +52,15 @@ mcpscore path/to/server.py
 mcpscore path/to/server.js
 
 # Local servers in any language: --stdio runs an arbitrary command
-# (it consumes the rest of the line, so put mcpscore options first;
-# pass secrets via --env — the command line appears in the report)
+# (it consumes the rest of the line, so put mcpscore options first)
 mcpscore --stdio ./my-go-server
 mcpscore --stdio java -jar server.jar
-mcpscore --env API_KEY=... --stdio dotnet run --project ./server
+
+# Server env vars: NAME=VALUE inline for plain config; for secrets use
+# the value-less form, which copies from mcpscore's own environment so
+# the value never touches a command line or the report
+mcpscore --env LOG_LEVEL=debug --stdio dotnet run --project ./server
+API_KEY=... mcpscore --env API_KEY --stdio ./my-go-server
 
 # Remote servers (Streamable HTTP / SSE, auto-detected —
 # including modern-only servers on the 2026 stateless lifecycle)

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -49,7 +49,7 @@ of three reasons:
 
 ## How an audit runs
 
-1. **Connect** — stdio (local `.py`/`.js` servers), Streamable HTTP, or SSE, with
+1. **Connect** — stdio (local servers in any language: `.py`/`.js` files directly, or an arbitrary command via `--stdio`), Streamable HTTP, or SSE, with
    automatic transport detection. A connection only counts once the server completes a
    real MCP handshake.
 2. **Collect** — protocol version, server info, capabilities, tools, resources,

--- a/mcpscore/__init__.py
+++ b/mcpscore/__init__.py
@@ -15,7 +15,7 @@ aspects of MCP compliance and contributes to an overall audit score.
 from . import spec
 from .enums import ConnectionErrorReason, MCPProtocolVersion, MCPTransportType
 from .mcp_auditor import MCPAuditor
-from .mcp_client import ConnectionFailure, MCPClient
+from .mcp_client import ConnectionFailure, MCPClient, StdioCommand
 from .rules import (
     AuditData,
     BaseRule,
@@ -36,5 +36,6 @@ __all__ = (
     "RuleResult",
     "RuleSeverity",
     "SkippedRule",
+    "StdioCommand",
     "spec",
 )

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -12,7 +12,7 @@ import os
 import sys
 from typing import TYPE_CHECKING, NoReturn
 
-from mcpscore import MCPAuditor, MCPClient
+from mcpscore import MCPAuditor, MCPClient, StdioCommand
 from mcpscore.enums import ConnectionErrorReason
 from mcpscore.mcp_auditor import has_authorization_credential
 from mcpscore.probes import observed_auth_status
@@ -56,7 +56,33 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "target",
-        help="Path to a local MCP server (.py, .js) or URL of a remote server (Streamable HTTP / SSE)",
+        nargs="?",
+        help=(
+            "Path to a local MCP server (.py, .js) or URL of a remote server (Streamable HTTP / SSE). "
+            "For servers in other languages, use --stdio instead."
+        ),
+    )
+    parser.add_argument(
+        "--stdio",
+        nargs=argparse.REMAINDER,
+        metavar="COMMAND",
+        help=(
+            "Launch a local MCP server as an arbitrary stdio command — any language: "
+            "--stdio ./server, --stdio java -jar server.jar, --stdio dotnet run --project ./srv. "
+            "Consumes the REST of the command line (the server's own flags included), so put "
+            "every mcpscore option before it. Replaces the positional target. The command runs "
+            "directly (no shell). Pass secrets via --env, not as arguments — the command line "
+            "appears as the report's target (and in the process list)."
+        ),
+    )
+    parser.add_argument(
+        "--env",
+        action="append",
+        metavar="NAME=VALUE",
+        help=(
+            "Extra environment variable for the --stdio server process, e.g. --env API_KEY=… "
+            "Repeatable. Merged over a minimal default environment; values are never logged."
+        ),
     )
     # An "action=version" argument exits during parsing, before argparse
     # enforces the required `target` — so `mcpscore --version` works on its
@@ -172,6 +198,60 @@ def collect_headers(args: argparse.Namespace) -> dict[str, str]:
     return headers
 
 
+def parse_env_vars(pairs: list[str]) -> dict[str, str]:
+    """Parse repeated ``NAME=VALUE`` --env arguments into a dict.
+
+    Args:
+        pairs: Raw --env values as given on the command line.
+
+    Returns:
+        Mapping of variable names to values (later duplicates win).
+
+    Raises:
+        ValueError: If an entry has no ``=`` or an empty name. The message
+            names the variable only — values are sensitive and never echoed.
+
+    """
+    env: dict[str, str] = {}
+    for raw in pairs:
+        name, sep, value = raw.partition("=")
+        if not sep or not name:
+            label = name or "<empty>"
+            raise ValueError(f"--env expects NAME=VALUE (got an entry for '{label}' without one)")
+        env[name] = value
+    return env
+
+
+def resolve_target(args: argparse.Namespace) -> str | StdioCommand:
+    """Resolve the audit target from the positional target and --stdio.
+
+    Exactly one of the two must be given; --env only makes sense with
+    --stdio (a URL or bare script target spawns no configurable process).
+
+    Returns:
+        The URL / script path string, or a StdioCommand for --stdio.
+
+    Raises:
+        ValueError: On any invalid combination (message is user-facing).
+
+    """
+    if args.stdio is not None:
+        if args.target is not None:
+            raise ValueError("give either a target or --stdio, not both")
+        if not args.stdio:
+            raise ValueError("--stdio needs a command to run, e.g. --stdio java -jar server.jar")
+        return StdioCommand(
+            command=args.stdio[0],
+            args=tuple(args.stdio[1:]),
+            env=parse_env_vars(args.env) if args.env else None,
+        )
+    if args.env:
+        raise ValueError("--env only applies to --stdio servers")
+    if args.target is None:
+        raise ValueError("a target is required: a URL, a .py/.js path, or --stdio <command>")
+    return args.target
+
+
 def _mcpscore_version() -> str:
     """Return the installed mcpscore package version, or "unknown"."""
     try:
@@ -244,7 +324,7 @@ def build_report(target: str, transport: MCPTransportType | None, auditor: MCPAu
     }
 
 
-async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> None:
+async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str], target: str | StdioCommand) -> None:
     """Run the --oauth browser flow and place the token into the header dict.
 
     Exits with code 1 on flag conflicts or a failed flow; a no-op when
@@ -264,14 +344,14 @@ async def _apply_oauth(args: argparse.Namespace, headers: dict[str, str]) -> Non
             "(--token, an Authorization --header, or the MCPSCORE_TOKEN environment variable) — pick one"
         )
         sys.exit(1)
-    if not args.target.startswith(("http://", "https://")):
+    if not isinstance(target, str) or not target.startswith(("http://", "https://")):
         logger.error("Usage error: --oauth requires an HTTP(S) server URL")
         sys.exit(1)
     from mcpscore.oauth import OAuthFlowError, obtain_token_interactively
 
     try:
         access_token = await obtain_token_interactively(
-            args.target, client_id=args.client_id, callback_port=args.callback_port
+            target, client_id=args.client_id, callback_port=args.callback_port
         )
     except OAuthFlowError as e:
         logger.error("OAuth: %s", e)  # noqa: TRY400 — user-facing outcome, not a traceback
@@ -307,6 +387,15 @@ async def async_main() -> None:
     # neither should be preceded by a banner.
     args = build_parser().parse_args()
 
+    # Resolve the target before greeting: an invalid target/--stdio combination
+    # is a usage error, and (like argparse's own) it should not be preceded by
+    # a banner.
+    try:
+        target = resolve_target(args)
+    except ValueError as e:
+        logger.error("Usage error: %s", e)  # noqa: TRY400 — usage error, not an exception to trace
+        sys.exit(1)
+
     logger.info("Welcome to mcpscore!")
 
     try:
@@ -315,7 +404,11 @@ async def async_main() -> None:
         logger.error("Usage error: %s", e)  # noqa: TRY400 — usage error, not an exception to trace
         sys.exit(1)
 
-    await _apply_oauth(args, headers)
+    # What the report and log lines call the target: the URL/path itself, or
+    # the joined command line for a --stdio server.
+    target_display = target if isinstance(target, str) else target.display
+
+    await _apply_oauth(args, headers, target)
 
     if headers:
         logger.info("Using %d custom header(s).", len(headers))
@@ -327,18 +420,18 @@ async def async_main() -> None:
     # can leave resources on the client's exit stack, so every path out —
     # early returns, sys.exit(2), audit errors — must reach cleanup().
     try:
-        success, transport = await client.detect_and_connect(args.target)
+        success, transport = await client.detect_and_connect(target)
 
         if not success:
-            if args.target.startswith(("http://", "https://")):
+            if isinstance(target, str) and target.startswith(("http://", "https://")):
                 logger.info("Legacy connection failed — checking for a modern-only (stateless lifecycle) MCP server...")
-                if await auditor.audit_modern_only(args.target):
+                if await auditor.audit_modern_only(target):
                     logger.info(
                         "Modern-only MCP server detected: audited via stateless probes (no legacy session available)."
                     )
                     log_audit_outcome(auditor)
                     if args.json:
-                        report = build_report(args.target, auditor.audit_data.transport_type, auditor)
+                        report = build_report(target_display, auditor.audit_data.transport_type, auditor)
                         sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
                     return
 
@@ -417,16 +510,16 @@ async def async_main() -> None:
                             f"Server requires authentication (HTTP {status}); scored the unauthenticated surface "
                             "only — pass a token to audit behind the gate."
                         )
-                    await auditor.audit_partial(args.target, reason=partial_reason)
+                    await auditor.audit_partial(target, reason=partial_reason)
                     log_audit_outcome(auditor)
                     if args.json:
-                        report = build_report(args.target, auditor.audit_data.transport_type, auditor)
+                        report = build_report(target_display, auditor.audit_data.transport_type, auditor)
                         sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
                     return
-            logger.error("Error connecting to the MCP server: %s", args.target)
+            logger.error("Error connecting to the MCP server: %s", target_display)
             sys.exit(2)
 
-        logger.info("Connected to the MCP server: %s", args.target)
+        logger.info("Connected to the MCP server: %s", target_display)
         logger.info("Transport: %s", transport)
 
         logger.info("Starting the audit...")
@@ -434,7 +527,7 @@ async def async_main() -> None:
         log_audit_outcome(auditor)
 
         if args.json:
-            report = build_report(args.target, transport, auditor)
+            report = build_report(target_display, transport, auditor)
             sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
     finally:
         await client.cleanup()

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -209,15 +209,17 @@ def parse_env_vars(pairs: list[str]) -> dict[str, str]:
 
     Raises:
         ValueError: If an entry has no ``=`` or an empty name. The message
-            names the variable only — values are sensitive and never echoed.
+            identifies the entry by position only and never echoes any part
+            of it: without a ``=`` there is no way to tell a variable name
+            from an accidentally pasted secret (same policy as
+            ``parse_header``).
 
     """
     env: dict[str, str] = {}
-    for raw in pairs:
+    for position, raw in enumerate(pairs, start=1):
         name, sep, value = raw.partition("=")
         if not sep or not name:
-            label = name or "<empty>"
-            raise ValueError(f"--env expects NAME=VALUE (got an entry for '{label}' without one)")
+            raise ValueError(f"--env #{position}: expected NAME=VALUE (the entry is not shown — it may carry a secret)")
         env[name] = value
     return env
 

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -71,8 +71,8 @@ def build_parser() -> argparse.ArgumentParser:
             "--stdio ./server, --stdio java -jar server.jar, --stdio dotnet run --project ./srv. "
             "Consumes the REST of the command line (the server's own flags included), so put "
             "every mcpscore option before it. Replaces the positional target. The command runs "
-            "directly (no shell). Pass secrets via --env, not as arguments — the command line "
-            "appears as the report's target (and in the process list)."
+            "directly (no shell). Never pass secrets as arguments — the command line appears as "
+            "the report's target (and in the process list); use the value-less --env NAME form."
         ),
     )
     parser.add_argument(
@@ -80,8 +80,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         metavar="NAME=VALUE",
         help=(
-            "Extra environment variable for the --stdio server process, e.g. --env API_KEY=… "
-            "Repeatable. Merged over a minimal default environment; values are never logged."
+            "Extra environment variable for the --stdio server process. Repeatable. "
+            "--env NAME=VALUE sets it inline (non-sensitive config only: the value lands in "
+            "shell history and the process list). --env NAME copies the value from mcpscore's "
+            "own environment — use this for secrets: API_KEY=… mcpscore --env API_KEY --stdio … "
+            "Merged over a minimal default environment; values are never logged or reported."
         ),
     )
     # An "action=version" argument exits during parsing, before argparse
@@ -199,7 +202,13 @@ def collect_headers(args: argparse.Namespace) -> dict[str, str]:
 
 
 def parse_env_vars(pairs: list[str]) -> dict[str, str]:
-    """Parse repeated ``NAME=VALUE`` --env arguments into a dict.
+    """Parse repeated --env arguments (``NAME=VALUE`` or value-less ``NAME``).
+
+    ``NAME=VALUE`` sets the value inline — fine for non-sensitive
+    configuration. A bare ``NAME`` copies the value from mcpscore's own
+    inherited environment (``API_KEY=… mcpscore --env API_KEY --stdio …``) —
+    the right form for secrets, because the value never appears on any
+    command line, in shell history, or in a process listing.
 
     Args:
         pairs: Raw --env values as given on the command line.
@@ -208,19 +217,29 @@ def parse_env_vars(pairs: list[str]) -> dict[str, str]:
         Mapping of variable names to values (later duplicates win).
 
     Raises:
-        ValueError: If an entry has no ``=`` or an empty name. The message
-            identifies the entry by position only and never echoes any part
-            of it: without a ``=`` there is no way to tell a variable name
-            from an accidentally pasted secret (same policy as
-            ``parse_header``).
+        ValueError: If an entry has an empty name, or names a variable that
+            is not set in the environment. Error messages identify the entry
+            by position only and never echo it: a malformed entry may be an
+            accidentally pasted secret (same policy as ``parse_header``).
 
     """
     env: dict[str, str] = {}
     for position, raw in enumerate(pairs, start=1):
         name, sep, value = raw.partition("=")
-        if not sep or not name:
-            raise ValueError(f"--env #{position}: expected NAME=VALUE (the entry is not shown — it may carry a secret)")
-        env[name] = value
+        if not name:
+            raise ValueError(
+                f"--env #{position}: expected NAME=VALUE or NAME (the entry is not shown — it may carry a secret)"
+            )
+        if not sep:
+            inherited = os.environ.get(name)
+            if inherited is None:
+                raise ValueError(
+                    f"--env #{position}: names a variable that is not set in the environment "
+                    "(the entry is not shown — it may be a mistyped name or a pasted secret)"
+                )
+            env[name] = inherited
+        else:
+            env[name] = value
     return env
 
 

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -1,8 +1,9 @@
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
+import shlex
 import sys
 import time
 from typing import TYPE_CHECKING, Any
@@ -17,7 +18,7 @@ from mcp import (
     StdioServerParameters,
 )
 from mcp.client.sse import sse_client
-from mcp.client.stdio import stdio_client
+from mcp.client.stdio import get_default_environment, stdio_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp_types import ListResourceTemplatesResult, PaginatedRequestParams, Prompt, Resource, ResourceTemplate, Tool
 
@@ -29,6 +30,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ERROR_NO_ACTIVE_SESSION = "No active session, connect to the MCP server first!"
+
+
+@dataclass(frozen=True)
+class StdioCommand:
+    """A local MCP server launched as an arbitrary stdio command.
+
+    Generalizes the ``.py``/``.js`` file targets to any language: a compiled
+    Go binary, ``java -jar server.jar``, ``dotnet run --project …``, and so
+    on. The command is executed directly (no shell), so arguments need no
+    quoting and behave identically across platforms.
+
+    Attributes:
+        command: The executable to launch (resolved on PATH or a file path).
+        args: Arguments passed to the executable, in order.
+        env: Extra environment variables for the server process, merged over
+            the SDK's minimal default environment. None inherits the default.
+
+    """
+
+    command: str
+    args: tuple[str, ...] = ()
+    env: Mapping[str, str] | None = field(default=None, hash=False)
+
+    @property
+    def display(self) -> str:
+        """Return the human-readable command line (for logs and the report)."""
+        return shlex.join([self.command, *self.args])
+
 
 HANDSHAKE_TIMEOUT_S = 30
 """Default timeout for the MCP initialize handshake performed during connect."""
@@ -176,19 +205,24 @@ class MCPClient:
         # HTTP status recovered from a single attempt's buffered teardown error.
         self._pending_http_status: int | None = None
 
-    async def detect_and_connect(self, server_path_or_url: str) -> tuple[bool, MCPTransportType | None]:
+    async def detect_and_connect(self, server_path_or_url: str | StdioCommand) -> tuple[bool, MCPTransportType | None]:
         """Automatically detect transport type and connect to MCP server.
 
         Attempts to connect using Streamable HTTP first, then falls back to SSE.
-        For local files (.py, .js), uses stdio transport.
+        For local files (.py, .js), uses stdio transport. A ``StdioCommand``
+        launches an arbitrary local server command over stdio (any language).
 
         Args:
-            server_path_or_url: Path to server script or URL
+            server_path_or_url: Path to server script, URL, or a StdioCommand
 
         Returns:
             Tuple of (success: bool, transport: MCPTransportType | None)
 
         """
+        if isinstance(server_path_or_url, StdioCommand):
+            success = await self._connect_with_stdio_command(server_path_or_url)
+            return (success, MCPTransportType.STDIO if success else None)
+
         # Check if it's a local file path
         if server_path_or_url.endswith((".py", ".js")):
             success = await self.connect_to_server(MCPTransportType.STDIO, server_path_or_url)
@@ -373,31 +407,64 @@ class MCPClient:
 
         # Use sys.executable for Python to ensure we use the same interpreter
         command: str = sys.executable if is_python else "node"
+        missing_hint = (
+            "Python interpreter not found. Please ensure Python is installed and on PATH."
+            if is_python
+            else "Node.js not found. Please ensure Node.js is installed and on PATH."
+        )
         server_params = StdioServerParameters(command=command, args=[server_script_path], env=None)
+        return await self._launch_stdio(server_params, display=server_script_path, missing_hint=missing_hint)
 
+    async def _connect_with_stdio_command(self, command: StdioCommand) -> bool:
+        """Launch an arbitrary local server command and connect over stdio.
+
+        Args:
+            command: The executable, its arguments, and optional extra
+                environment variables (merged over the SDK's default env).
+
+        Returns:
+            True if a connection was successful, False otherwise
+
+        """
+        env = {**get_default_environment(), **command.env} if command.env else None
+        server_params = StdioServerParameters(command=command.command, args=list(command.args), env=env)
+        missing_hint = f"Command not found: '{command.command}'. Please ensure it is installed and on PATH."
+        return await self._launch_stdio(server_params, display=command.display, missing_hint=missing_hint)
+
+    async def _launch_stdio(self, server_params: StdioServerParameters, display: str, missing_hint: str) -> bool:
+        """Start a stdio server process and perform the MCP handshake.
+
+        Args:
+            server_params: Fully-resolved command, arguments and environment.
+            display: Human-readable target for log messages (script path or
+                joined command line).
+            missing_hint: Message logged when the launcher executable is not
+                found on PATH.
+
+        Returns:
+            True if a connection was successful, False otherwise
+
+        """
         try:
             await self._establish_session(stdio_client(server_params), MCPTransportType.STDIO, url=None)
             return True
         except FileNotFoundError as e:
-            if is_python:
-                logger.exception("Python interpreter not found. Please ensure Python is installed and on PATH.")
-            else:
-                logger.exception("Node.js not found. Please ensure Node.js is installed and on PATH.")
+            logger.exception(missing_hint)
             logger.debug("Error details: %s", e)
             self._record_failure(ConnectionErrorReason.UNREACHABLE)
             return False
         except PermissionError as e:
-            logger.exception("Permission denied accessing server script: %s", server_script_path)
+            logger.exception("Permission denied launching server: %s", display)
             logger.debug("Error details: %s", e)
             self._record_failure(ConnectionErrorReason.UNREACHABLE)
             return False
         except TimeoutError:
-            logger.error("MCP initialize handshake timed out for server: %s", server_script_path)  # noqa: TRY400
+            logger.error("MCP initialize handshake timed out for server: %s", display)  # noqa: TRY400
             self._record_failure(ConnectionErrorReason.TIMEOUT)
             return False
         except asyncio.CancelledError:
             self._reraise_if_cancelled()
-            logger.error("MCP initialize handshake failed for server: %s", server_script_path)  # noqa: TRY400
+            logger.error("MCP initialize handshake failed for server: %s", display)  # noqa: TRY400
             self._record_failure(ConnectionErrorReason.NOT_MCP)
             return False
         except Exception as e:

--- a/mcpscore/mcp_client.py
+++ b/mcpscore/mcp_client.py
@@ -46,12 +46,14 @@ class StdioCommand:
         args: Arguments passed to the executable, in order.
         env: Extra environment variables for the server process, merged over
             the SDK's minimal default environment. None inherits the default.
+            Excluded from the repr — env values are secrets by assumption and
+            must never surface in logs or tracebacks.
 
     """
 
     command: str
     args: tuple[str, ...] = ()
-    env: Mapping[str, str] | None = field(default=None, hash=False)
+    env: Mapping[str, str] | None = field(default=None, hash=False, repr=False)
 
     @property
     def display(self) -> str:

--- a/tests/stdio_e2e_server.py
+++ b/tests/stdio_e2e_server.py
@@ -1,0 +1,54 @@
+"""Minimal stdlib-only MCP stdio server for the real-process e2e test.
+
+Speaks just enough of the legacy (stateful) protocol for a client to complete
+the initialize handshake over newline-delimited JSON-RPC on stdio. It echoes
+the ``MCPSCORE_E2E_ENV`` environment variable back as its serverInfo.version,
+so the test can prove that ``StdioCommand.env`` values genuinely reach the
+launched process — through the SDK's environment handling, not a mock.
+
+Not a test module (no ``test_`` prefix): pytest never collects it; it is only
+ever run as a subprocess via ``--stdio``-style launching.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main() -> None:
+    """Serve initialize (echoing the requested protocol version) until EOF."""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        message = json.loads(line)
+        if message.get("method") == "initialize":
+            response = {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "protocolVersion": message["params"]["protocolVersion"],
+                    "capabilities": {},
+                    "serverInfo": {
+                        "name": "stdio-e2e-server",
+                        "version": os.environ.get("MCPSCORE_E2E_ENV", "env-var-missing"),
+                    },
+                },
+            }
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+        elif "id" in message:  # any other request: method not found
+            error = {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+            sys.stdout.write(json.dumps(error) + "\n")
+            sys.stdout.flush()
+        # Notifications (no id) are ignored.
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,8 +21,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mcpscore import MCPAuditor, MCPClient, MCPTransportType
-from mcpscore.cli import _mcpscore_version, async_main, build_parser, build_report, main
+from mcpscore import MCPAuditor, MCPClient, MCPTransportType, StdioCommand
+from mcpscore.cli import (
+    _mcpscore_version,
+    async_main,
+    build_parser,
+    build_report,
+    main,
+    parse_env_vars,
+    resolve_target,
+)
 
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
@@ -1411,3 +1419,120 @@ class TestOAuthCliFlow:
             with pytest.raises(SystemExit) as exc:
                 await async_main()
             assert exc.value.code == 1
+
+
+class TestStdioCommandCliFlow:
+    """--stdio: generic any-language local servers, and --env plumbing."""
+
+    def test_stdio_remainder_captures_command_and_flags(self) -> None:
+        args = build_parser().parse_args(["--json", "--stdio", "java", "-jar", "server.jar", "--port", "9"])
+        assert args.json is True
+        assert args.stdio == ["java", "-jar", "server.jar", "--port", "9"]
+        assert args.target is None
+
+    def test_resolve_target_builds_stdio_command(self) -> None:
+        args = build_parser().parse_args(["--env", "API_KEY=k", "--stdio", "dotnet", "run"])
+        target = resolve_target(args)
+        assert isinstance(target, StdioCommand)
+        assert target.command == "dotnet"
+        assert target.args == ("run",)
+        assert target.env == {"API_KEY": "k"}
+
+    def test_resolve_target_plain_url_unchanged(self) -> None:
+        args = build_parser().parse_args(["https://example.com/mcp"])
+        assert resolve_target(args) == "https://example.com/mcp"
+
+    def test_resolve_target_rejects_both(self) -> None:
+        args = build_parser().parse_args(["server.py", "--stdio", "./srv"])
+        with pytest.raises(ValueError, match="not both"):
+            resolve_target(args)
+
+    def test_resolve_target_rejects_empty_stdio(self) -> None:
+        args = build_parser().parse_args(["--stdio"])
+        with pytest.raises(ValueError, match="needs a command"):
+            resolve_target(args)
+
+    def test_resolve_target_rejects_missing_target(self) -> None:
+        args = build_parser().parse_args([])
+        with pytest.raises(ValueError, match="target is required"):
+            resolve_target(args)
+
+    def test_resolve_target_rejects_env_without_stdio(self) -> None:
+        args = build_parser().parse_args(["https://example.com/mcp", "--env", "A=1"])
+        with pytest.raises(ValueError, match="--env only applies"):
+            resolve_target(args)
+
+    def test_parse_env_vars_rejects_malformed_without_echoing_value(self) -> None:
+        with pytest.raises(ValueError, match="NAME=VALUE") as exc_info:
+            parse_env_vars(["SECRETVALUE"])
+        assert "SECRETVALUE" in str(exc_info.value)  # the *name* side is safe to show
+        with pytest.raises(ValueError, match="NAME=VALUE"):
+            parse_env_vars(["=value-only"])
+
+    async def test_stdio_usage_error_precedes_banner(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "--stdio"])
+        with caplog.at_level(logging.INFO), pytest.raises(SystemExit) as exc_info:
+            await async_main()
+        assert exc_info.value.code == 1
+        assert "Usage error" in caplog.text
+        assert "Welcome to mcpscore!" not in caplog.text
+
+    async def test_oauth_rejects_stdio_target(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "--oauth", "--stdio", "./server"])
+        with caplog.at_level(logging.INFO), pytest.raises(SystemExit) as exc_info:
+            await async_main()
+        assert exc_info.value.code == 1
+        assert "--oauth requires an HTTP(S) server URL" in caplog.text
+
+    async def test_async_main_audits_stdio_command(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+        caplog: LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A --stdio audit connects, audits, and reports the joined command line."""
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "--json", "--stdio", "java", "-jar", "server.jar"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(True, MCPTransportType.STDIO))
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            caplog.at_level(logging.INFO),
+        ):
+            await async_main()
+
+        (call_target,) = mock_client.detect_and_connect.call_args.args
+        assert isinstance(call_target, StdioCommand)
+        assert call_target.command == "java"
+        assert call_target.args == ("-jar", "server.jar")
+        assert "Connected to the MCP server: java -jar server.jar" in caplog.text
+        report = json.loads(capsys.readouterr().out)
+        assert report["target"] == "java -jar server.jar"
+        assert report["transport"] == "stdio"
+        mock_client.cleanup.assert_called_once()
+
+    async def test_async_main_stdio_command_failure_exits_2(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+        caplog: LogCaptureFixture,
+    ) -> None:
+        """A failed --stdio connect exits 2 without the URL-only fallbacks."""
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "--stdio", "./no-such-server"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            caplog.at_level(logging.INFO),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            await async_main()
+
+        assert exc_info.value.code == 2
+        assert "Error connecting to the MCP server: ./no-such-server" in caplog.text
+        mock_auditor.audit_modern_only.assert_not_called()
+        mock_client.cleanup.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1462,12 +1462,23 @@ class TestStdioCommandCliFlow:
         with pytest.raises(ValueError, match="--env only applies"):
             resolve_target(args)
 
-    def test_parse_env_vars_rejects_malformed_without_echoing_value(self) -> None:
+    def test_parse_env_vars_rejects_malformed_without_echoing_entry(self) -> None:
+        # Without a '=', a "name" is indistinguishable from a pasted secret —
+        # the error identifies the entry by position and never echoes it.
         with pytest.raises(ValueError, match="NAME=VALUE") as exc_info:
-            parse_env_vars(["SECRETVALUE"])
-        assert "SECRETVALUE" in str(exc_info.value)  # the *name* side is safe to show
-        with pytest.raises(ValueError, match="NAME=VALUE"):
-            parse_env_vars(["=value-only"])
+            parse_env_vars(["A=1", "SECRETVALUE"])
+        assert "SECRETVALUE" not in str(exc_info.value)
+        assert "#2" in str(exc_info.value)
+        with pytest.raises(ValueError, match="NAME=VALUE") as exc_info:
+            parse_env_vars(["=secret-value-only"])
+        assert "secret-value-only" not in str(exc_info.value)
+
+    def test_stdio_command_repr_hides_env(self) -> None:
+        cmd = StdioCommand(command="./server", args=("--x",), env={"API_KEY": "hunter2"})
+        rendered = repr(cmd)
+        assert "hunter2" not in rendered
+        assert "API_KEY" not in rendered
+        assert "./server" in rendered  # command/args stay debuggable
 
     async def test_stdio_usage_error_precedes_banner(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
         monkeypatch.setattr(sys, "argv", ["mcpscore", "--stdio"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1462,14 +1462,29 @@ class TestStdioCommandCliFlow:
         with pytest.raises(ValueError, match="--env only applies"):
             resolve_target(args)
 
-    def test_parse_env_vars_rejects_malformed_without_echoing_entry(self) -> None:
-        # Without a '=', a "name" is indistinguishable from a pasted secret —
-        # the error identifies the entry by position and never echoes it.
-        with pytest.raises(ValueError, match="NAME=VALUE") as exc_info:
+    def test_parse_env_vars_inherits_value_less_names(self, monkeypatch: MonkeyPatch) -> None:
+        # The secret-safe form: --env NAME copies from mcpscore's own
+        # environment, so the value never appears on any command line.
+        monkeypatch.setenv("API_KEY", "s3cret-value")
+        argv = ["--env", "API_KEY", "--env", "LOG_LEVEL=debug", "--stdio", "./srv"]
+        target = resolve_target(build_parser().parse_args(argv))
+        assert isinstance(target, StdioCommand)
+        assert target.env == {"API_KEY": "s3cret-value", "LOG_LEVEL": "debug"}
+        # The regression the review asked for: the inherited value reaches the
+        # command's env without ever having been a CLI argument.
+        assert not any("s3cret-value" in token for token in argv)
+
+    def test_parse_env_vars_unset_name_errors_without_echoing_entry(self, monkeypatch: MonkeyPatch) -> None:
+        # A no-'=' entry might be a mistyped name OR a pasted secret — the
+        # error identifies it by position and never echoes it.
+        monkeypatch.delenv("SECRETVALUE", raising=False)
+        with pytest.raises(ValueError, match="not set in the environment") as exc_info:
             parse_env_vars(["A=1", "SECRETVALUE"])
         assert "SECRETVALUE" not in str(exc_info.value)
         assert "#2" in str(exc_info.value)
-        with pytest.raises(ValueError, match="NAME=VALUE") as exc_info:
+
+    def test_parse_env_vars_rejects_empty_name_without_echoing_entry(self) -> None:
+        with pytest.raises(ValueError, match="NAME=VALUE or NAME") as exc_info:
             parse_env_vars(["=secret-value-only"])
         assert "secret-value-only" not in str(exc_info.value)
 

--- a/tests/test_mcp_client_stdio.py
+++ b/tests/test_mcp_client_stdio.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from mcpscore.enums import MCPTransportType
-from mcpscore.mcp_client import MCPClient
+from mcpscore.mcp_client import MCPClient, StdioCommand
 
 
 class TestMCPClientStdioErrors:
@@ -67,7 +67,7 @@ class TestMCPClientStdioErrors:
             result = await mcp_client._connect_with_stdio(server_path)
 
             assert result is False
-            assert "Permission denied accessing server script" in caplog.text
+            assert "Permission denied launching server" in caplog.text
 
     async def test_connect_stdio_generic_exception(self, mcp_client, caplog):
         """Test stdio connection with generic exception."""
@@ -136,3 +136,67 @@ class TestMCPClientStdioErrors:
 
             assert success is False
             assert transport is None
+
+
+class TestStdioCommand:
+    """Generic stdio commands: any-language local servers via StdioCommand."""
+
+    @pytest.fixture
+    def mcp_client(self):
+        return MCPClient()
+
+    async def test_display_joins_command_and_args(self):
+        cmd = StdioCommand(command="java", args=("-jar", "server.jar"))
+        assert cmd.display == "java -jar server.jar"
+
+    async def test_detect_and_connect_dispatches_stdio_command(self, mcp_client):
+        cmd = StdioCommand(command="./server")
+        with patch.object(mcp_client, "_connect_with_stdio_command", return_value=True) as connect:
+            success, transport = await mcp_client.detect_and_connect(cmd)
+        assert success is True
+        assert transport is MCPTransportType.STDIO
+        connect.assert_awaited_once_with(cmd)
+
+    async def test_detect_and_connect_stdio_command_failure(self, mcp_client):
+        cmd = StdioCommand(command="./server")
+        with patch.object(mcp_client, "_connect_with_stdio_command", return_value=False):
+            success, transport = await mcp_client.detect_and_connect(cmd)
+        assert success is False
+        assert transport is None
+
+    async def test_command_passed_through_without_env(self, mcp_client):
+        """No --env: the SDK's own default environment handling applies (env=None)."""
+        cmd = StdioCommand(command="dotnet", args=("run", "--project", "./srv"))
+        with (
+            patch("mcpscore.mcp_client.stdio_client") as mock_stdio,
+            patch.object(mcp_client, "_establish_session", new=AsyncMock()) as establish,
+        ):
+            result = await mcp_client._connect_with_stdio_command(cmd)
+        assert result is True
+        params = mock_stdio.call_args.args[0]
+        assert params.command == "dotnet"
+        assert params.args == ["run", "--project", "./srv"]
+        assert params.env is None
+        establish.assert_awaited_once()
+
+    async def test_env_merged_over_default_environment(self, mcp_client):
+        """--env vars land on top of the SDK default env, not instead of it."""
+        cmd = StdioCommand(command="./server", env={"API_KEY": "secret", "PATH": "/custom"})
+        with (
+            patch("mcpscore.mcp_client.stdio_client") as mock_stdio,
+            patch("mcpscore.mcp_client.get_default_environment", return_value={"PATH": "/usr/bin", "HOME": "/home"}),
+            patch.object(mcp_client, "_establish_session", new=AsyncMock()),
+        ):
+            result = await mcp_client._connect_with_stdio_command(cmd)
+        assert result is True
+        params = mock_stdio.call_args.args[0]
+        assert params.env == {"PATH": "/custom", "HOME": "/home", "API_KEY": "secret"}
+
+    async def test_command_not_found_names_the_command(self, mcp_client, caplog):
+        cmd = StdioCommand(command="no-such-binary")
+        with patch("mcpscore.mcp_client.stdio_client") as mock_stdio:
+            mock_stdio.return_value.__aenter__.side_effect = FileNotFoundError("not found")
+            result = await mcp_client._connect_with_stdio_command(cmd)
+        assert result is False
+        assert "Command not found: 'no-such-binary'" in caplog.text
+        assert mcp_client.last_connection_error is not None

--- a/tests/test_mcp_client_stdio.py
+++ b/tests/test_mcp_client_stdio.py
@@ -200,3 +200,60 @@ class TestStdioCommand:
         assert result is False
         assert "Command not found: 'no-such-binary'" in caplog.text
         assert mcp_client.last_connection_error is not None
+
+    async def test_command_handshake_timeout_classified(self, mcp_client, caplog):
+        cmd = StdioCommand(command="./slow-server")
+        with patch("mcpscore.mcp_client.stdio_client") as mock_stdio:
+            mock_stdio.return_value.__aenter__.side_effect = TimeoutError()
+            result = await mcp_client._connect_with_stdio_command(cmd)
+        assert result is False
+        assert "handshake timed out" in caplog.text
+        assert "./slow-server" in caplog.text
+        assert mcp_client.last_connection_error.reason.value == "timeout"
+
+    async def test_command_handshake_cancelled_classified_not_mcp(self, mcp_client, caplog):
+        """Classify an SDK-teardown CancelledError as NOT_MCP, not a re-raise.
+
+        The cancellation comes from the SDK's context teardown, not from our
+        own task being cancelled — it means the process spoke no MCP.
+        """
+        import asyncio
+
+        cmd = StdioCommand(command="./not-an-mcp-server")
+        with patch("mcpscore.mcp_client.stdio_client") as mock_stdio:
+            mock_stdio.return_value.__aenter__.side_effect = asyncio.CancelledError()
+            result = await mcp_client._connect_with_stdio_command(cmd)
+        assert result is False
+        assert "handshake failed" in caplog.text
+        assert mcp_client.last_connection_error.reason.value == "not_mcp"
+
+
+class TestStdioCommandRealProcess:
+    """End-to-end: launch a real server process, no transport mocking.
+
+    Guards the integration the mocked tests cannot see: StdioServerParameters,
+    the SDK's environment handling, actual process launch, and the MCP
+    handshake working together.
+    """
+
+    async def test_handshake_and_env_round_trip_through_real_process(self):
+        from pathlib import Path
+        import sys as _sys
+
+        server = str(Path(__file__).parent / "stdio_e2e_server.py")
+        cmd = StdioCommand(
+            command=_sys.executable,
+            args=(server,),
+            env={"MCPSCORE_E2E_ENV": "env-round-trip-proof"},
+        )
+        client = MCPClient()
+        try:
+            success, transport = await client.detect_and_connect(cmd)
+            assert success is True
+            assert transport is MCPTransportType.STDIO
+            # The env var reached the real subprocess: the server echoes it
+            # back as its version through the actual handshake.
+            assert client._init_result is not None
+            assert client._init_result.server_info.version == "env-round-trip-proof"
+        finally:
+            await client.cleanup()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Spawns arbitrary user-supplied processes and can pass environment variables, so misuse or secret leakage via inline `--env=VALUE` is possible; mitigations include no-shell exec, env omitted from repr/logs, and positional-only error messages.
> 
> **Overview**
> **Adds generic local stdio auditing** so mcpscore is no longer limited to `.py`/`.js` paths. **`--stdio`** takes the rest of the argv as a direct (no-shell) server command; **`--env`** configures the child process, with value-less `--env NAME` inheriting secrets from the parent env without echoing them in errors or logs.
> 
> The CLI makes the positional `target` optional, resolves target vs `--stdio` via `resolve_target`, uses the joined command line as the report `target`, rejects `--oauth` for non-URL targets, and skips URL-only failure fallbacks when stdio connect fails. **`MCPClient.detect_and_connect`** now accepts **`StdioCommand`**; stdio launch is refactored through **`_launch_stdio`** with env merged over the SDK default.
> 
> Docs and changelog describe the workflow; tests cover parsing, validation, repr hiding env, CLI flows, and a real subprocess e2e for env round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ceb89fe8245ffcf5dbd29bef659f7132bc2a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->