### PR TITLE
Empty catalogs no longer earn green quality passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Empty catalogs no longer earn green quality passes.** A successful empty
+  tools, prompts, resources, or resource-templates listing now makes per-item
+  quality rules skip as not applicable and contribute 0/0. The dedicated
+  `tools_at_least_one` rule still judges and fails a complete empty tools
+  catalog; unavailable and empty partial listings remain insufficient data.
 - **Remote-only checks no longer award ten unearned points to stdio
   servers.** TLS, malformed-request handling, error-data-leak, and Streamable
   HTTP transport rules now skip as not applicable for stdio instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quality rules skip as not applicable and contribute 0/0. The dedicated
   `tools_at_least_one` rule still judges and fails a complete empty tools
   catalog; unavailable and empty partial listings remain insufficient data.
+
+  The bigger population is servers that never declare a capability at all:
+  those previously passed every quality rule for the absent catalog too ("✅ No
+  prompts to evaluate"), and now skip the same way. A tools-only server stops
+  earning ~24 vacuous prompt/resource/template passes, so scores move on almost
+  every server — e.g. DeepWiki 123/132 (93%) → 76/85 (89%). The removed credit
+  always scored 100%, so honest percentages are lower for any server that is
+  imperfect elsewhere; the points removed were never evidence of anything.
 - **Remote-only checks no longer award ten unearned points to stdio
   servers.** TLS, malformed-request handling, error-data-leak, and Streamable
   HTTP transport rules now skip as not applicable for stdio instead of

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -43,9 +43,15 @@ of three reasons:
 
 | Skip reason | Meaning |
 |---|---|
-| `not-applicable` | The rule's requirement does not exist for the negotiated version or transport (e.g. an HTTP-header rule during a stdio audit) |
+| `not-applicable` | The rule has no subject for this audit: its requirement does not exist for the negotiated version or transport, or an optional catalog has no items to judge |
 | `insufficient-data` | The observations the rule needs are unavailable (e.g. a probe errored) — the rule can neither pass nor fail |
 | `requires-modern-support` | A readiness detail check on a server with no modern-lifecycle support — the gateway rules already carry that verdict; repeating it per detail would pile on noise |
+
+For example, a successfully fetched empty tools, prompts, resources, or resource-template
+catalog gives per-item quality rules nothing to assess, so those rules contribute 0/0.
+If a declared catalog could not be fetched, or an incomplete listing returned no
+items, the same rules use `insufficient-data` because an item may exist but remain
+unobserved. A dedicated presence rule can still judge whether a complete catalog is empty.
 
 ## How an audit runs
 

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -3,7 +3,15 @@ from collections import Counter
 
 from mcp_types import Prompt
 
-from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .base import (
+    SKIP_REASON_INSUFFICIENT_DATA,
+    SKIP_REASON_NOT_APPLICABLE,
+    AuditData,
+    BaseRule,
+    RuleResult,
+    RuleSeverity,
+    requires_fields,
+)
 from .icon_validation import find_invalid_icons
 from .registry import register_rule
 
@@ -11,15 +19,24 @@ from .registry import register_rule
 class PromptsBaseRule(BaseRule):
     """Base class for prompt-quality audit rules.
 
-    Prompts are an optional MCP capability, so these rules never penalize a
-    server that offers none: with no prompts there is nothing to evaluate and
-    the check passes as not-applicable. They grade only the *quality* of
-    prompts that are actually declared. (Whether a server *should* offer
-    prompts at all is handled by the capability-presence rules.)
+    Prompts are an optional MCP capability. With no prompts there is nothing
+    whose quality can be judged, so these rules skip as not applicable and add
+    no score weight. Capability consistency is judged separately.
     """
 
     group_name = "prompts"
     group_order = 8
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when the prompt catalog is unavailable or has no prompts to judge."""
+        listing = "prompts"
+        unavailable = audit_data.prompts is None and listing in audit_data.listings_attempted
+        empty_partial = not audit_data.prompts and listing in audit_data.incomplete_listings
+        if unavailable or empty_partial:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        if not audit_data.prompts:
+            return SKIP_REASON_NOT_APPLICABLE
+        return None
 
     @requires_fields("prompts")
     def check(self, prompts: list[Prompt] | None) -> RuleResult:  # type: ignore[override]
@@ -32,14 +49,7 @@ class PromptsBaseRule(BaseRule):
             RuleResult indicating whether the prompt check passed
 
         """
-        if not prompts:
-            return RuleResult(
-                rule_name=self.rule_name,
-                severity=self.severity,
-                passed=True,
-                message="✅ No prompts to evaluate",
-                details={"prompts_count": 0},
-            )
+        assert prompts  # noqa: S101 — skip_reason guarantees prompts to judge
         return self._check_prompts(prompts)
 
     @abstractmethod
@@ -258,6 +268,8 @@ class PromptsNamesUniqueRule(PromptsBaseRule):
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
         """Skip when pagination did not produce the complete prompt list."""
+        if reason := super().skip_reason(audit_data):
+            return reason
         return SKIP_REASON_INSUFFICIENT_DATA if "prompts" in audit_data.incomplete_listings else None
 
     def _check_prompts(self, prompts: list[Prompt]) -> RuleResult:

--- a/mcpscore/rules/prompts.py
+++ b/mcpscore/rules/prompts.py
@@ -30,7 +30,8 @@ class PromptsBaseRule(BaseRule):
     def skip_reason(self, audit_data: AuditData) -> str | None:
         """Skip when the prompt catalog is unavailable or has no prompts to judge."""
         listing = "prompts"
-        unavailable = audit_data.prompts is None and listing in audit_data.listings_attempted
+        declares_prompts = getattr(audit_data.capabilities, "prompts", None) is not None
+        unavailable = audit_data.prompts is None and (declares_prompts or listing in audit_data.listings_attempted)
         empty_partial = not audit_data.prompts and listing in audit_data.incomplete_listings
         if unavailable or empty_partial:
             return SKIP_REASON_INSUFFICIENT_DATA

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -4,7 +4,15 @@ import re
 
 from mcp_types import ResourceTemplate
 
-from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .base import (
+    SKIP_REASON_INSUFFICIENT_DATA,
+    SKIP_REASON_NOT_APPLICABLE,
+    AuditData,
+    BaseRule,
+    RuleResult,
+    RuleSeverity,
+    requires_fields,
+)
 from .catalog_validation import is_iso_8601, is_valid_media_type
 from .icon_validation import find_invalid_icons
 from .registry import register_rule
@@ -100,19 +108,16 @@ class ResourceTemplatesBaseRule(BaseRule):
         listing = "resource_templates"
         unavailable = audit_data.resource_templates is None and listing in audit_data.listings_attempted
         empty_partial = not audit_data.resource_templates and listing in audit_data.incomplete_listings
-        return SKIP_REASON_INSUFFICIENT_DATA if unavailable or empty_partial else None
+        if unavailable or empty_partial:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        if not audit_data.resource_templates:
+            return SKIP_REASON_NOT_APPLICABLE
+        return None
 
     @requires_fields("resource_templates")
     def check(self, templates: list[ResourceTemplate] | None) -> RuleResult:  # type: ignore[override]
         """Execute the rule, treating an absent optional catalog as not applicable."""
-        if not templates:
-            return RuleResult(
-                rule_name=self.rule_name,
-                severity=self.severity,
-                passed=True,
-                message="✅ No resource templates to evaluate",
-                details={"resource_templates_count": 0},
-            )
+        assert templates  # noqa: S101 — skip_reason guarantees templates to judge
         return self._check_templates(templates)
 
     @abstractmethod
@@ -179,11 +184,9 @@ class ResourceTemplatesUniqueRule(ResourceTemplatesBaseRule):
         Uniqueness judged on a partial listing can produce a false pass — the
         duplicate may live on a page that was never fetched.
         """
-        return (
-            SKIP_REASON_INSUFFICIENT_DATA
-            if super().skip_reason(audit_data) is not None or "resource_templates" in audit_data.incomplete_listings
-            else None
-        )
+        if reason := super().skip_reason(audit_data):
+            return reason
+        return SKIP_REASON_INSUFFICIENT_DATA if "resource_templates" in audit_data.incomplete_listings else None
 
     def _check_templates(self, templates: list[ResourceTemplate]) -> RuleResult:
         counts = Counter(template.uri_template for template in templates)

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -106,7 +106,10 @@ class ResourceTemplatesBaseRule(BaseRule):
     def skip_reason(self, audit_data: AuditData) -> str | None:
         """Skip when an attempted listing produced no evidence to judge."""
         listing = "resource_templates"
-        unavailable = audit_data.resource_templates is None and listing in audit_data.listings_attempted
+        declares_resources = getattr(audit_data.capabilities, "resources", None) is not None
+        unavailable = audit_data.resource_templates is None and (
+            declares_resources or listing in audit_data.listings_attempted
+        )
         empty_partial = not audit_data.resource_templates and listing in audit_data.incomplete_listings
         if unavailable or empty_partial:
             return SKIP_REASON_INSUFFICIENT_DATA

--- a/mcpscore/rules/resource_templates.py
+++ b/mcpscore/rules/resource_templates.py
@@ -104,7 +104,7 @@ class ResourceTemplatesBaseRule(BaseRule):
     group_order = 7
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
-        """Skip when an attempted listing produced no evidence to judge."""
+        """Skip when the template catalog is unavailable or has no templates to judge."""
         listing = "resource_templates"
         declares_resources = getattr(audit_data.capabilities, "resources", None) is not None
         unavailable = audit_data.resource_templates is None and (

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -37,7 +37,8 @@ class ResourcesBaseRule(BaseRule):
     def skip_reason(self, audit_data: AuditData) -> str | None:
         """Skip when the resource catalog is unavailable or has no resources to judge."""
         listing = "resources"
-        unavailable = audit_data.resources is None and listing in audit_data.listings_attempted
+        declares_resources = getattr(audit_data.capabilities, "resources", None) is not None
+        unavailable = audit_data.resources is None and (declares_resources or listing in audit_data.listings_attempted)
         empty_partial = not audit_data.resources and listing in audit_data.incomplete_listings
         if unavailable or empty_partial:
             return SKIP_REASON_INSUFFICIENT_DATA

--- a/mcpscore/rules/resources.py
+++ b/mcpscore/rules/resources.py
@@ -5,7 +5,15 @@ from urllib.parse import urlsplit
 
 from mcp_types import Resource
 
-from .base import SKIP_REASON_INSUFFICIENT_DATA, AuditData, BaseRule, RuleResult, RuleSeverity, requires_fields
+from .base import (
+    SKIP_REASON_INSUFFICIENT_DATA,
+    SKIP_REASON_NOT_APPLICABLE,
+    AuditData,
+    BaseRule,
+    RuleResult,
+    RuleSeverity,
+    requires_fields,
+)
 from .catalog_validation import is_iso_8601, is_valid_media_type
 from .icon_validation import find_invalid_icons
 from .registry import register_rule
@@ -18,15 +26,24 @@ _INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 class ResourcesBaseRule(BaseRule):
     """Base class for resource-quality audit rules.
 
-    Resources are an optional MCP capability, so these rules never penalize a
-    server that offers none: with no resources there is nothing to evaluate and
-    the check passes as not-applicable. They grade only the *quality* of
-    resources that are actually declared. (Whether a server *should* offer
-    resources at all is handled by the capability-presence rules.)
+    Resources are an optional MCP capability. With no resources there is
+    nothing whose quality can be judged, so these rules skip as not applicable
+    and add no score weight. Capability consistency is judged separately.
     """
 
     group_name = "resources"
     group_order = 6
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip when the resource catalog is unavailable or has no resources to judge."""
+        listing = "resources"
+        unavailable = audit_data.resources is None and listing in audit_data.listings_attempted
+        empty_partial = not audit_data.resources and listing in audit_data.incomplete_listings
+        if unavailable or empty_partial:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        if not audit_data.resources:
+            return SKIP_REASON_NOT_APPLICABLE
+        return None
 
     @requires_fields("resources")
     def check(self, resources: list[Resource] | None) -> RuleResult:  # type: ignore[override]
@@ -39,14 +56,7 @@ class ResourcesBaseRule(BaseRule):
             RuleResult indicating whether the resource check passed
 
         """
-        if not resources:
-            return RuleResult(
-                rule_name=self.rule_name,
-                severity=self.severity,
-                passed=True,
-                message="✅ No resources to evaluate",
-                details={"resources_count": 0},
-            )
+        assert resources  # noqa: S101 — skip_reason guarantees resources to judge
         return self._check_resources(resources)
 
     @abstractmethod
@@ -330,6 +340,8 @@ class ResourcesUrisUniqueRule(ResourcesBaseRule):
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
         """Skip when pagination did not produce the complete resource list."""
+        if reason := super().skip_reason(audit_data):
+            return reason
         return SKIP_REASON_INSUFFICIENT_DATA if "resources" in audit_data.incomplete_listings else None
 
     def _check_resources(self, resources: list[Resource]) -> RuleResult:

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -1,12 +1,13 @@
 from abc import abstractmethod
 from collections import Counter
 import re
-from typing import Any
+from typing import Any, ClassVar
 
 from mcp_types import Tool
 
 from .base import (
     SKIP_REASON_INSUFFICIENT_DATA,
+    SKIP_REASON_NOT_APPLICABLE,
     AuditData,
     BaseRule,
     RuleResult,
@@ -27,12 +28,19 @@ class ToolsBaseRule(BaseRule):
 
     group_name = "tools"
     group_order = 4
+    judge_empty_catalog: ClassVar[bool] = False
+    """Whether this rule's subject is the absence of tools itself."""
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
-        """Skip quality checks when a declared tools catalog is unavailable."""
+        """Skip when the tools catalog is unavailable or has no tools to judge."""
+        listing = "tools"
         declares_tools = getattr(audit_data.capabilities, "tools", None) is not None
-        if declares_tools and audit_data.tools is None:
+        unavailable = audit_data.tools is None and (declares_tools or listing in audit_data.listings_attempted)
+        empty_partial = not audit_data.tools and listing in audit_data.incomplete_listings
+        if unavailable or empty_partial:
             return SKIP_REASON_INSUFFICIENT_DATA
+        if not audit_data.tools and not self.judge_empty_catalog:
+            return SKIP_REASON_NOT_APPLICABLE
         return None
 
     @requires_tools
@@ -54,7 +62,7 @@ class ToolsBaseRule(BaseRule):
                 message="❌ Tools object is not available",
                 details={"tools": None},
             )
