### PR TITLE
Add a new rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A LOW resource-template quality rule recommends human-readable display
+  titles for MCP 2025-06-18+ catalogs.
 - Three resource-template quality rules validate declared MIME types and
   annotations, and recommend descriptions that help clients and models
   understand parameterized resources.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-79 rules across four categories — the same four the report, the JSON output, and
+80 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 
@@ -55,7 +55,7 @@ enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/ru
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
-**Tools Quality** (39 rules) — tool names (presence, uniqueness, format), titles,
+**Tools Quality** (40 rules) — tool names (presence, uniqueness, format), titles,
 descriptions of tools and their input properties, and JSON Schema validity of input and
 output schemas, including the 2026-07-28 `x-mcp-header` constraints — plus the
 equivalent catalog checks for prompts, resources, and resource templates: valid and

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -111,6 +111,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `resource_templates_mime_types_valid` | Resource Templates - Declared MIME types must be valid | MEDIUM | 2 | all versions |
 | `resource_templates_annotations_valid` | Resource Templates - Declared annotations must be valid | MEDIUM | 2 | all versions |
 | `resource_templates_description_present` | Resource Templates - All templates should have a description | MEDIUM | 2 | all versions |
+| `resource_templates_titles_present` | Resource Templates - All templates should have a display title | LOW | 1 | 2025-06-18 – … |
 
 ## Prompts
 

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -73,6 +73,7 @@ from .resource_templates import (
     ResourceTemplatesIconsValidRule,
     ResourceTemplatesMimeTypesValidRule,
     ResourceTemplatesNamesPresentRule,
+    ResourceTemplatesTitlesPresentRule,
     ResourceTemplatesUniqueRule,
     ResourceTemplatesUriTemplatesValidRule,
 )
@@ -163,6 +164,7 @@ __all__ = (
     "ResourceTemplatesIconsValidRule",
     "ResourceTemplatesMimeTypesValidRule",
     "ResourceTemplatesNamesPresentRule",
+    "ResourceTemplatesTitlesPresentRule",
     "ResourceTemplatesUniqueRule",
     "ResourceTemplatesUriTemplatesValidRule",
     "ResourcesAnnotationsValidRule",

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -376,3 +376,36 @@ class ResourceTemplatesDescriptionPresentRule(ResourceTemplatesBaseRule):
             ),
             details={"templates_without_description": missing},
         )
+
+
+@register_rule
+class ResourceTemplatesTitlesPresentRule(ResourceTemplatesBaseRule):
+    """Low check: encourage human-readable display titles for resource templates."""
+
+    rule_id = "resource_templates_titles_present"
+    basis = "MCP 2026-07-28 Resources §Resource Templates (title: optional human-readable name for display)"
+    min_spec_version = "2025-06-18"
+    rule_order = 27
+
+    @property
+    def rule_name(self) -> str:
+        return "Resource Templates - All templates should have a display title"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.LOW
+
+    def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
+        missing = [template.uri_template for template in templates if not (template.title and template.title.strip())]
+        passed = not missing
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                "✅ All resource templates have a display title"
+                if passed
+                else f"❌ Number of resource templates without a display title: {len(missing)}"
+            ),
+            details={"templates_without_title": missing},
+        )

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -384,6 +384,10 @@ class ResourceTemplatesTitlesPresentRule(ResourceTemplatesBaseRule):
 
     rule_id = "resource_templates_titles_present"
     basis = "MCP 2026-07-28 Resources §Resource Templates (title: optional human-readable name for display)"
+    # `title` was introduced in the 2025-06-18 revision — earlier servers
+    # cannot declare one and must not be penalized for its absence. (The
+    # basis cites the revision the rule was verified against, per repo
+    # policy — intentionally not the introduction revision.)
     min_spec_version = "2025-06-18"
     rule_order = 27
 

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -6,8 +6,10 @@ from mcpscore.rules import (
     ResourceTemplatesDescriptionPresentRule,
     ResourceTemplatesMimeTypesValidRule,
     ResourceTemplatesNamesPresentRule,
+    ResourceTemplatesTitlesPresentRule,
     ResourceTemplatesUniqueRule,
     ResourceTemplatesUriTemplatesValidRule,
+    RuleSeverity,
 )
 from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
 from mcpscore.rules.resource_templates import is_valid_uri_template
