### PR TITLE
Add another rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2026-08-03: 143/436 sampled servers declare output schemas, zero violate —
   pure forward protection as 2026-07-28 adoption spreads.
 
+### Changed
+
+- `tools_output_schema_valid` no longer requires an object root: from
+  2026-07-28 an output schema "can be any valid JSON Schema 2020-12", so a
+  modern server declaring an array-rooted schema was a false positive (input
+  schemas keep the object-root requirement — that literal persists in every
+  revision). The object-root question for 2025-06-18..2025-11-25 now belongs
+  exclusively to the new version-scoped rule, so one condition is never
+  penalized twice.
+
 ## [1.4.0] - 2026-08-03
 
 Catalog polish release: eight new rules — icon validation across all four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New HIGH version-scoped rule `tools_output_schema_root_object`: on
+  revisions 2025-06-18 through 2025-11-25 the schema restricts `outputSchema`
+  to `type: "object"` at the root (any-root schemas became legal in
+  2026-07-28) — a non-object root on a legacy negotiation breaks clients
+  that compile declared schemas relying on that guarantee. Registry dry-run
+  2026-08-03: 143/436 sampled servers declare output schemas, zero violate —
+  pure forward protection as 2026-07-28 adoption spreads.
+
 ## [1.4.0] - 2026-08-03
 
 Catalog polish release: eight new rules — icon validation across all four

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-80 rules across four categories — the same four the report, the JSON output, and
+81 rules across four categories — the same four the report, the JSON output, and
 [mcpscore.dev](https://mcpscore.dev) show. Every rule cites the spec section or RFC it
 enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/rules/).
 
