### PR TITLE
Add new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Three resource-template quality rules validate declared MIME types and
+  annotations, and recommend descriptions that help clients and models
+  understand parameterized resources.
 - Four MCP 2025-11-25+ catalog rules validate icon source URIs, optional MIME
   types, and optional size tokens consistently across resources, resource
   templates, prompts, and tools. Diagnostics identify only the catalog item

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-76 rules across four categories — the same four the report, the JSON output, and
+79 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 
@@ -55,7 +55,7 @@ enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/ru
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
-**Tools Quality** (36 rules) — tool names (presence, uniqueness, format), titles,
+**Tools Quality** (39 rules) — tool names (presence, uniqueness, format), titles,
 descriptions of tools and their input properties, and JSON Schema validity of input and
 output schemas, including the 2026-07-28 `x-mcp-header` constraints — plus the
 equivalent catalog checks for prompts, resources, and resource templates: valid and

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -108,6 +108,9 @@ Every rule mcpscore runs, generated from the rule registry
 | `resource_templates_unique` | Resource Templates - URI templates must be unique | HIGH | 3 | all versions |
 | `resource_templates_names_present` | Resource Templates - All templates must have a name | MEDIUM | 2 | all versions |
 | `resource_templates_icons_valid` | Resource Templates - Declared icons must be valid | LOW | 1 | 2025-11-25 – … |
