### PR TITLE
Add more rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Four MCP 2025-11-25+ catalog rules validate icon source URIs, optional MIME
+  types, and optional size tokens consistently across resources, resource
+  templates, prompts, and tools. Diagnostics identify only the catalog item
+  and icon index, keeping large embedded `data:` payloads out of audit
+  reports.
+
 ## [1.3.0] - 2026-08-02
 
 Any-language release: local MCP servers in Go, Java, C#, Rust — any runtime —

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-72 rules across four categories — the same four the report, the JSON output, and
+76 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -78,6 +78,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `tools_mcp_headers_primitive_types` | Tools - MCP headers must annotate supported primitive types | HIGH | 3 | 2026-07-28 – … |
 | `tools_mcp_headers_statically_reachable` | Tools - MCP header parameters must be statically reachable | HIGH | 3 | 2026-07-28 – … |
 | `tools_input_properties_documented` | Tools - Input properties should be documented | MEDIUM | 2 | all versions |
+| `tools_icons_valid` | Tools - Declared icons must be valid | LOW | 1 | 2025-11-25 – … |
 
 ## Transport
 
@@ -97,6 +98,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `resources_description_present` | Resources - All resources should have a description | MEDIUM | 2 | all versions |
 | `resources_uris_unique` | Resources - Resource URIs must be unique | HIGH | 3 | all versions |
 | `resources_titles_present` | Resources - All resources should have a display title | LOW | 1 | 2025-06-18 – … |
+| `resources_icons_valid` | Resources - Declared icons must be valid | LOW | 1 | 2025-11-25 – … |
 
 ## Resource Templates
 
@@ -105,6 +107,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `resource_templates_uri_templates_valid` | Resource Templates - URI templates must be valid | HIGH | 3 | all versions |
 | `resource_templates_unique` | Resource Templates - URI templates must be unique | HIGH | 3 | all versions |
 | `resource_templates_names_present` | Resource Templates - All templates must have a name | MEDIUM | 2 | all versions |
+| `resource_templates_icons_valid` | Resource Templates - Declared icons must be valid | LOW | 1 | 2025-11-25 – … |
 
 ## Prompts
 
@@ -116,6 +119,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `prompts_arguments_documented` | Prompts - All prompt arguments should be documented | LOW | 1 | all versions |
 | `prompts_names_unique` | Prompts - Prompt names must be unique | HIGH | 3 | all versions |
 | `prompts_titles_present` | Prompts - All prompts should have a display title | LOW | 1 | 2025-06-18 – … |
+| `prompts_icons_valid` | Prompts - Declared icons must be valid | LOW | 1 | 2025-11-25 – … |
 
 ## Readiness rules (separate score)
 

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -43,6 +43,7 @@ from .prompts import (
     PromptsArgumentNamesUniqueRule,
     PromptsArgumentsDocumentedRule,
     PromptsDescriptionPresentRule,
+    PromptsIconsValidRule,
     PromptsNamesUniqueRule,
     PromptsTitlesPresentRule,
 )