-
+        assert tools or self.judge_empty_catalog  # noqa: S101 — skip_reason gates empty quality catalogs
         return self._check_tools(tools)
 
     @abstractmethod
@@ -82,6 +90,7 @@ class ToolsAtLeastOneRule(ToolsBaseRule):
     rule_id = "tools_at_least_one"
     basis = "MCP 2025-11-25 Tools §Listing Tools (tools/list)"
     rule_order = 1
+    judge_empty_catalog = True
 
     @property
     def rule_name(self) -> str:
@@ -98,9 +107,10 @@ class ToolsAtLeastOneRule(ToolsBaseRule):
         tools may live on a page that was never fetched. A non-empty partial
         listing proves presence, so the rule still judges (and passes) it.
         """
-        if reason := super().skip_reason(audit_data):
-            return reason
-        if "tools" in audit_data.incomplete_listings and not audit_data.tools:
+        listing = "tools"
+        declares_tools = getattr(audit_data.capabilities, "tools", None) is not None
+        unavailable = audit_data.tools is None and (declares_tools or listing in audit_data.listings_attempted)
+        if unavailable or (listing in audit_data.incomplete_listings and not audit_data.tools):
             return SKIP_REASON_INSUFFICIENT_DATA
         return None
 
@@ -1009,9 +1019,14 @@ class ToolsExecutionConsistentRule(BaseRule):
         tools rules already report the missing list, so re-passing here on an
         empty fallback would be a false green.
         """
