### PR TITLE
Prepare the 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-02
+
+Any-language release: local MCP servers in Go, Java, C#, Rust — any runtime —
+can now be audited over stdio via `--stdio`, with secret-safe `--env`
+configuration. Plus resource-template collection with three new catalog
+rules, a new readiness rule for `supportedVersions`, and a tightened
+unsupported-version error check.
+
 ### Added
 
 - **`--stdio`: audit local MCP servers written in any language.** The flag
@@ -769,7 +777,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/mcp-box/mcpscore/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mcp-box/mcpscore/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/mcp-box/mcpscore/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/mcp-box/mcpscore/compare/v1.1.0rc1...v1.1.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-71 rules across four categories — the same four the report, the JSON output, and
+72 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 
@@ -70,7 +70,7 @@ metadata, the RFC 8414 authorization-server chain, and whether PKCE (S256) is en
 A gated server is scored on this surface without credentials — see
 [auditing authenticated servers](https://docs.mcpscore.dev/authenticated-servers/).
 
-**Readiness** (12 rules) — how ready the server is for the 2026-07-28 MCP spec revision,
+**Readiness** (13 rules) — how ready the server is for the 2026-07-28 MCP spec revision,
 reported on its own axis. For servers already speaking the new lifecycle those points
 also count toward the main score; for everyone else the axis stays informative.
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-box/mcpscore",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Audit an MCP server and get a scored, actionable quality report in seconds. Node wrapper for the Python mcpscore CLI.",
   "bin": {
     "mcpscore": "bin/mcpscore.js"
@@ -33,7 +33,7 @@
     "developer-tools"
   ],
   "mcpscore": {
-    "pythonVersion": "1.2.0"
+    "pythonVersion": "1.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.2.0"
+version = "1.3.0"
 description = "Audit an MCP server and get a scored, actionable quality report in seconds."
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime or audit logic modified in this diff.
> 
> **Overview**
> **Release 1.3.0** — bumps the published version from **1.2.0** to **1.3.0** in `pyproject.toml`, `npm/package.json` (including `mcpscore.pythonVersion`), and `uv.lock`.
> 
> The **CHANGELOG** adds a dated **[1.3.0] - 2026-08-02** section (summarizing `--stdio`/`--env`, resource-template rules, `supportedVersions` readiness, and stricter unsupported-version error checks) and updates compare links so **[Unreleased]** tracks `v1.3.0...HEAD`.
> 
> **README** rule totals are updated to **72** rules and **13** readiness rules to match the 1.3.0 ruleset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e85d904d04e21ffbf67577754140c46fef3e5dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->