+| `resource_templates_mime_types_valid` | Resource Templates - Declared MIME types must be valid | MEDIUM | 2 | all versions |
+| `resource_templates_annotations_valid` | Resource Templates - Declared annotations must be valid | MEDIUM | 2 | all versions |
+| `resource_templates_description_present` | Resource Templates - All templates should have a description | MEDIUM | 2 | all versions |
 
 ## Prompts
 

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -68,7 +68,10 @@ from .readiness import (
 )
 from .registry import RuleRegistry, create_all_rules
 from .resource_templates import (
+    ResourceTemplatesAnnotationsValidRule,
+    ResourceTemplatesDescriptionPresentRule,
     ResourceTemplatesIconsValidRule,
+    ResourceTemplatesMimeTypesValidRule,
     ResourceTemplatesNamesPresentRule,
     ResourceTemplatesUniqueRule,
     ResourceTemplatesUriTemplatesValidRule,
@@ -155,7 +158,10 @@ __all__ = (
     "PromptsNamesUniqueRule",
     "PromptsTitlesPresentRule",
     "RemovedMethodsReadinessRule",
+    "ResourceTemplatesAnnotationsValidRule",
+    "ResourceTemplatesDescriptionPresentRule",
     "ResourceTemplatesIconsValidRule",
+    "ResourceTemplatesMimeTypesValidRule",
     "ResourceTemplatesNamesPresentRule",
     "ResourceTemplatesUniqueRule",
     "ResourceTemplatesUriTemplatesValidRule",

--- a/mcpscore/rules/catalog_validation.py
+++ b/mcpscore/rules/catalog_validation.py
@@ -1,0 +1,28 @@
+"""Shared validators for MCP resource catalog fields."""
+
+from datetime import datetime
+import re
+
+_MEDIA_TYPE_ATOM_PATTERN = r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+"
+_MEDIA_TYPE_QUOTED_VALUE = r'"(?:[\t !#-\[\]-~]|\\[\t -~])*"'
+_MEDIA_TYPE_RE = re.compile(
+    rf"^{_MEDIA_TYPE_ATOM_PATTERN}/{_MEDIA_TYPE_ATOM_PATTERN}"
+    rf"(?:[ \t]*;[ \t]*{_MEDIA_TYPE_ATOM_PATTERN}="
+    rf"(?:{_MEDIA_TYPE_ATOM_PATTERN}|{_MEDIA_TYPE_QUOTED_VALUE}))*$"
+)
+
+
+def is_valid_media_type(value: str) -> bool:
+    """Return whether *value* is a syntactically valid media type."""
+    return _MEDIA_TYPE_RE.fullmatch(value) is not None
+
+
+def is_iso_8601(value: str) -> bool:
+    """Return whether *value* is a non-blank ISO 8601 date or timestamp."""
+    if not value or value != value.strip():
+        return False
+    try:
+        datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return True

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -5,6 +5,7 @@ import re
 from mcp_types import ResourceTemplate
 
 from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .catalog_validation import is_iso_8601, is_valid_media_type
 from .icon_validation import find_invalid_icons
 from .registry import register_rule
 
@@ -264,4 +265,114 @@ class ResourceTemplatesIconsValidRule(ResourceTemplatesBaseRule):
             passed=passed,
             message=message,
             details={"invalid_icons": invalid_icons},
+        )
+
+
+@register_rule
+class ResourceTemplatesMimeTypesValidRule(ResourceTemplatesBaseRule):
+    """Medium check: validate every declared resource-template MIME type."""
+
+    rule_id = "resource_templates_mime_types_valid"
+    basis = "MCP 2026-07-28 Resources §Resource Templates (mimeType)"
+    rule_order = 24
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - Declared MIME types must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        invalid = [
+            {"name": template.name, "mime_type": template.mime_type}
+            for template in templates
+            if template.mime_type is not None and not is_valid_media_type(template.mime_type)
+        ]
+        passed = not invalid
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                "✅ All declared resource-template MIME types are valid"
+                if passed
+                else f"❌ Number of resource templates with invalid MIME types: {len(invalid)}"
+            ),
+            details={"templates_with_invalid_mime_type": invalid},
+        )
+
+
+@register_rule
+class ResourceTemplatesAnnotationsValidRule(ResourceTemplatesBaseRule):
+    """Medium check: validate every declared resource-template annotation."""
+
+    rule_id = "resource_templates_annotations_valid"
+    basis = "MCP 2026-07-28 Resources §Resource Templates (annotations); Schema Reference §Annotations"
+    rule_order = 25
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - Declared annotations must be valid"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        invalid = [
+            template.uri_template
+            for template in templates
+            if template.annotations is not None
+            and template.annotations.last_modified is not None
+            and not is_iso_8601(template.annotations.last_modified)
+        ]
+        passed = not invalid
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                "✅ All declared resource-template annotations are valid"
+                if passed
+                else f"❌ Number of resource templates with invalid annotations: {len(invalid)}"
+            ),
+            details={"templates_with_invalid_annotations": invalid},
+        )
+
+
+@register_rule
+class ResourceTemplatesDescriptionPresentRule(ResourceTemplatesBaseRule):
+    """Medium check: require a useful description for every resource template."""
+
+    rule_id = "resource_templates_description_present"
+    basis = "MCP 2026-07-28 Resources §Resource Templates (description improves the LLM's understanding)"
+    rule_order = 26
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - All templates should have a description"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.MEDIUM
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        missing = [
+            template.uri_template
+            for template in templates
+            if not (template.description and template.description.strip())
+        ]
+        passed = not missing
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                "✅ All resource templates have a description"
+                if passed
+                else f"❌ Number of resource templates without a description: {len(missing)}"
+            ),
+            details={"templates_without_description": missing},
         )

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -1,25 +1,18 @@
 from abc import abstractmethod
 from collections import Counter
-from datetime import datetime
 import re
 from urllib.parse import urlsplit
 
 from mcp_types import Resource
 
 from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .catalog_validation import is_iso_8601, is_valid_media_type
 from .icon_validation import find_invalid_icons
 from .registry import register_rule
 
 _URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
 _URI_CHARACTER_RE = re.compile(r"^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+$")
 _INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
-_MEDIA_TYPE_ATOM_PATTERN = r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+"
-_MEDIA_TYPE_QUOTED_VALUE = r'"(?:[\t !#-\[\]-~]|\\[\t -~])*"'
-_MEDIA_TYPE_RE = re.compile(
-    rf"^{_MEDIA_TYPE_ATOM_PATTERN}/{_MEDIA_TYPE_ATOM_PATTERN}"
-    rf"(?:[ \t]*;[ \t]*{_MEDIA_TYPE_ATOM_PATTERN}="
-    rf"(?:{_MEDIA_TYPE_ATOM_PATTERN}|{_MEDIA_TYPE_QUOTED_VALUE}))*$"
-)
 
 
 class ResourcesBaseRule(BaseRule):