@@ -55,7 +55,7 @@ enforces; the full list is in the [rules reference](https://docs.mcpscore.dev/ru
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
-**Tools Quality** (40 rules) — tool names (presence, uniqueness, format), titles,
+**Tools Quality** (41 rules) — tool names (presence, uniqueness, format), titles,
 descriptions of tools and their input properties, and JSON Schema validity of input and
 output schemas, including the 2026-07-28 `x-mcp-header` constraints — plus the
 equivalent catalog checks for prompts, resources, and resource templates: valid and

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -79,6 +79,7 @@ Every rule mcpscore runs, generated from the rule registry
 | `tools_mcp_headers_statically_reachable` | Tools - MCP header parameters must be statically reachable | HIGH | 3 | 2026-07-28 – … |
 | `tools_input_properties_documented` | Tools - Input properties should be documented | MEDIUM | 2 | all versions |
 | `tools_icons_valid` | Tools - Declared icons must be valid | LOW | 1 | 2025-11-25 – … |
+| `tools_output_schema_root_object` | Tools - Output schemas must be object-rooted on this revision | HIGH | 3 | 2025-06-18 – 2025-11-25 |
 
 ## Transport
 

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -116,6 +116,7 @@ from .tools import (
     ToolsNamePresentRule,
     ToolsNamesUniqueRule,
     ToolsNamesValidFormatRule,
+    ToolsOutputSchemaRootObjectRule,
     ToolsOutputSchemaValidRule,
     ToolsTitlePresentRule,
 )
@@ -206,6 +207,7 @@ __all__ = (
     "ToolsNamePresentRule",
     "ToolsNamesUniqueRule",
     "ToolsNamesValidFormatRule",
+    "ToolsOutputSchemaRootObjectRule",
     "ToolsOutputSchemaValidRule",
     "ToolsTitlePresentRule",
     "UnsupportedVersionErrorReadinessRule",

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -475,6 +475,40 @@ def is_valid_schema(schema: dict[str, Any] | None) -> bool:
     return True
 
 
+def is_valid_output_schema(schema: dict[str, Any] | None) -> bool:
+    """Validate an ``outputSchema`` without requiring an object root.
+
+    From 2026-07-28 an output schema "can be any valid JSON Schema 2020-12",
+    so unlike ``is_valid_schema`` (input schemas keep their object-root
+    requirement in every revision) this accepts any root:
+
+    - combinators/references are valid top-level forms;
+    - an object-rooted schema gets the full object shape checks;
+    - any other root is accepted when its plain-string ``type`` (if present)
+      is a real JSON Schema type.
+
+    Whether a non-object root is *allowed on the negotiated revision* is a
+    separate, version-scoped question — ``tools_output_schema_root_object``
+    judges that for 2025-06-18..2025-11-25, so the two rules never
+    double-penalize one condition.
+
+    Args:
+        schema: The schema dictionary to validate
+
+    Returns:
+        bool: True if a schema is valid, False otherwise
+
+    """
+    if schema is None:
+        return False
+    if any(key in schema for key in ("anyOf", "oneOf", "allOf", "$ref")):
+        return True
+    if schema.get("type") == "object":
+        return is_valid_schema(schema)
+    root_type = schema.get("type")
+    return not isinstance(root_type, str) or root_type in _VALID_JSON_TYPES
+
+
 @register_rule
 class ToolsInputSchemaValidRule(ToolsBaseRule):
     """High check: Verify that each tool has a valid input schema."""
@@ -526,7 +560,9 @@ class ToolsOutputSchemaValidRule(ToolsBaseRule):
 
     The MCP specification makes ``outputSchema`` optional — tools returning
     unstructured content simply omit it. Only tools that declare one are
-    validated.
+    validated. Validity here is root-agnostic (2026-07-28 allows any valid
+    JSON Schema root); the object-root restriction of earlier revisions is
+    the version-scoped ``tools_output_schema_root_object`` rule's job.
     """
 
     rule_id = "tools_output_schema_valid"
@@ -551,7 +587,9 @@ class ToolsOutputSchemaValidRule(ToolsBaseRule):
 
         """
         tools_with_invalid_output_schema: list[str] = [
-            tool.name for tool in tools if tool.output_schema is not None and not is_valid_schema(tool.output_schema)
+            tool.name
+            for tool in tools
+            if tool.output_schema is not None and not is_valid_output_schema(tool.output_schema)
         ]
 
         passed = len(tools_with_invalid_output_schema) == 0

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -570,6 +570,55 @@ class ToolsOutputSchemaValidRule(ToolsBaseRule):
         )
 
 
+@register_rule
+class ToolsOutputSchemaRootObjectRule(ToolsBaseRule):
+    """High check: output schemas must be object-rooted where the revision requires it.
+
+    Through 2025-11-25 the schema literal restricts ``outputSchema`` to
+    ``type: "object"`` at the root ("Currently restricted to type: 'object'
+    at the root level"); any-root schemas became legal in 2026-07-28. A
+    server negotiating an older revision while declaring a non-object root
+    breaks clients that compile declared schemas relying on that guarantee
+    (e.g. the Go and Rust quickstart clients).
+    """
+
+    rule_id = "tools_output_schema_root_object"
+    basis = 'MCP 2025-11-25 Schema Reference §Tool (outputSchema "restricted to type: object at the root level")'
+    # outputSchema itself was introduced in 2025-06-18; the root restriction
+    # was lifted in 2026-07-28 — the rule applies only inside that window.
+    min_spec_version = "2025-06-18"
+    max_spec_version = "2025-11-25"
+    rule_order = 17
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools - Output schemas must be object-rooted on this revision"
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def _check_tools(self, tools: list[Tool]) -> RuleResult:
+        offending = {
+            tool.name: tool.output_schema.get("type", "<absent>")
+            for tool in tools
+            if tool.output_schema is not None and tool.output_schema.get("type") != "object"
+        }
+        passed = not offending
+        message = (
+            "✅ All declared output schemas are object-rooted"
+            if passed
+            else f"❌ Number of tools with a non-object output schema root: {len(offending)}"
+        )
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=message,
+            details={"tools_with_non_object_root": offending},
+        )
+
+
 class ToolsMcpHeadersBaseRule(ToolsBaseRule):
     """Base class for 2026 x-mcp-header definition rules."""
 

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -39,6 +39,7 @@ from mcpscore.rules.tools import (
     ToolsOutputSchemaRootObjectRule,
     ToolsOutputSchemaValidRule,
     ToolsTitlePresentRule,
+    is_valid_output_schema,
     is_valid_schema,
 )
 
@@ -198,7 +199,11 @@ def tool_with_invalid_output_schema() -> Tool:
             "required": [],
         },
         output_schema={
-            "type": "array",  # Wrong type
+            # An array root is VALID for output schemas since the 2026-08 split
+            # (the version question is tools_output_schema_root_object's job) —
+            # a malformed properties mapping is what invalidity means here.
+            "type": "object",
+            "properties": "not-a-mapping",
             "title": "Invalid Output",
         },
     )
@@ -1235,3 +1240,37 @@ class TestToolsOutputSchemaRootObjectRule:
         assert not result.passed
         assert result.details["tools_with_non_object_root"] == {"arr": "array", "untyped": "<absent>"}
         assert "2" in result.message