+        listing = "tools"
         declares_tools = getattr(audit_data.capabilities, "tools", None) is not None
-        if declares_tools and audit_data.tools is None:
+        unavailable = audit_data.tools is None and (declares_tools or listing in audit_data.listings_attempted)
+        empty_partial = not audit_data.tools and listing in audit_data.incomplete_listings
+        if unavailable or empty_partial:
             return SKIP_REASON_INSUFFICIENT_DATA
+        if not audit_data.tools:
+            return SKIP_REASON_NOT_APPLICABLE
         return None
 
     @property

--- a/mcpscore/rules/tools.py
+++ b/mcpscore/rules/tools.py
@@ -1012,12 +1012,11 @@ class ToolsExecutionConsistentRule(BaseRule):
     min_spec_version = "2025-11-25"
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
-        """Skip when the tools list is unavailable despite a declared tools capability.
+        """Skip when the tools catalog is unavailable or has no tools to judge.
 
-        A failed ``tools/list`` (tools is None while the server declared the
-        tools capability) means this rule cannot judge consistency — the peer
-        tools rules already report the missing list, so re-passing here on an
-        empty fallback would be a false green.
+        A declared-but-unobserved catalog or an empty partial listing lacks
+        enough evidence to judge consistency. A complete empty catalog has no
+        tool whose execution metadata this rule can assess.
         """
         listing = "tools"
         declares_tools = getattr(audit_data.capabilities, "tools", None) is not None

--- a/tests/test_prompts_rules.py
+++ b/tests/test_prompts_rules.py
@@ -43,6 +43,13 @@ class TestPromptsDescriptionPresentRule:
         assert rule.skip_reason(unavailable) == SKIP_REASON_INSUFFICIENT_DATA
         assert rule.skip_reason(empty_partial) == SKIP_REASON_INSUFFICIENT_DATA
 
+    def test_declared_but_unobserved_prompts_are_insufficient_data(self, capabilities_full) -> None:
+        rule = PromptsDescriptionPresentRule()
+
+        assert (
+            rule.skip_reason(AuditData(prompts=None, capabilities=capabilities_full)) == SKIP_REASON_INSUFFICIENT_DATA
+        )
+
     def test_all_described_passes(self) -> None:
         rule = PromptsDescriptionPresentRule()
         result = rule.check(AuditData(prompts=[_prompt("a"), _prompt("b")]))

--- a/tests/test_prompts_rules.py
+++ b/tests/test_prompts_rules.py
@@ -12,7 +12,7 @@ from mcpscore.rules import (
     PromptsTitlesPresentRule,
     RuleSeverity,
 )
-from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
 
 
 def _prompt(
@@ -30,10 +30,18 @@ class TestPromptsDescriptionPresentRule:
         assert rule.severity == RuleSeverity.MEDIUM
         assert rule.group_name == "prompts"
 
-    def test_no_prompts_is_not_applicable_and_passes(self) -> None:
+    def test_no_prompts_is_not_applicable_and_skips(self) -> None:
         rule = PromptsDescriptionPresentRule()
-        assert rule.check(AuditData(prompts=None)).passed
-        assert rule.check(AuditData(prompts=[])).passed
+        assert rule.skip_reason(AuditData(prompts=None)) == SKIP_REASON_NOT_APPLICABLE
+        assert rule.skip_reason(AuditData(prompts=[])) == SKIP_REASON_NOT_APPLICABLE
+
+    def test_unavailable_or_empty_partial_prompts_are_insufficient_data(self) -> None:
+        rule = PromptsDescriptionPresentRule()
+        unavailable = AuditData(prompts=None, listings_attempted=frozenset({"prompts"}))
+        empty_partial = AuditData(prompts=[], incomplete_listings=frozenset({"prompts"}))
+
+        assert rule.skip_reason(unavailable) == SKIP_REASON_INSUFFICIENT_DATA
+        assert rule.skip_reason(empty_partial) == SKIP_REASON_INSUFFICIENT_DATA
 
     def test_all_described_passes(self) -> None:
         rule = PromptsDescriptionPresentRule()
@@ -151,8 +159,9 @@ class TestPromptsArgumentsDocumentedRule:
         assert rule.rule_id == "prompts_arguments_documented"
         assert rule.severity == RuleSeverity.LOW
 
-    def test_no_prompts_passes(self) -> None:
-        assert PromptsArgumentsDocumentedRule().check(AuditData(prompts=None)).passed
+    def test_no_prompts_skips(self) -> None:
+        rule = PromptsArgumentsDocumentedRule()
+        assert rule.skip_reason(AuditData(prompts=None)) == SKIP_REASON_NOT_APPLICABLE
 
     def test_prompt_without_arguments_passes(self) -> None:
         """A prompt with no arguments has nothing to document."""

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -201,6 +201,15 @@ def test_template_rules_treat_unavailable_or_empty_partial_catalog_as_insufficie
     assert rule.skip_reason(empty_partial) == SKIP_REASON_INSUFFICIENT_DATA
 
 
+def test_declared_resources_with_unobserved_templates_are_insufficient(capabilities_full) -> None:
+    rule = ResourceTemplatesUriTemplatesValidRule()
+
+    assert (
+        rule.skip_reason(AuditData(resource_templates=None, capabilities=capabilities_full))
+        == SKIP_REASON_INSUFFICIENT_DATA
+    )
+
+
 def test_only_the_uniqueness_rule_skips_incomplete_catalogs() -> None:
     """Per-item rules judge partial evidence; only uniqueness needs the full catalog."""
     data = AuditData(

--- a/tests/test_resource_template_rules.py
+++ b/tests/test_resource_template_rules.py
@@ -11,7 +11,7 @@ from mcpscore.rules import (
     ResourceTemplatesUriTemplatesValidRule,
     RuleSeverity,
 )
-from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
 from mcpscore.rules.resource_templates import is_valid_uri_template
 
 
@@ -178,7 +178,7 @@ def test_titles_rule_reports_missing_and_blank_titles() -> None:
     assert result.details == {"templates_without_title": ["missing/{id}", "blank/{id}"]}
 
 
-def test_template_rules_pass_when_capability_has_no_templates() -> None:
+def test_template_rules_skip_when_capability_has_no_templates() -> None:
     for rule in (
         ResourceTemplatesUriTemplatesValidRule(),
         ResourceTemplatesUniqueRule(),
@@ -188,8 +188,17 @@ def test_template_rules_pass_when_capability_has_no_templates() -> None:
         ResourceTemplatesDescriptionPresentRule(),
         ResourceTemplatesTitlesPresentRule(),
     ):
-        assert rule.check(AuditData(resource_templates=[])).passed
-        assert rule.check(AuditData(resource_templates=None)).passed
+        assert rule.skip_reason(AuditData(resource_templates=[])) == SKIP_REASON_NOT_APPLICABLE
+        assert rule.skip_reason(AuditData(resource_templates=None)) == SKIP_REASON_NOT_APPLICABLE
+
+
+def test_template_rules_treat_unavailable_or_empty_partial_catalog_as_insufficient() -> None:
+    rule = ResourceTemplatesUriTemplatesValidRule()
+    unavailable = AuditData(resource_templates=None, listings_attempted=frozenset({"resource_templates"}))
+    empty_partial = AuditData(resource_templates=[], incomplete_listings=frozenset({"resource_templates"}))
+
+    assert rule.skip_reason(unavailable) == SKIP_REASON_INSUFFICIENT_DATA
+    assert rule.skip_reason(empty_partial) == SKIP_REASON_INSUFFICIENT_DATA
 
 
 def test_only_the_uniqueness_rule_skips_incomplete_catalogs() -> None:

--- a/tests/test_resources_rules.py
+++ b/tests/test_resources_rules.py
@@ -15,7 +15,7 @@ from mcpscore.rules import (
     ResourcesUrisValidRule,
     RuleSeverity,
 )
-from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
 
 
 def _resource(
@@ -236,11 +236,19 @@ class TestResourcesDescriptionPresentRule:
         assert rule.severity == RuleSeverity.MEDIUM
         assert rule.group_name == "resources"
 
-    def test_no_resources_is_not_applicable_and_passes(self) -> None:
+    def test_no_resources_is_not_applicable_and_skips(self) -> None:
         """Optional capability: a server with no resources is not penalized."""
         rule = ResourcesDescriptionPresentRule()
-        assert rule.check(AuditData(resources=None)).passed
-        assert rule.check(AuditData(resources=[])).passed
+        assert rule.skip_reason(AuditData(resources=None)) == SKIP_REASON_NOT_APPLICABLE
+        assert rule.skip_reason(AuditData(resources=[])) == SKIP_REASON_NOT_APPLICABLE
+
+    def test_unavailable_or_empty_partial_resources_are_insufficient_data(self) -> None:
+        rule = ResourcesDescriptionPresentRule()
+        unavailable = AuditData(resources=None, listings_attempted=frozenset({"resources"}))
+        empty_partial = AuditData(resources=[], incomplete_listings=frozenset({"resources"}))
+
+        assert rule.skip_reason(unavailable) == SKIP_REASON_INSUFFICIENT_DATA
+        assert rule.skip_reason(empty_partial) == SKIP_REASON_INSUFFICIENT_DATA
 
     def test_all_described_passes(self) -> None:
         rule = ResourcesDescriptionPresentRule()

--- a/tests/test_resources_rules.py
+++ b/tests/test_resources_rules.py
@@ -250,6 +250,13 @@ class TestResourcesDescriptionPresentRule:
         assert rule.skip_reason(unavailable) == SKIP_REASON_INSUFFICIENT_DATA
         assert rule.skip_reason(empty_partial) == SKIP_REASON_INSUFFICIENT_DATA
 
+    def test_declared_but_unobserved_resources_are_insufficient_data(self, capabilities_full) -> None:
+        rule = ResourcesDescriptionPresentRule()
+
+        assert (
+            rule.skip_reason(AuditData(resources=None, capabilities=capabilities_full)) == SKIP_REASON_INSUFFICIENT_DATA
+        )
+
     def test_all_described_passes(self) -> None:
         rule = ResourcesDescriptionPresentRule()
         result = rule.check(AuditData(resources=[_resource("a", "An A"), _resource("b", "A B")]))

--- a/tests/test_rule_applicability.py
+++ b/tests/test_rule_applicability.py
@@ -13,6 +13,7 @@ from mcpscore.rules import (
     TLSEnabledRule,
 )
 from mcpscore.rules.base import SKIP_REASON_NOT_APPLICABLE, SkippedRule
+from mcpscore.rules.registry import create_all_rules
 
 
 class VersionedRule(BaseRule):
@@ -161,3 +162,18 @@ class TestAuditorSkipsNonApplicableRules:
             "security_error_data_leak": SKIP_REASON_NOT_APPLICABLE,
             "transport_streamable_http": SKIP_REASON_NOT_APPLICABLE,
         }
+
+    def test_empty_catalog_quality_rules_are_skipped_and_score_zero_points(self):
+        auditor = MCPAuditor()
+        catalog_groups = {"tools", "prompts", "resources", "resource_templates"}
+        auditor.rules = [rule for rule in create_all_rules() if rule.group_name in catalog_groups]
+        auditor.audit_data = AuditData(tools=[], prompts=[], resources=[], resource_templates=[])
+
+        auditor._run_all_rules()
+
+        assert [result.rule_id for result in auditor.results] == ["tools_at_least_one"]
+        assert auditor.results[0].passed is False
+        assert auditor.score == 0
+        assert auditor.max_score == RuleSeverity.CRITICAL
+        assert len(auditor.skipped_rules) == len(auditor.rules) - 1
+        assert {rule.reason for rule in auditor.skipped_rules} == {SKIP_REASON_NOT_APPLICABLE}

--- a/tests/test_tools_rules.py
+++ b/tests/test_tools_rules.py
@@ -20,7 +20,7 @@ from mcp_types import Tool, ToolAnnotations, ToolExecution
 import pytest
 
 from mcpscore.rules import AuditData, RuleSeverity
-from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
 from mcpscore.rules.registry import create_all_rules
 from mcpscore.rules.tools import (
     ToolsAnnotationsPresentRule,
@@ -421,6 +421,17 @@ class TestToolsBaseRule:
         """No declaration is distinct from a declared catalog that failed to load."""
         data = AuditData(tools=None, capabilities=capabilities_missing)
         assert ToolsAtLeastOneRule().skip_reason(data) is None
+
+    def test_empty_complete_catalog_skips_every_quality_rule(self) -> None:
+        data = AuditData(tools=[])
+        quality_rules = [
+            rule
+            for rule in create_all_rules()
+            if isinstance(rule, ToolsBaseRule) and not isinstance(rule, ToolsAtLeastOneRule)
+        ]
+
+        assert quality_rules
+        assert {rule.skip_reason(data) for rule in quality_rules} == {SKIP_REASON_NOT_APPLICABLE}
 
 
 # ============================================================================
@@ -1199,11 +1210,10 @@ class TestToolsExecutionConsistentRule:
         assert result.details is not None
         assert result.details["task_tools"] == ["runner"]
 
-    def test_no_tools_at_all_passes(self):
-        """No tools capability declared → nothing to check → runs and passes."""
+    def test_no_tools_at_all_skips(self):
+        """No tools means task-execution consistency has no subject to judge."""
         rule = ToolsExecutionConsistentRule()
-        assert rule.skip_reason(AuditData()) is None
-        assert rule.check(AuditData()).passed is True
+        assert rule.skip_reason(AuditData()) == SKIP_REASON_NOT_APPLICABLE
 
     def test_skips_when_tools_unavailable_despite_capability(self, capabilities_full):
         """A failed tools/list (tools None, capability declared) skips rather than false-passing."""


### PR DESCRIPTION
A successful empty tools, prompts, resources, or resource-templates listing now makes per-item quality rules skip as not applicable and contribute 0/0. The dedicated `tools_at_least_one` rule still judges and fails a complete empty tools catalog; unavailable and empty partial listings remain insufficient data.