@@ -215,7 +208,7 @@ class ResourcesMimeTypesValidRule(ResourcesBaseRule):
         resources_with_invalid_mime_type = [
             {"name": resource.name, "mime_type": resource.mime_type}
             for resource in resources
-            if resource.mime_type is not None and _MEDIA_TYPE_RE.fullmatch(resource.mime_type) is None
+            if resource.mime_type is not None and not is_valid_media_type(resource.mime_type)
         ]
         passed = not resources_with_invalid_mime_type
         message = (
@@ -255,7 +248,7 @@ class ResourcesAnnotationsValidRule(ResourcesBaseRule):
             for resource in resources
             if resource.annotations is not None
             and resource.annotations.last_modified is not None
-            and not _is_iso_8601(resource.annotations.last_modified)
+            and not is_iso_8601(resource.annotations.last_modified)
         ]
         passed = not resources_with_invalid_annotations
         message = (
@@ -270,17 +263,6 @@ class ResourcesAnnotationsValidRule(ResourcesBaseRule):
             message=message,
             details={"resources_with_invalid_annotations": resources_with_invalid_annotations},
         )
-
-
-def _is_iso_8601(value: str) -> bool:
-    """Return whether a value is a non-blank ISO 8601 date or timestamp."""
-    if not value or value != value.strip():
-        return False
-    try:
-        datetime.fromisoformat(value)
-    except ValueError:
-        return False
-    return True
 
 
 @register_rule

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -1,7 +1,10 @@
-from mcp_types import ResourceTemplate
+from mcp_types import Annotations, ResourceTemplate
 
 from mcpscore.rules import (
     AuditData,
+    ResourceTemplatesAnnotationsValidRule,
+    ResourceTemplatesDescriptionPresentRule,
+    ResourceTemplatesMimeTypesValidRule,
     ResourceTemplatesNamesPresentRule,
     ResourceTemplatesUniqueRule,
     ResourceTemplatesUriTemplatesValidRule,
@@ -10,8 +13,21 @@ from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
 from mcpscore.rules.resource_templates import is_valid_uri_template
 
 
-def _template(name: str, uri_template: str) -> ResourceTemplate:
-    return ResourceTemplate(name=name, uriTemplate=uri_template)
+def _template(
+    name: str,
+    uri_template: str,
+    *,
+    description: str | None = "Description",
+    mime_type: str | None = None,
+    annotations: Annotations | None = None,
+) -> ResourceTemplate:
+    return ResourceTemplate(
+        name=name,
+        uriTemplate=uri_template,
+        description=description,
+        mime_type=mime_type,
+        annotations=annotations,
+    )
 
 
 def test_uri_template_validator_accepts_rfc_6570_levels() -> None:
@@ -74,11 +90,69 @@ def test_names_rule_rejects_blank_names() -> None:
     assert result.details == {"templates_without_name": ["files/{id}"]}
 
 
+def test_mime_types_rule_accepts_absent_and_valid_values() -> None:
+    templates = [
+        _template("unknown", "unknown/{id}"),
+        _template("text", "text/{id}", mime_type="text/plain"),
+        _template("parameter", "parameter/{id}", mime_type='text/plain; charset="utf-8"'),
+    ]
+    result = ResourceTemplatesMimeTypesValidRule().check(AuditData(resource_templates=templates))
+    assert result.passed
+    assert result.details == {"templates_with_invalid_mime_type": []}
+
+
+def test_mime_types_rule_reports_invalid_values() -> None:
+    templates = [
+        _template("missing-subtype", "one/{id}", mime_type="text"),
+        _template("blank", "two/{id}", mime_type=""),
+    ]
+    result = ResourceTemplatesMimeTypesValidRule().check(AuditData(resource_templates=templates))
+    assert not result.passed
+    assert result.details == {
+        "templates_with_invalid_mime_type": [
+            {"name": "missing-subtype", "mime_type": "text"},
+            {"name": "blank", "mime_type": ""},
+        ]
+    }
+
+
+def test_annotations_rule_accepts_absent_and_iso_8601_values() -> None:
+    templates = [
+        _template("none", "none/{id}"),
+        _template("date", "date/{id}", annotations=Annotations(last_modified="2026-08-03")),
+        _template("timestamp", "timestamp/{id}", annotations=Annotations(last_modified="2026-08-03T12:30:00Z")),
+    ]
+    result = ResourceTemplatesAnnotationsValidRule().check(AuditData(resource_templates=templates))
+    assert result.passed
+    assert result.details == {"templates_with_invalid_annotations": []}
+
+
+def test_annotations_rule_reports_invalid_last_modified() -> None:
+    template = _template("bad", "bad/{id}", annotations=Annotations(last_modified="3 August 2026"))
+    result = ResourceTemplatesAnnotationsValidRule().check(AuditData(resource_templates=[template]))
+    assert not result.passed
+    assert result.details == {"templates_with_invalid_annotations": ["bad/{id}"]}
+
+
+def test_description_rule_reports_missing_and_blank_descriptions() -> None:
+    templates = [
+        _template("good", "good/{id}", description="Fetch an item"),
+        _template("missing", "missing/{id}", description=None),
+        _template("blank", "blank/{id}", description="  "),
+    ]
+    result = ResourceTemplatesDescriptionPresentRule().check(AuditData(resource_templates=templates))
+    assert not result.passed
+    assert result.details == {"templates_without_description": ["missing/{id}", "blank/{id}"]}
+
+
 def test_template_rules_pass_when_capability_has_no_templates() -> None:
     for rule in (
         ResourceTemplatesUriTemplatesValidRule(),
         ResourceTemplatesUniqueRule(),
         ResourceTemplatesNamesPresentRule(),
+        ResourceTemplatesMimeTypesValidRule(),
+        ResourceTemplatesAnnotationsValidRule(),
+        ResourceTemplatesDescriptionPresentRule(),
     ):
         assert rule.check(AuditData(resource_templates=[])).passed
         assert rule.check(AuditData(resource_templates=None)).passed
@@ -93,6 +167,9 @@ def test_only_the_uniqueness_rule_skips_incomplete_catalogs() -> None:
     assert ResourceTemplatesUniqueRule().skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
     assert ResourceTemplatesUriTemplatesValidRule().skip_reason(data) is None
     assert ResourceTemplatesNamesPresentRule().skip_reason(data) is None
+    assert ResourceTemplatesMimeTypesValidRule().skip_reason(data) is None
+    assert ResourceTemplatesAnnotationsValidRule().skip_reason(data) is None
+    assert ResourceTemplatesDescriptionPresentRule().skip_reason(data) is None
     # A bad template on a fetched page is a finding even when pages are missing.
     assert ResourceTemplatesUriTemplatesValidRule().check(data).passed is False
 
@@ -109,5 +186,8 @@ def test_all_template_rules_skip_when_listing_produced_no_evidence() -> None:
             ResourceTemplatesUriTemplatesValidRule(),
             ResourceTemplatesUniqueRule(),
             ResourceTemplatesNamesPresentRule(),
+            ResourceTemplatesMimeTypesValidRule(),
+            ResourceTemplatesAnnotationsValidRule(),
+            ResourceTemplatesDescriptionPresentRule(),
         ):
             assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive read-only audit rules and a small refactor with tests; no connection, auth, or scoring-engine behavior changes beyond new optional-capability checks.
> 
> **Overview**
> Adds **three MEDIUM resource-template quality rules** aligned with existing resource catalog checks: valid declared `mimeType`, valid annotations (ISO 8601 `lastModified`), and non-empty descriptions so parameterized resources are easier for clients and models to use.
> 
> MIME and annotation validation is centralized in new `catalog_validation.py` (`is_valid_media_type`, `is_iso_8601`); **resources** rules now import those helpers instead of local regex/`datetime` logic. Rule registry exports, `docs/rules.mdx`, README, and CHANGELOG reflect **+3 rules** (79 total; Tools Quality category count updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d502060c6b97aa26ea32159414847a94de2041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->