### PR TITLE
Fixed rules on icon validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/ru
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
-**Tools Quality** (32 rules) — tool names (presence, uniqueness, format), titles,
+**Tools Quality** (36 rules) — tool names (presence, uniqueness, format), titles,
 descriptions of tools and their input properties, and JSON Schema validity of input and
 output schemas, including the 2026-07-28 `x-mcp-header` constraints — plus the
 equivalent catalog checks for prompts, resources, and resource templates: valid and

--- a/mcpscore/rules/icon_validation.py
+++ b/mcpscore/rules/icon_validation.py
@@ -1,5 +1,7 @@
 """Shared validation for MCP catalog icon declarations."""
 
+import base64
+import binascii
 import re
 from typing import Protocol
 from urllib.parse import urlsplit
@@ -16,6 +18,14 @@ class IconOwner(Protocol):
 
 
 _URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
+_URI_CHARACTER_RE = re.compile(r"^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+$")
+_INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_DATA_URI_RE = re.compile(
+    r"^data:(image/[A-Za-z0-9!#$&^_.+-]+)"
+    r"(?:;[A-Za-z0-9!#$&^_.+-]+=[A-Za-z0-9!#$&^_.+%-]+)*"
+    r";base64,([A-Za-z0-9+/]*={0,2})$",
+    re.IGNORECASE,
+)
 _MIME_TYPE_ATOM = r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+"
 _MIME_TYPE_QUOTED = r'"(?:[\t !#-\[\]-~]|\\[\t -~])*"'
 _MIME_TYPE_RE = re.compile(
@@ -45,11 +55,30 @@ def find_invalid_icons(items: list[tuple[str, IconOwner]]) -> list[dict[str, obj
 
 
 def _is_absolute_uri(value: str) -> bool:
-    """Return whether *value* has a syntactically valid URI scheme."""
-    if not value or any(character.isspace() for character in value):
+    """Return whether *value* is a usable absolute icon URI."""
+    if not value or _URI_CHARACTER_RE.fullmatch(value) is None or _INVALID_PERCENT_ESCAPE_RE.search(value) is not None:
         return False
     try:
-        scheme = urlsplit(value).scheme
+        parsed = urlsplit(value)
+        _ = parsed.port  # urlsplit validates ports lazily.
     except ValueError:
         return False
-    return bool(scheme and _URI_SCHEME_RE.fullmatch(scheme))
+    if not parsed.scheme or _URI_SCHEME_RE.fullmatch(parsed.scheme) is None:
+        return False
+    if parsed.scheme.lower() in {"http", "https"}:
+        return parsed.hostname is not None
+    if parsed.scheme.lower() == "data":
+        return _is_base64_image_data_uri(value)
+    return True
+
+
+def _is_base64_image_data_uri(value: str) -> bool:
+    """Return whether *value* embeds a base64-encoded image."""
+    match = _DATA_URI_RE.fullmatch(value)
+    if match is None or not match.group(2):
+        return False
+    try:
+        base64.b64decode(match.group(2), validate=True)
+    except (binascii.Error, ValueError):
+        return False
+    return True

--- a/mcpscore/rules/icon_validation.py
+++ b/mcpscore/rules/icon_validation.py
@@ -1,7 +1,5 @@
 """Shared validation for MCP catalog icon declarations."""
 
-import base64
-import binascii
 import re
 from typing import Protocol
 from urllib.parse import urlsplit
@@ -73,12 +71,14 @@ def _is_absolute_uri(value: str) -> bool:
 
 
 def _is_base64_image_data_uri(value: str) -> bool:
-    """Return whether *value* embeds a base64-encoded image."""
+    """Return whether *value* embeds a base64-encoded image.
+
+    No decoding: the regex already constrains the payload to the base64
+    alphabet with at most two trailing ``=``, so strict validity (what
+    ``base64.b64decode(..., validate=True)`` would check) reduces to the
+    length being a multiple of four — O(1) on untrusted input of any size.
+    """
     match = _DATA_URI_RE.fullmatch(value)
     if match is None or not match.group(2):
         return False
-    try:
-        base64.b64decode(match.group(2), validate=True)
-    except (binascii.Error, ValueError):
-        return False
-    return True
+    return len(match.group(2)) % 4 == 0

--- a/tests/test_icon_rules.py
+++ b/tests/test_icon_rules.py
@@ -59,6 +59,12 @@ def test_valid_catalog_icons_pass(
         Icon(src="https://example.com/icon.png", mime_type="image/png", sizes=["48x48", "any"], theme="light"),
         Icon(src="http://example.com/icon.svg", mime_type='image/svg+xml; charset="utf-8"'),
         Icon(src="data:image/png;base64,AAAA"),
+        Icon(src="data:image/svg+xml;charset=utf-8;base64,PHN2Zy8+"),
+        Icon(src="DATA:IMAGE/PNG;BASE64,AAAA"),
+        # Schemes beyond http(s)/data are deliberately allowed: the spec's
+        # "May be an HTTP/HTTPS URL or a data: URI" is exemplary, not
+        # exhaustive — this case pins the leniency.
+        Icon(src="file:///opt/icons/tool.png"),
     ]
 
     assert rule.check(make_data(icons)).passed
@@ -77,6 +83,7 @@ def test_invalid_catalog_icon_fields_are_reported_without_payloads(
     result = rule.check(make_data([invalid_icon]))
 
     assert not result.passed
+    assert result.details is not None
     assert len(result.details["invalid_icons"]) == 1
     invalid_detail = result.details["invalid_icons"][0]
     assert invalid_detail["icon_index"] == 0
@@ -92,6 +99,15 @@ def test_invalid_catalog_icon_fields_are_reported_without_payloads(
         "http://[::1",  # urlsplit raises ValueError (invalid IPv6 literal)
         "example.com/icon.png",  # no scheme
         "1http://example.com",  # scheme must start with a letter
+        "https://",  # HTTP(S) icons require a host
+        "https://example.com:bad/icon.png",  # invalid port
+        "https://example.com/%ZZ",  # malformed percent escape
+        "https://example.com/é.png",  # a URI cannot contain raw non-ASCII
+        "data:",  # data icons must contain an image payload
+        "data:image/png,not-base64",  # data icons must use base64 encoding
+        "data:image/png;base64,not_base64",  # invalid base64 alphabet
+        "data:image/png;base64,A",  # regex-valid alphabet, invalid base64 length
+        "data:text/plain;base64,AAAA",  # icon data must be an image
     ],
 )
 def test_invalid_src_variants_are_rejected(src: str) -> None:
@@ -102,4 +118,5 @@ def test_invalid_src_variants_are_rejected(src: str) -> None:
     """
     result = ToolsIconsValidRule().check(_tool([Icon(src=src)]))
     assert not result.passed
+    assert result.details is not None
     assert result.details["invalid_icons"][0]["invalid_fields"] == ["src"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only audit-time icon validation logic and tests; no runtime server behavior or auth/data paths are modified.
> 
> **Overview**
> **Hardens shared icon `src` checks** used by tools, prompts, resources, and resource templates so malformed URIs fail the icons-valid rules instead of passing on scheme-only validation.
> 
> `_is_absolute_uri` now rejects invalid URI characters, bad percent-escapes, and raw non-ASCII; **HTTP(S)** must include a host and a valid port; **`data:`** must be a base64-encoded **image** payload (checked via regex plus length mod 4, without decoding untrusted data). Non-`http`/`https`/`data` schemes such as `file:` remain allowed, matching spec leniency.
> 
> Tests add passing cases (SVG data URIs, case-insensitive `DATA:`, `file:`) and many failing `src` shapes; invalid-icon tests now assert `details` is present. README updates **Tools Quality** from 32 to **36** rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de11f45ac00ff2b9bfe912abc02ca8952231047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->