### PR TITLE
Prepare 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-03
+
+Catalog polish release: eight new rules — icon validation across all four
+catalog surfaces (tools, resources, resource templates, prompts) with strict
+URI/data-URI checking, plus resource-template quality checks (MIME types,
+annotations, descriptions, display titles) that bring templates to parity
+with the resources catalog. 80 rules total.
+
 ### Added
 
 - A LOW resource-template quality rule recommends human-readable display
@@ -790,7 +798,8 @@ declared is graded.
 - Transport rule: SSE transport support detection.
 - Tools rules: unique names and valid name format checks.
 
-[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/mcp-box/mcpscore/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/mcp-box/mcpscore/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/mcp-box/mcpscore/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mcp-box/mcpscore/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/mcp-box/mcpscore/compare/v1.1.0...v1.1.1

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-box/mcpscore",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Audit an MCP server and get a scored, actionable quality report in seconds. Node wrapper for the Python mcpscore CLI.",
   "bin": {
     "mcpscore": "bin/mcpscore.js"
@@ -33,7 +33,7 @@
     "developer-tools"
   ],
   "mcpscore": {
-    "pythonVersion": "1.3.0"
+    "pythonVersion": "1.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = ["mcpscore"]
 
 [project]
 name = "mcpscore"
-version = "1.3.0"
+version = "1.4.0"
 description = "Audit an MCP server and get a scored, actionable quality report in seconds."
 authors = [{ name = "Alex Akimov"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "mcpscore"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime or audit logic modified in this PR.
> 
> **Overview**
> **Release prep for 1.4.0** — bumps the version from **1.3.0** to **1.4.0** in `pyproject.toml`, `npm/package.json` (including `mcpscore.pythonVersion`), and `uv.lock`, with no application code changes in this diff.
> 
> **CHANGELOG** adds a dated **[1.4.0] - 2026-08-03** section summarizing the catalog polish release (eight new rules: icon validation on tools, resources, resource templates, and prompts; resource-template MIME, annotations, descriptions, and display titles; **80 rules** total). The Unreleased compare link now points at `v1.4.0...HEAD`, and a new `[1.4.0]` release link is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d201ad66d7fdc54422e3c1d2524da95e94210f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->