+
+
+class TestIsValidOutputSchema:
+    """Root-agnostic output-schema validity.
+
+    The root-vs-revision question belongs to
+    ``tools_output_schema_root_object``, not to this helper.
+    """
+
+    def test_array_root_is_valid(self):
+        assert is_valid_output_schema({"type": "array", "items": {"type": "object"}})
+
+    def test_scalar_and_untyped_roots_are_valid(self):
+        assert is_valid_output_schema({"type": "string"})
+        assert is_valid_output_schema({"description": "anything"})  # no type at root
+
+    def test_object_root_keeps_full_shape_checks(self):
+        assert is_valid_output_schema({"type": "object", "properties": {}})
+        assert not is_valid_output_schema({"type": "object", "properties": "nope"})
+        assert not is_valid_output_schema({"type": "object", "required": ["x"], "properties": {}})
+
+    def test_invalid_root_type_and_none_fail(self):
+        assert not is_valid_output_schema({"type": "tuple"})
+        assert not is_valid_output_schema(None)
+
+    def test_output_rule_accepts_array_root(self):
+        tool = Tool(name="t", input_schema={"type": "object"}, output_schema={"type": "array", "items": {}})
+        result = ToolsOutputSchemaValidRule().check(AuditData(tools=[tool]))
+        assert result.passed
+
+    def test_input_rule_still_requires_object_root(self):
+        tool = Tool(name="t", input_schema={"type": "array"}, output_schema=None)
+        result = ToolsInputSchemaValidRule().check(AuditData(tools=[tool]))
+        assert not result.passed

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -36,6 +36,7 @@ from mcpscore.rules.tools import (
     ToolsNamePresentRule,
     ToolsNamesUniqueRule,
     ToolsNamesValidFormatRule,
+    ToolsOutputSchemaRootObjectRule,
     ToolsOutputSchemaValidRule,
     ToolsTitlePresentRule,
     is_valid_schema,
@@ -1200,3 +1201,37 @@ class TestToolsExecutionConsistentRule:
         rule = ToolsExecutionConsistentRule()
         data = AuditData(tools=None, capabilities=capabilities_full)
         assert rule.skip_reason(data) == SKIP_REASON_INSUFFICIENT_DATA
+
+
+class TestToolsOutputSchemaRootObjectRule:
+    """Version-scoped root-type restriction (2025-06-18 .. 2025-11-25)."""
+
+    def _tool(self, output_schema):
+        return Tool(name="t", input_schema={"type": "object"}, output_schema=output_schema)
+
+    def test_scoped_to_the_restriction_window(self):
+        rule = ToolsOutputSchemaRootObjectRule()
+        assert not rule.applies_to("2025-03-26")  # outputSchema does not exist yet
+        assert rule.applies_to("2025-06-18")
+        assert rule.applies_to("2025-11-25")
+        assert not rule.applies_to("2026-07-28")  # any root became legal
+
+    def test_object_rooted_and_absent_schemas_pass(self):
+        tools = [
+            self._tool({"type": "object", "properties": {}}),
+            Tool(name="none", input_schema={"type": "object"}),  # no outputSchema at all
+        ]
+        result = ToolsOutputSchemaRootObjectRule().check(AuditData(tools=tools))
+        assert result.passed
+        assert result.details == {"tools_with_non_object_root": {}}
+
+    def test_non_object_roots_fail_with_root_named(self):
+        tools = [
+            Tool(name="arr", input_schema={"type": "object"}, output_schema={"type": "array", "items": {}}),
+            Tool(name="untyped", input_schema={"type": "object"}, output_schema={"properties": {}}),
+            Tool(name="ok", input_schema={"type": "object"}, output_schema={"type": "object"}),
+        ]
+        result = ToolsOutputSchemaRootObjectRule().check(AuditData(tools=tools))
+        assert not result.passed
+        assert result.details["tools_with_non_object_root"] == {"arr": "array", "untyped": "<absent>"}
+        assert "2" in result.message


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes audit scoring and rule logic only; no runtime server behavior, auth, or transport paths. Modern servers with array-root output schemas may see higher scores; legacy-scoped checks add forward protection without touching critical infrastructure.
> 
> **Overview**
> Splits **tool `outputSchema` validation** along MCP revision lines so modern servers are not penalized for non-object roots while legacy negotiations still enforce the old guarantee.
> 
> **`tools_output_schema_valid`** now uses a new **`is_valid_output_schema`** helper that accepts any valid JSON Schema 2020-12 root (arrays, scalars, combinators), matching **2026-07-28** where output schemas are no longer object-only. Input schemas still require an object root via **`is_valid_schema`**.
> 
> A new HIGH rule **`tools_output_schema_root_object`** applies only on **2025-06-18 through 2025-11-25** and fails tools whose declared `outputSchema` root is not `type: "object"`, so clients that rely on the pre-2026 restriction are protected without double-counting the same defect against validity.
> 
> Docs and changelog reflect **81** total rules (41 in Tools Quality); tests cover scoping, helpers, and the split between the two rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e073f8ca3e0b79175b74e33da32b2bcc4ef27a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->