@@ -67,6 +68,7 @@ from .readiness import (
 )
 from .registry import RuleRegistry, create_all_rules
 from .resource_templates import (
+    ResourceTemplatesIconsValidRule,
     ResourceTemplatesNamesPresentRule,
     ResourceTemplatesUniqueRule,
     ResourceTemplatesUriTemplatesValidRule,
@@ -74,6 +76,7 @@ from .resource_templates import (
 from .resources import (
     ResourcesAnnotationsValidRule,
     ResourcesDescriptionPresentRule,
+    ResourcesIconsValidRule,
     ResourcesMimeTypesValidRule,
     ResourcesNamesPresentRule,
     ResourcesSizesValidRule,
@@ -99,6 +102,7 @@ from .tools import (
     ToolsAtLeastOneRule,
     ToolsDescriptionPresentRule,
     ToolsExecutionConsistentRule,
+    ToolsIconsValidRule,
     ToolsInputPropertiesDocumentedRule,
     ToolsInputSchemaValidRule,
     ToolsMcpHeadersPrimitiveTypesRule,
@@ -147,14 +151,17 @@ __all__ = (
     "PromptsArgumentNamesUniqueRule",
     "PromptsArgumentsDocumentedRule",
     "PromptsDescriptionPresentRule",
+    "PromptsIconsValidRule",
     "PromptsNamesUniqueRule",
     "PromptsTitlesPresentRule",
     "RemovedMethodsReadinessRule",
+    "ResourceTemplatesIconsValidRule",
     "ResourceTemplatesNamesPresentRule",
     "ResourceTemplatesUniqueRule",
     "ResourceTemplatesUriTemplatesValidRule",
     "ResourcesAnnotationsValidRule",
     "ResourcesDescriptionPresentRule",
+    "ResourcesIconsValidRule",
     "ResourcesMimeTypesValidRule",
     "ResourcesNamesPresentRule",
     "ResourcesSizesValidRule",
@@ -181,6 +188,7 @@ __all__ = (
     "ToolsAtLeastOneRule",
     "ToolsDescriptionPresentRule",
     "ToolsExecutionConsistentRule",
+    "ToolsIconsValidRule",
     "ToolsInputPropertiesDocumentedRule",
     "ToolsInputSchemaValidRule",
     "ToolsMcpHeadersPrimitiveTypesRule",

--- a/mcpscore/rules/icon_validation.py
+++ b/mcpscore/rules/icon_validation.py
@@ -11,7 +11,8 @@ class IconOwner(Protocol):
     """Catalog item carrying optional icons."""
 
     @property
-    def icons(self) -> list[Icon] | None: ...
+    def icons(self) -> list[Icon] | None:  # pragma: no cover — typing stub, never called
+        """Icons declared by the catalog item, if any."""
 
 
 _URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")

--- a/mcpscore/rules/icon_validation.py
+++ b/mcpscore/rules/icon_validation.py
@@ -1,0 +1,54 @@
+"""Shared validation for MCP catalog icon declarations."""
+
+import re
+from typing import Protocol
+from urllib.parse import urlsplit
+
+from mcp_types import Icon
+
+
+class IconOwner(Protocol):
+    """Catalog item carrying optional icons."""
+
+    @property
+    def icons(self) -> list[Icon] | None: ...
+
+
+_URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
+_MIME_TYPE_ATOM = r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+"
+_MIME_TYPE_QUOTED = r'"(?:[\t !#-\[\]-~]|\\[\t -~])*"'
+_MIME_TYPE_RE = re.compile(
+    rf"^{_MIME_TYPE_ATOM}/{_MIME_TYPE_ATOM}"
+    rf"(?:[ \t]*;[ \t]*{_MIME_TYPE_ATOM}=(?:{_MIME_TYPE_ATOM}|{_MIME_TYPE_QUOTED}))*$"
+)
+_SIZE_RE = re.compile(r"^[1-9][0-9]*x[1-9][0-9]*$")
+
+
+def find_invalid_icons(items: list[tuple[str, IconOwner]]) -> list[dict[str, object]]:
+    """Return compact diagnostics for structurally invalid catalog icons."""
+    invalid: list[dict[str, object]] = []
+    for owner, item in items:
+        for index, icon in enumerate(item.icons or []):
+            fields: list[str] = []
+            if not _is_absolute_uri(icon.src):
+                fields.append("src")
+            if icon.mime_type is not None and _MIME_TYPE_RE.fullmatch(icon.mime_type) is None:
+                fields.append("mimeType")
+            if icon.sizes is not None and any(
+                size != "any" and _SIZE_RE.fullmatch(size) is None for size in icon.sizes
+            ):
+                fields.append("sizes")
+            if fields:
+                invalid.append({"item": owner, "icon_index": index, "invalid_fields": fields})
+    return invalid
+
+
+def _is_absolute_uri(value: str) -> bool:
+    """Return whether *value* has a syntactically valid URI scheme."""
+    if not value or any(character.isspace() for character in value):
+        return False
+    try:
+        scheme = urlsplit(value).scheme
+    except ValueError:
+        return False
+    return bool(scheme and _URI_SCHEME_RE.fullmatch(scheme))

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -4,6 +4,7 @@ from collections import Counter
 from mcp_types import Prompt
 
 from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .icon_validation import find_invalid_icons
 from .registry import register_rule
 
 
@@ -314,4 +315,38 @@ class PromptsTitlesPresentRule(PromptsBaseRule):
             passed=passed,
             message=message,
             details={"prompts_without_title": prompts_without_title},
+        )
+
+
+@register_rule
+class PromptsIconsValidRule(PromptsBaseRule):
+    """Low check: validate every declared prompt icon."""
+
+    rule_id = "prompts_icons_valid"
+    basis = "MCP 2026-07-28 Schema Reference §Common Types (Icon); Prompts §Prompt (icons)"
+    min_spec_version = "2025-11-25"
+    rule_order = 7
+
+    @property
+    def rule_name(self) -> str:
+        return "Prompts - Declared icons must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def _check_prompts(self, prompts: list[Prompt]) -> RuleResult:
+        invalid_icons = find_invalid_icons([(prompt.name, prompt) for prompt in prompts])
+        passed = not invalid_icons
+        message = (
+            "✅ All declared prompt icons are valid"
+            if passed
+            else f"❌ Number of invalid prompt icons: {len(invalid_icons)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"invalid_icons": invalid_icons},
         )

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -5,6 +5,7 @@ import re
 from mcp_types import ResourceTemplate
 
 from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .icon_validation import find_invalid_icons
 from .registry import register_rule
 
 _PCT_ENCODED_RE = re.compile(r"%[0-9A-Fa-f]{2}")
@@ -229,4 +230,38 @@ class ResourceTemplatesNamesPresentRule(ResourceTemplatesBaseRule):
                 else f"❌ Number of resource templates without a name: {len(unnamed)}"
             ),
             details={"templates_without_name": unnamed},
+        )
+
+
+@register_rule
+class ResourceTemplatesIconsValidRule(ResourceTemplatesBaseRule):
+    """Low check: validate every declared resource-template icon."""
+
+    rule_id = "resource_templates_icons_valid"
+    basis = "MCP 2026-07-28 Schema Reference §Common Types (Icon); Resources §Resource Templates (icons)"
+    min_spec_version = "2025-11-25"
+    rule_order = 23
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - Declared icons must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        invalid_icons = find_invalid_icons([(template.uri_template, template) for template in templates])
+        passed = not invalid_icons
+        message = (
+            "✅ All declared resource-template icons are valid"
+            if passed
+            else f"❌ Number of invalid resource-template icons: {len(invalid_icons)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"invalid_icons": invalid_icons},
         )

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -7,6 +7,7 @@ from urllib.parse import urlsplit
 from mcp_types import Resource
 
 from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .icon_validation import find_invalid_icons
 from .registry import register_rule
 
 _URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
@@ -406,4 +407,38 @@ class ResourcesTitlesPresentRule(ResourcesBaseRule):
             passed=passed,
             message=message,
             details={"resources_without_title": resources_without_title},
+        )
+
+
+@register_rule
+class ResourcesIconsValidRule(ResourcesBaseRule):
+    """Low check: validate every declared resource icon."""
+
+    rule_id = "resources_icons_valid"
+    basis = "MCP 2026-07-28 Schema Reference §Common Types (Icon); Resources §Resource (icons)"
+    min_spec_version = "2025-11-25"
+    rule_order = 9
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources - Declared icons must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def _check_resources(self, resources: list[Resource]) -> RuleResult:
+        invalid_icons = find_invalid_icons([(resource.uri, resource) for resource in resources])
+        passed = not invalid_icons
+        message = (
+            "✅ All declared resource icons are valid"
+            if passed
+            else f"❌ Number of invalid resource icons: {len(invalid_icons)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"invalid_icons": invalid_icons},
         )

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -14,6 +14,7 @@ from .base import (
     requires_fields,
     requires_tools,
 )
+from .icon_validation import find_invalid_icons
 from .registry import register_rule
 
 
@@ -848,6 +849,40 @@ class ToolsAnnotationsPresentRule(ToolsBaseRule):
             passed=passed,
             message=message,
             details={"tools_without_annotations": tools_without_annotations},
+        )
+
+
+@register_rule
+class ToolsIconsValidRule(ToolsBaseRule):
+    """Low check: validate every declared tool icon."""
+
+    rule_id = "tools_icons_valid"
+    basis = "MCP 2026-07-28 Schema Reference §Common Types (Icon); Tools §Tool (icons)"
+    min_spec_version = "2025-11-25"
+    rule_order = 16
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools - Declared icons must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def _check_tools(self, tools: list[Tool]) -> RuleResult:
+        invalid_icons = find_invalid_icons([(tool.name, tool) for tool in tools])
+        passed = not invalid_icons
+        message = (
+            "✅ All declared tool icons are valid"
+            if passed
+            else f"❌ Number of invalid tool icons: {len(invalid_icons)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"invalid_icons": invalid_icons},
         )
 
 

--- a/tests/test_icon_rules.py
+++ b/tests/test_icon_rules.py
@@ -82,3 +82,24 @@ def test_invalid_catalog_icon_fields_are_reported_without_payloads(
     assert invalid_detail["icon_index"] == 0
     assert invalid_detail["invalid_fields"] == ["src", "mimeType", "sizes"]
     assert oversized_src not in repr(result.details)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "",  # empty
+        "https://example.com/a b.png",  # embedded whitespace
+        "http://[::1",  # urlsplit raises ValueError (invalid IPv6 literal)
+        "example.com/icon.png",  # no scheme
+        "1http://example.com",  # scheme must start with a letter
+    ],
+)
+def test_invalid_src_variants_are_rejected(src: str) -> None:
+    """Reject every malformed-src shape via invalid_fields.
+
+    Includes the urlsplit ValueError path (invalid IPv6 literal), which must
+    classify as invalid rather than crash.
+    """
+    result = ToolsIconsValidRule().check(_tool([Icon(src=src)]))
+    assert not result.passed
+    assert result.details["invalid_icons"][0]["invalid_fields"] == ["src"]