@@ -20,6 +22,7 @@ def _template(
     description: str | None = "Description",
     mime_type: str | None = None,
     annotations: Annotations | None = None,
+    title: str | None = "Display title",
 ) -> ResourceTemplate:
     return ResourceTemplate(
         name=name,
@@ -27,6 +30,7 @@ def _template(
         description=description,
         mime_type=mime_type,
         annotations=annotations,
+        title=title,
     )
 
 
@@ -145,6 +149,35 @@ def test_description_rule_reports_missing_and_blank_descriptions() -> None:
     assert result.details == {"templates_without_description": ["missing/{id}", "blank/{id}"]}
 
 
+def test_titles_rule_is_scoped_to_revisions_that_define_title() -> None:
+    rule = ResourceTemplatesTitlesPresentRule()
+    assert rule.rule_id == "resource_templates_titles_present"
+    assert rule.severity == RuleSeverity.LOW
+    assert rule.min_spec_version == "2025-06-18"
+    assert not rule.applies_to("2025-03-26")
+    assert rule.applies_to("2025-06-18")
+
+
+def test_titles_rule_accepts_non_blank_titles() -> None:
+    templates = [
+        _template("users", "users/{id}", title="User profile"),
+        _template("files", "files/{path}", title="Project file"),
+    ]
+    result = ResourceTemplatesTitlesPresentRule().check(AuditData(resource_templates=templates))
+    assert result.passed
+    assert result.details == {"templates_without_title": []}
+
+
+def test_titles_rule_reports_missing_and_blank_titles() -> None:
+    templates = [
+        _template("missing", "missing/{id}", title=None),
+        _template("blank", "blank/{id}", title="  "),
+    ]
+    result = ResourceTemplatesTitlesPresentRule().check(AuditData(resource_templates=templates))
+    assert not result.passed
+    assert result.details == {"templates_without_title": ["missing/{id}", "blank/{id}"]}
+
+
 def test_template_rules_pass_when_capability_has_no_templates() -> None:
     for rule in (
         ResourceTemplatesUriTemplatesValidRule(),
@@ -153,6 +186,7 @@ def test_template_rules_pass_when_capability_has_no_templates() -> None:
         ResourceTemplatesMimeTypesValidRule(),
         ResourceTemplatesAnnotationsValidRule(),
         ResourceTemplatesDescriptionPresentRule(),
+        ResourceTemplatesTitlesPresentRule(),
     ):
         assert rule.check(AuditData(resource_templates=[])).passed
         assert rule.check(AuditData(resource_templates=None)).passed
@@ -170,6 +204,7 @@ def test_only_the_uniqueness_rule_skips_incomplete_catalogs() -> None:
     assert ResourceTemplatesMimeTypesValidRule().skip_reason(data) is None
     assert ResourceTemplatesAnnotationsValidRule().skip_reason(data) is None
     assert ResourceTemplatesDescriptionPresentRule().skip_reason(data) is None
+    assert ResourceTemplatesTitlesPresentRule().skip_reason(data) is None
     # A bad template on a fetched page is a finding even when pages are missing.
     assert ResourceTemplatesUriTemplatesValidRule().check(data).passed is False
 
@@ -189,5 +224,6 @@ def test_all_template_rules_skip_when_listing_produced_no_evidence() -> None:
             ResourceTemplatesMimeTypesValidRule(),
             ResourceTemplatesAnnotationsValidRule(),
             ResourceTemplatesDescriptionPresentRule(),
+            ResourceTemplatesTitlesPresentRule(),
         ):
             assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds an optional LOW-severity catalog recommendation with spec-version scoping and no changes to connection, scoring math beyond one new rule weight, or security paths.
> 
> **Overview**
> Adds a **LOW** audit rule `resource_templates_titles_present` that flags resource templates missing a non-blank optional `title` on MCP **2025-06-18+** catalogs, aligned with existing resource/prompt/tool title checks.
> 
> The rule is registered and exported, documented in the rules reference and changelog, and covered by tests (version scoping, pass/fail cases, empty catalogs, partial listings, and insufficient-data skips). README rule counts move from 79→80 total and 39→40 in Tools Quality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e17b027de323710e11d1452c628468fd27955e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->