--- a/tests/test_icon_rules.py
+++ b/tests/test_icon_rules.py
@@ -1,0 +1,84 @@
+"""Shared behavior tests for catalog icon validation rules."""
+
+from collections.abc import Callable
+
+from mcp_types import Icon, Prompt, Resource, ResourceTemplate, Tool
+import pytest
+
+from mcpscore.rules import (
+    PromptsIconsValidRule,
+    ResourcesIconsValidRule,
+    ResourceTemplatesIconsValidRule,
+    RuleSeverity,
+    ToolsIconsValidRule,
+)
+from mcpscore.rules.base import AuditData, BaseRule
+
+Case = tuple[BaseRule, str, Callable[[list[Icon] | None], AuditData]]
+
+
+def _resource(icons: list[Icon] | None) -> AuditData:
+    return AuditData(resources=[Resource(name="docs", uri="https://example.com/docs", icons=icons)])
+
+
+def _prompt(icons: list[Icon] | None) -> AuditData:
+    return AuditData(prompts=[Prompt(name="summarize", icons=icons)])
+
+
+def _tool(icons: list[Icon] | None) -> AuditData:
+    return AuditData(tools=[Tool(name="search", input_schema={"type": "object"}, icons=icons)])
+
+
+def _template(icons: list[Icon] | None) -> AuditData:
+    return AuditData(resource_templates=[ResourceTemplate(name="files", uri_template="file:///{path}", icons=icons)])
+
+
+CASES: tuple[Case, ...] = (
+    (ResourcesIconsValidRule(), "resources_icons_valid", _resource),
+    (PromptsIconsValidRule(), "prompts_icons_valid", _prompt),
+    (ToolsIconsValidRule(), "tools_icons_valid", _tool),
+    (ResourceTemplatesIconsValidRule(), "resource_templates_icons_valid", _template),
+)
+
+
+@pytest.mark.parametrize(("rule", "rule_id", "make_data"), CASES)
+def test_icon_rule_metadata_and_absent_icons_pass(
+    rule: BaseRule, rule_id: str, make_data: Callable[[list[Icon] | None], AuditData]
+) -> None:
+    assert rule.rule_id == rule_id
+    assert rule.severity is RuleSeverity.LOW
+    assert rule.min_spec_version == "2025-11-25"
+    assert rule.check(make_data(None)).passed
+
+
+@pytest.mark.parametrize(("rule", "_rule_id", "make_data"), CASES)
+def test_valid_catalog_icons_pass(
+    rule: BaseRule, _rule_id: str, make_data: Callable[[list[Icon] | None], AuditData]
+) -> None:
+    icons = [
+        Icon(src="https://example.com/icon.png", mime_type="image/png", sizes=["48x48", "any"], theme="light"),
+        Icon(src="http://example.com/icon.svg", mime_type='image/svg+xml; charset="utf-8"'),
+        Icon(src="data:image/png;base64,AAAA"),
+    ]
+
+    assert rule.check(make_data(icons)).passed
+
+
+@pytest.mark.parametrize(("rule", "_rule_id", "make_data"), CASES)
+def test_invalid_catalog_icon_fields_are_reported_without_payloads(
+    rule: BaseRule, _rule_id: str, make_data: Callable[[list[Icon] | None], AuditData]
+) -> None:
+    oversized_src = "relative/" + "x" * 10_000
+    invalid_icon = Icon(
+        src=oversized_src,
+        mime_type="not a mime type",
+        sizes=["48", "0x32", "ANY"],
+    )
+    result = rule.check(make_data([invalid_icon]))
+
+    assert not result.passed
+    assert len(result.details["invalid_icons"]) == 1
+    invalid_detail = result.details["invalid_icons"][0]
+    assert invalid_detail["icon_index"] == 0
+    assert invalid_detail["invalid_fields"] == ["src", "mimeType", "sizes"]
+    assert oversized_src not in repr(result.details)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive audit-only rules with no changes to connection, auth, or scoring mechanics beyond four new LOW-weight checks; behavior is covered by shared parametrized tests.
> 
> **Overview**
> Adds **four LOW-severity rules** (`tools_icons_valid`, `resources_icons_valid`, `prompts_icons_valid`, `resource_templates_icons_valid`) for MCP **2025-11-25+**, bringing the documented rule count from **72 to 76**.
> 
> Shared logic in `icon_validation.py` checks each declared icon’s **`src`** (absolute URI with a valid scheme, including `data:`), optional **`mimeType`**, and optional **`sizes`** (`WxH` or `any`). Failures record only the catalog identifier, **icon index**, and **`invalid_fields`**—not full `src` payloads—so large embedded `data:` icons do not bloat audit output.
> 
> CHANGELOG, README, and the rules reference are updated accordingly. Parametrized tests in `tests/test_icon_rules.py` cover all four rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407a49cc172640e88eed1a49f92f8ec9af1f3ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->