### PR TITLE
Resurrect security_error_data_leak, relax the malformed-JSON id check, sweep docstring nits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected two stale rule docstrings that quoted an old severity-point scale
   (`10 points (CRITICAL)` → 5, `5 points (MEDIUM)` → 2); the weights are
   `RuleSeverity` (CRITICAL 5 / HIGH 3 / MEDIUM 2 / LOW 1).
-- **Malformed-request scoring now has normative evidence.** The existing
-  `security_malformed_request_handling` rule is backed by a safe raw probe and
-  requires the JSON-RPC 2.0 Parse error response (`-32700` with a null **or
-  absent** `id` — the id is unknowable when the request never parsed, and a
-  registry calibration found conforming servers that omit it). HTTP status is
-  deliberately not constrained because JSON-RPC is transport agnostic. A
-  successful mandatory `server/discover` control prevents auth, endpoint, or
-  optional-capability failures from becoming false verdicts.
+- **Malformed-request scoring now has real evidence.** The existing
+  `security_malformed_request_handling` rule is backed by a safe raw probe.
+  It enforces the JSON-RPC 2.0 Parse error code (`-32700`) as the normative
+  requirement, and **deliberately relaxes** one strict-JSON-RPC point: the
+  response `id` may be null **or absent** (the id is unknowable when the
+  request never parsed, and a registry calibration found conforming servers
+  that omit it) — a calibrated interoperability allowance, not full Response
+  Object conformance. HTTP status is deliberately not constrained because
+  JSON-RPC is transport agnostic. A successful mandatory `server/discover`
+  control prevents auth, endpoint, or optional-capability failures from
+  becoming false verdicts. The probe streams and bounds the response body
+  (16 KB) so a hostile server cannot exhaust memory on the deliberately
+  malformed request.
 - **Report rule order now matches its documentation.** Rules sort by
   `(group_order, group_name, rule_order, rule_id)` — the tie-breaks the
   attribute docs always promised. Previously the sort key was a single
@@ -52,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and explicitly reserves result *positions* for change in any release) —
   but if you imported `sort_order` anyway, sort with
   `(rule.group_order, rule.group_name, rule.rule_order, rule.rule_id)`.
+- **`AuditData.error_response`.** A dead constructor field — nothing in the
+  repo's history ever produced it, and its last reader
+  (`security_error_data_leak`) now scans the malformed-request probe's body
+  instead. Removed rather than kept as a phantom (its presence is what
+  produced the never-observed-behavior confusion in the first place). The
+  Python class surface is outside the stability contract as above; migration:
+  drop the kwarg — any code that constructed `AuditData(error_response=...)`
+  was setting a value no rule ever read.
 
 ## [1.8.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`security_error_data_leak` now runs.** It read a field (`error_response`)
+  that no code path ever produced, so it silently skipped on every audit. It
+  now scans the response body the malformed-request probe elicits — the
+  request most likely to make a server dump a stack trace, file path, or
+  secret — for sensitive-data leaks, and skips as insufficient data only when
+  no body was captured (stdio is not applicable). A leaked value is **never
+  echoed back into the report** (only the leak type and a count), because the
+  report is shareable and echoing the secret would re-leak it. Servers that
+  do not leak gain the 2 points they previously never had a chance to earn —
+  e.g. DeepWiki 76/85 → 78/87.
+- Corrected two stale rule docstrings that quoted an old severity-point scale
+  (`10 points (CRITICAL)` → 5, `5 points (MEDIUM)` → 2); the weights are
+  `RuleSeverity` (CRITICAL 5 / HIGH 3 / MEDIUM 2 / LOW 1).
 - **Malformed-request scoring now has normative evidence.** The existing
   `security_malformed_request_handling` rule is backed by a safe raw probe and
-  requires the JSON-RPC 2.0 Parse error response (`-32700` with `id: null`).
-  HTTP status is deliberately not constrained because JSON-RPC is transport
-  agnostic. A successful mandatory `server/discover` control prevents auth,
-  endpoint, or optional-capability failures from becoming false verdicts.
+  requires the JSON-RPC 2.0 Parse error response (`-32700` with a null **or
+  absent** `id` — the id is unknowable when the request never parsed, and a
+  registry calibration found conforming servers that omit it). HTTP status is
+  deliberately not constrained because JSON-RPC is transport agnostic. A
+  successful mandatory `server/discover` control prevents auth, endpoint, or
+  optional-capability failures from becoming false verdicts.
 - **Report rule order now matches its documentation.** Rules sort by
   `(group_order, group_name, rule_order, rule_id)` — the tie-breaks the
   attribute docs always promised. Previously the sort key was a single

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -395,46 +395,66 @@ class _HttpTarget:
             payload=_parse_payload(response),
         )
 
-    async def post_raw(self, content: bytes, headers: dict[str, str]) -> tuple[_HttpProbeResponse, str, bool]:
+    async def post_raw(
+        self, content: bytes, headers: dict[str, str]
+    ) -> tuple[_HttpProbeResponse, str | None, str | None]:
         """POST an intentionally invalid raw body without following redirects.
 
         Only HTTP-specific negative probes use this path. Redirects stay off so
         caller-supplied credentials cannot leave the audited endpoint while
         mcpscore is sending malformed input.
 
-        The response is **streamed and bounded** to ``_RAW_BODY_SCAN_LIMIT``:
-        this probe deliberately provokes error handlers, exactly where a
-        hostile or broken server is most likely to return an unbounded body.
-        Each chunk is appended only up to the remaining capacity — a single
-        large (or decompressed) chunk cannot overshoot the cap — and reading
-        stops there.
+        Memory is bounded against a hostile server, including a compression
+        bomb. The request asks for ``Accept-Encoding: identity`` and the body
+        is read **only when the response carries no content-encoding** — so
+        ``aiter_bytes`` has nothing to decode and cannot inflate a chunk. Each
+        chunk is appended only up to the remaining ``_RAW_BODY_SCAN_LIMIT``
+        capacity, so a single large chunk cannot overshoot the cap. If the
+        server compresses anyway (ignoring the identity request), the body is
+        never fed to the decoder — that is where the bomb would inflate — and
+        is reported unobservable.
 
-        Returns ``(response, bounded_text, truncated)``. The bounded text is
-        the leak surface for ``security_error_data_leak`` (a mishandled parse
-        error dumps a stack trace or file path into a non-JSON body). The
-        ``truncated`` flag tells the caller the parsed payload came from a
-        prefix, so an unparsable prefix must not be read as a protocol
-        verdict — the full body might have been valid JSON we cut.
+        Returns ``(response, body_text, unobservable_reason)``. ``body_text``
+        is the bounded leak surface for ``security_error_data_leak`` (a
+        mishandled parse dumps a stack trace or path into a non-JSON body);
+        it is ``None`` when the reason is ``"encoded"``. ``unobservable_reason``
+        is ``None`` (fully read), ``"truncated"`` (body exceeded the cap — an
+        unparsable prefix is not a protocol verdict), or ``"encoded"`` (server
+        content-encoded despite the identity request; not decoded).
         """
+        probe_headers = {**headers, "Accept-Encoding": "identity"}
         async with self.client.stream(
             "POST",
             self.url,
             content=content,
-            headers=headers,
+            headers=probe_headers,
             timeout=PROBE_TIMEOUT_S,
             follow_redirects=False,
         ) as response:
-            body = bytearray()
-            truncated = False
-            async for chunk in response.aiter_bytes():
-                space = _RAW_BODY_SCAN_LIMIT - len(body)
-                if len(chunk) > space:
-                    body.extend(chunk[:space])
-                    truncated = True
-                    break
-                body.extend(chunk)
             status_code = response.status_code
             response_headers = dict(response.headers)
+            encoding = response.headers.get("content-encoding", "").strip().lower()
+            encoded = encoding not in ("", "identity")
+            body = bytearray()
+            truncated = False
+            if not encoded:
+                # No content-encoding, so aiter_bytes yields identity bytes and
+                # performs no decompression — bounding the chunks bounds peak
+                # memory. An encoded body is deliberately never iterated (the
+                # `async with` closes it without decoding).
+                async for chunk in response.aiter_bytes():
+                    space = _RAW_BODY_SCAN_LIMIT - len(body)
+                    if len(chunk) > space:
+                        body.extend(chunk[:space])
+                        truncated = True
+                        break
+                    body.extend(chunk)
+        if encoded:
+            return (
+                _HttpProbeResponse(status_code=status_code, headers=response_headers, payload=None),
+                None,
+                "encoded",
+            )
         text = bytes(body).decode("utf-8", errors="replace")
         return (
             _HttpProbeResponse(
@@ -443,7 +463,7 @@ class _HttpTarget:
                 payload=_parse_payload_text(text, response_headers.get("content-type", "")),
             ),
             text,
-            truncated,
+            "truncated" if truncated else None,
         )
 
 
@@ -1001,7 +1021,10 @@ async def _probe_unknown_method(target: _ProbeTarget) -> ProbeResult:
 
 
 def _malformed_json_result(
-    response: _HttpProbeResponse, control: _HttpProbeResponse, raw_body: str, truncated: bool
+    response: _HttpProbeResponse,
+    control: _HttpProbeResponse,
+    raw_body: str | None,
+    unobservable_reason: str | None,
 ) -> ProbeResult:
     """Judge JSON-RPC's normative malformed-JSON response, status-agnostically.
 
@@ -1010,11 +1033,12 @@ def _malformed_json_result(
     ``security_error_data_leak`` to scan — the malformed request is the probe
     most likely to make a server dump a stack trace or a file path.
 
-    ``truncated`` means the body exceeded the scan cap, so the parsed payload
-    came from a prefix. An unparsable *prefix* is not a protocol verdict — a
-    valid but oversized ``-32700`` response would parse to ``None`` only
-    because it was cut — so a truncated-and-unparsable response is
-    unobservable, not UNSUPPORTED.
+    ``unobservable_reason`` (from ``post_raw``) means the parse verdict cannot
+    be trusted: ``"truncated"`` (payload came from a bounded prefix — a valid
+    oversized ``-32700`` would parse to ``None`` only because it was cut) or
+    ``"encoded"`` (the body was content-encoded and not decoded, to bound
+    memory against a compression bomb). Either way an unparsable/absent
+    payload is unobservable, not UNSUPPORTED.
     """
     details = _base_details(response)
     details["control_http_status"] = control.status_code
@@ -1062,13 +1086,18 @@ def _malformed_json_result(
         and "result" not in payload
     )
     details["response_id_absent_or_null"] = id_absent_or_null
-    if not correct and truncated and not isinstance(payload, dict):
-        # The prefix did not parse and the body was cut at the cap — the
-        # untruncated response might have been a valid -32700. Cannot fail the
-        # server for a verdict we could not observe. (Any real -32700 envelope
-        # parses well within the cap, so this only fires on pathological
-        # bodies; the leak scan still sees the bounded prefix.)
-        details["reason"] = "response body exceeded scan cap; parse verdict not observable"
+    if not correct and unobservable_reason is not None and not isinstance(payload, dict):
+        # The payload is absent/unparsable and the read was bounded — a
+        # truncated prefix (the untruncated body might have been a valid
+        # -32700) or an undecoded content-encoded body. Cannot fail the server
+        # for a verdict we could not observe. (A real -32700 envelope parses
+        # well within the cap, so this only fires on pathological bodies; for
+        # a truncated body the leak scan still sees the bounded prefix.)
+        details["reason"] = (
+            "response was content-encoded; not decoded to bound memory, parse verdict not observable"
+            if unobservable_reason == "encoded"
+            else "response body exceeded scan cap; parse verdict not observable"
+        )
         return ProbeResult(PROBE_MALFORMED_JSON, ProbeOutcome.NOT_APPLICABLE, details, payload=leak_payload)
     outcome = ProbeOutcome.SUPPORTED if correct else ProbeOutcome.UNSUPPORTED
     return ProbeResult(PROBE_MALFORMED_JSON, outcome, details, payload=leak_payload)
@@ -1083,11 +1112,11 @@ async def _probe_malformed_json(target: _HttpTarget) -> ProbeResult:
         headers,
         follow_redirects=False,
     )
-    response, raw_body, truncated = await target.post_raw(
+    response, raw_body, unobservable_reason = await target.post_raw(
         b'{"jsonrpc":"2.0","id":13,"method":"server/discover",',
         headers,
     )
-    return _malformed_json_result(response, control, raw_body, truncated)
+    return _malformed_json_result(response, control, raw_body, unobservable_reason)
 
 
 _TRANSPORT_AGNOSTIC_PROBES: dict[str, Callable[[_ProbeTarget], Awaitable[ProbeResult]]] = {

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -323,20 +323,24 @@ def _request_headers(protocol_version: str, method: str, name: str | None = None
     return headers
 
 
-def _parse_payload(response: httpx2.Response) -> dict[str, Any] | None:
-    """Extract the JSON-RPC message from a JSON or SSE response body."""
-    content_type = response.headers.get("content-type", "")
+def _parse_payload_text(text: str, content_type: str) -> dict[str, Any] | None:
+    """Extract the JSON-RPC message from a JSON or SSE response body text."""
     try:
         if "text/event-stream" in content_type:
-            for line in response.text.splitlines():
+            for line in text.splitlines():
                 if line.startswith("data:"):
                     parsed = json.loads(line[len("data:") :].strip())
                     return parsed if isinstance(parsed, dict) else None
             return None
-        parsed = response.json()
+        parsed = json.loads(text)
     except (json.JSONDecodeError, ValueError):
         return None
     return parsed if isinstance(parsed, dict) else None
+
+
+def _parse_payload(response: httpx2.Response) -> dict[str, Any] | None:
+    """Extract the JSON-RPC message from a JSON or SSE response body."""
+    return _parse_payload_text(response.text, response.headers.get("content-type", ""))
 
 
 class _ProbeTarget(Protocol):
@@ -398,26 +402,38 @@ class _HttpTarget:
         caller-supplied credentials cannot leave the audited endpoint while
         mcpscore is sending malformed input.
 
-        Returns the parsed response and its raw body text (bounded) — the raw
-        text is the leak surface for ``security_error_data_leak``: a mishandled
-        parse error is where a server dumps a stack trace or a file path, and
-        that appears in a non-JSON body the parsed payload cannot carry.
+        The response is **streamed and bounded** to ``_RAW_BODY_SCAN_LIMIT``:
+        this probe deliberately provokes error handlers, exactly where a
+        hostile or broken server is most likely to return an unbounded body,
+        so reading is stopped at the cap rather than buffering the whole thing.
+        Returns the parsed response and its bounded raw body text — the raw
+        text is the leak surface for ``security_error_data_leak`` (a mishandled
+        parse error dumps a stack trace or file path into a non-JSON body the
+        parsed payload cannot carry).
         """
-        request = self.client.build_request(
+        async with self.client.stream(
             "POST",
             self.url,
             content=content,
             headers=headers,
             timeout=PROBE_TIMEOUT_S,
-        )
-        response = await self.client.send(request, follow_redirects=False)
+            follow_redirects=False,
+        ) as response:
+            body = bytearray()
+            async for chunk in response.aiter_bytes():
+                body.extend(chunk)
+                if len(body) >= _RAW_BODY_SCAN_LIMIT:
+                    break
+            status_code = response.status_code
+            response_headers = dict(response.headers)
+        text = bytes(body[:_RAW_BODY_SCAN_LIMIT]).decode("utf-8", errors="replace")
         return (
             _HttpProbeResponse(
-                status_code=response.status_code,
-                headers=dict(response.headers),
-                payload=_parse_payload(response),
+                status_code=status_code,
+                headers=response_headers,
+                payload=_parse_payload_text(text, response_headers.get("content-type", "")),
             ),
-            response.text[:_RAW_BODY_SCAN_LIMIT],
+            text,
         )
 
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -395,7 +395,7 @@ class _HttpTarget:
             payload=_parse_payload(response),
         )
 
-    async def post_raw(self, content: bytes, headers: dict[str, str]) -> tuple[_HttpProbeResponse, str]:
+    async def post_raw(self, content: bytes, headers: dict[str, str]) -> tuple[_HttpProbeResponse, str, bool]:
         """POST an intentionally invalid raw body without following redirects.
 
         Only HTTP-specific negative probes use this path. Redirects stay off so
@@ -404,12 +404,17 @@ class _HttpTarget:
 
         The response is **streamed and bounded** to ``_RAW_BODY_SCAN_LIMIT``:
         this probe deliberately provokes error handlers, exactly where a
-        hostile or broken server is most likely to return an unbounded body,
-        so reading is stopped at the cap rather than buffering the whole thing.
-        Returns the parsed response and its bounded raw body text — the raw
-        text is the leak surface for ``security_error_data_leak`` (a mishandled
-        parse error dumps a stack trace or file path into a non-JSON body the
-        parsed payload cannot carry).
+        hostile or broken server is most likely to return an unbounded body.
+        Each chunk is appended only up to the remaining capacity — a single
+        large (or decompressed) chunk cannot overshoot the cap — and reading
+        stops there.
+
+        Returns ``(response, bounded_text, truncated)``. The bounded text is
+        the leak surface for ``security_error_data_leak`` (a mishandled parse
+        error dumps a stack trace or file path into a non-JSON body). The
+        ``truncated`` flag tells the caller the parsed payload came from a
+        prefix, so an unparsable prefix must not be read as a protocol
+        verdict — the full body might have been valid JSON we cut.
         """
         async with self.client.stream(
             "POST",
@@ -420,13 +425,17 @@ class _HttpTarget:
             follow_redirects=False,
         ) as response:
             body = bytearray()
+            truncated = False
             async for chunk in response.aiter_bytes():
-                body.extend(chunk)
-                if len(body) >= _RAW_BODY_SCAN_LIMIT:
+                space = _RAW_BODY_SCAN_LIMIT - len(body)
+                if len(chunk) > space:
+                    body.extend(chunk[:space])
+                    truncated = True
                     break
+                body.extend(chunk)
             status_code = response.status_code
             response_headers = dict(response.headers)
-        text = bytes(body[:_RAW_BODY_SCAN_LIMIT]).decode("utf-8", errors="replace")
+        text = bytes(body).decode("utf-8", errors="replace")
         return (
             _HttpProbeResponse(
                 status_code=status_code,
@@ -434,6 +443,7 @@ class _HttpTarget:
                 payload=_parse_payload_text(text, response_headers.get("content-type", "")),
             ),
             text,
+            truncated,
         )
 
 
@@ -990,13 +1000,21 @@ async def _probe_unknown_method(target: _ProbeTarget) -> ProbeResult:
     return ProbeResult(PROBE_UNKNOWN_METHOD, outcome, details)
 
 
-def _malformed_json_result(response: _HttpProbeResponse, control: _HttpProbeResponse, raw_body: str) -> ProbeResult:
+def _malformed_json_result(
+    response: _HttpProbeResponse, control: _HttpProbeResponse, raw_body: str, truncated: bool
+) -> ProbeResult:
     """Judge JSON-RPC's normative malformed-JSON response, status-agnostically.
 
     The raw response body is carried on the ProbeResult ``payload`` (excluded
     from ``to_dict``, so it never reaches a report) for
     ``security_error_data_leak`` to scan — the malformed request is the probe
     most likely to make a server dump a stack trace or a file path.
+
+    ``truncated`` means the body exceeded the scan cap, so the parsed payload
+    came from a prefix. An unparsable *prefix* is not a protocol verdict — a
+    valid but oversized ``-32700`` response would parse to ``None`` only
+    because it was cut — so a truncated-and-unparsable response is
+    unobservable, not UNSUPPORTED.
     """
     details = _base_details(response)
     details["control_http_status"] = control.status_code
@@ -1044,6 +1062,14 @@ def _malformed_json_result(response: _HttpProbeResponse, control: _HttpProbeResp
         and "result" not in payload
     )
     details["response_id_absent_or_null"] = id_absent_or_null
+    if not correct and truncated and not isinstance(payload, dict):
+        # The prefix did not parse and the body was cut at the cap — the
+        # untruncated response might have been a valid -32700. Cannot fail the
+        # server for a verdict we could not observe. (Any real -32700 envelope
+        # parses well within the cap, so this only fires on pathological
+        # bodies; the leak scan still sees the bounded prefix.)
+        details["reason"] = "response body exceeded scan cap; parse verdict not observable"
+        return ProbeResult(PROBE_MALFORMED_JSON, ProbeOutcome.NOT_APPLICABLE, details, payload=leak_payload)
     outcome = ProbeOutcome.SUPPORTED if correct else ProbeOutcome.UNSUPPORTED
     return ProbeResult(PROBE_MALFORMED_JSON, outcome, details, payload=leak_payload)
 
@@ -1057,11 +1083,11 @@ async def _probe_malformed_json(target: _HttpTarget) -> ProbeResult:
         headers,
         follow_redirects=False,
     )
-    response, raw_body = await target.post_raw(
+    response, raw_body, truncated = await target.post_raw(
         b'{"jsonrpc":"2.0","id":13,"method":"server/discover",',
         headers,
     )
-    return _malformed_json_result(response, control, raw_body)
+    return _malformed_json_result(response, control, raw_body, truncated)
 
 
 _TRANSPORT_AGNOSTIC_PROBES: dict[str, Callable[[_ProbeTarget], Awaitable[ProbeResult]]] = {

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -72,6 +72,11 @@ __all__ = [
 PROBE_TIMEOUT_S = 10.0
 """Per-request timeout for a single probe."""
 
+_RAW_BODY_SCAN_LIMIT = 16_384
+"""Cap on the malformed-request response body scanned for data leaks. A server
+dumping a stack trace can return an unbounded body; 16 KB is far more than any
+real leak-bearing error page needs while bounding memory and scan time."""
+
 META_PREFIX = "io.modelcontextprotocol/"
 """Prefix of the reserved ``_meta`` keys carrying per-request context (2026-07-28)."""
 
@@ -163,8 +168,8 @@ Not "probes that happen to use HTTP" — every probe does that over an HTTP
 target. These ask questions that only exist in HTTP: the ``Mcp-Method`` header
 contradicting the body (SEP-2243), the unauthenticated status and
 ``WWW-Authenticate`` challenge, the removed ``Mcp-Session-Id`` header, the
-RFC 9728/8414 well-known documents, and ``Origin`` validation against DNS
-rebinding, plus raw malformed HTTP request bodies. Over stdio they record
+RFC 9728/8414 well-known documents, ``Origin`` validation against DNS
+rebinding, and raw malformed HTTP request bodies. Over stdio they record
 ``NOT_APPLICABLE``, which is the honest answer: this probe path cannot send
 malformed wire input through the SDK transport.
 """
@@ -386,12 +391,17 @@ class _HttpTarget:
             payload=_parse_payload(response),
         )
 
-    async def post_raw(self, content: bytes, headers: dict[str, str]) -> _HttpProbeResponse:
+    async def post_raw(self, content: bytes, headers: dict[str, str]) -> tuple[_HttpProbeResponse, str]:
         """POST an intentionally invalid raw body without following redirects.
 
         Only HTTP-specific negative probes use this path. Redirects stay off so
         caller-supplied credentials cannot leave the audited endpoint while
         mcpscore is sending malformed input.
+
+        Returns the parsed response and its raw body text (bounded) — the raw
+        text is the leak surface for ``security_error_data_leak``: a mishandled
+        parse error is where a server dumps a stack trace or a file path, and
+        that appears in a non-JSON body the parsed payload cannot carry.
         """
         request = self.client.build_request(
             "POST",
@@ -401,10 +411,13 @@ class _HttpTarget:
             timeout=PROBE_TIMEOUT_S,
         )
         response = await self.client.send(request, follow_redirects=False)
-        return _HttpProbeResponse(
-            status_code=response.status_code,
-            headers=dict(response.headers),
-            payload=_parse_payload(response),
+        return (
+            _HttpProbeResponse(
+                status_code=response.status_code,
+                headers=dict(response.headers),
+                payload=_parse_payload(response),
+            ),
+            response.text[:_RAW_BODY_SCAN_LIMIT],
         )
 
 
@@ -961,10 +974,17 @@ async def _probe_unknown_method(target: _ProbeTarget) -> ProbeResult:
     return ProbeResult(PROBE_UNKNOWN_METHOD, outcome, details)
 
 
-def _malformed_json_result(response: _HttpProbeResponse, control: _HttpProbeResponse) -> ProbeResult:
-    """Judge JSON-RPC's normative malformed-JSON response, status-agnostically."""
+def _malformed_json_result(response: _HttpProbeResponse, control: _HttpProbeResponse, raw_body: str) -> ProbeResult:
+    """Judge JSON-RPC's normative malformed-JSON response, status-agnostically.
+
+    The raw response body is carried on the ProbeResult ``payload`` (excluded
+    from ``to_dict``, so it never reaches a report) for
+    ``security_error_data_leak`` to scan — the malformed request is the probe
+    most likely to make a server dump a stack trace or a file path.
+    """
     details = _base_details(response)
     details["control_http_status"] = control.status_code
+    leak_payload = {"error_body": raw_body}
 
     # The control proves that this endpoint parses valid JSON-RPC rather than
     # returning one canned parse-error response for every POST. Modern servers
@@ -985,27 +1005,35 @@ def _malformed_json_result(response: _HttpProbeResponse, control: _HttpProbeResp
             if control.status_code in AUTH_GATED_STATUSES
             else "control did not return a correlated JSON-RPC response; payload parsing not observable"
         )
-        return ProbeResult(PROBE_MALFORMED_JSON, ProbeOutcome.NOT_APPLICABLE, details)
+        # Still carry the body: a server can leak data in an error response
+        # whether or not its parse-error verdict is judgeable.
+        return ProbeResult(PROBE_MALFORMED_JSON, ProbeOutcome.NOT_APPLICABLE, details, payload=leak_payload)
 
     payload = response.payload
     error = response.error
+    # A missing `id` counts the same as an explicit `null`: on a parse error
+    # the id is genuinely unknowable (the request never parsed), and no client
+    # correlates a parse error by id anyway, so `null` vs absent carries no
+    # observable difference. `payload.get("id")` is None for both, and a real
+    # value (e.g. 0) is excluded. Calibrated against the registry 2026-08-22:
+    # 7/250 healthy servers returned a correct -32700 with the id omitted.
+    id_absent_or_null = isinstance(payload, dict) and payload.get("id") is None
     correct = (
         isinstance(payload, dict)
         and payload.get("jsonrpc") == "2.0"
-        and "id" in payload
-        and payload["id"] is None
+        and id_absent_or_null
         and response.error_code == -32700
         and error is not None
         and isinstance(error.get("message"), str)
         and "result" not in payload
     )
-    details["response_id_is_null"] = isinstance(payload, dict) and "id" in payload and payload["id"] is None
+    details["response_id_absent_or_null"] = id_absent_or_null
     outcome = ProbeOutcome.SUPPORTED if correct else ProbeOutcome.UNSUPPORTED
-    return ProbeResult(PROBE_MALFORMED_JSON, outcome, details)
+    return ProbeResult(PROBE_MALFORMED_JSON, outcome, details, payload=leak_payload)
 
 
 async def _probe_malformed_json(target: _HttpTarget) -> ProbeResult:
-    """Send truncated JSON and require JSON-RPC Parse error with a null ID."""
+    """Send truncated JSON and require JSON-RPC Parse error with a null or absent ID."""
     target_version = _target_version()
     headers = _request_headers(target_version, "server/discover")
     control = await target.post(
@@ -1013,11 +1041,11 @@ async def _probe_malformed_json(target: _HttpTarget) -> ProbeResult:
         headers,
         follow_redirects=False,
     )
-    response = await target.post_raw(
+    response, raw_body = await target.post_raw(
         b'{"jsonrpc":"2.0","id":13,"method":"server/discover",',
         headers,
     )
-    return _malformed_json_result(response, control)
+    return _malformed_json_result(response, control, raw_body)
 
 
 _TRANSPORT_AGNOSTIC_PROBES: dict[str, Callable[[_ProbeTarget], Awaitable[ProbeResult]]] = {

--- a/mcpscore/rules/base.py
+++ b/mcpscore/rules/base.py
@@ -128,7 +128,6 @@ class AuditData:
     tls_version: str | None = None
     connection_time_ms: int | None = None
     server_headers: dict[str, str] | None = None
-    error_response: str | None = None
 
     # Sessionless probe observations (see mcpscore.probes), keyed by probe_id.
     # None until the auditor's probe-collection phase has run.

--- a/mcpscore/rules/security.py
+++ b/mcpscore/rules/security.py
@@ -225,19 +225,86 @@ class ErrorDataLeakRule(BaseRule):
         body = payload.get("error_body") if isinstance(payload, dict) else None
         return body if isinstance(body, str) else None
 
-    # Patterns that indicate sensitive data leakage
-    SENSITIVE_PATTERNS: ClassVar[list[tuple[str, str]]] = [
+    # Structural leaks — the pattern's presence IS the leak (a path or a stack
+    # trace in an error body is a defect regardless of any value).
+    STRUCTURAL_PATTERNS: ClassVar[list[tuple[str, str]]] = [
         (r"/home/\w+", "file path"),
         (r"/usr/\w+", "file path"),
         (r"C:\\Users\\", "file path"),
         (r"Traceback \(most recent call last\)", "stack trace"),
         (r"at \w+\.\w+ \([^)]+:\d+:\d+\)", "stack trace"),  # JavaScript stack trace
-        (r'password["\']?\s*[:=]\s*["\']?[\w!@#$%^&*]+', "password"),
-        (r'secret["\']?\s*[:=]\s*["\']?[\w!@#$%^&*]+', "secret"),
-        (r'api[_-]?key["\']?\s*[:=]\s*["\']?[\w-]+', "API key"),
-        (r'token["\']?\s*[:=]\s*["\']?[\w-]+', "token"),
-        (r"Bearer\s+[\w-]+", "auth token"),
     ]
+
+    # Credential leaks — a match is a leak only if the *captured value* (group
+    # 1) looks like a real secret. This rule now scans live auth-gated error
+    # bodies, which routinely say "Bearer token required" or
+    # "password=redacted"; matching the keyword alone would fail well-behaved
+    # servers that leak nothing. See _is_probable_secret.
+    CREDENTIAL_PATTERNS: ClassVar[list[tuple[str, str]]] = [
+        (r'password["\']?\s*[:=]\s*["\']?([\w!@#$%^&*.\-]+)', "password"),
+        (r'secret["\']?\s*[:=]\s*["\']?([\w!@#$%^&*.\-]+)', "secret"),
+        (r'api[_-]?key["\']?\s*[:=]\s*["\']?([\w.\-]+)', "API key"),
+        (r'token["\']?\s*[:=]\s*["\']?([\w.\-]+)', "token"),
+        (r"Bearer\s+([\w.\-]+)", "auth token"),
+    ]
+
+    # Values that are descriptions of a secret, not a secret. A credential
+    # match whose value contains one of these (or is too short / too
+    # low-entropy) is a placeholder, not a leak.
+    _PLACEHOLDER_WORDS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "required",
+            "redacted",
+            "missing",
+            "none",
+            "null",
+            "empty",
+            "example",
+            "placeholder",
+            "changeme",
+            "here",
+            "your",
+            "token",
+            "key",
+            "secret",
+            "value",
+            "string",
+            "password",
+            "hidden",
+            "provided",
+            "expected",
+            "invalid",
+            "unauthorized",
+            "masked",
+            "omitted",
+            "removed",
+            "xxx",
+        }
+    )
+
+    @classmethod
+    def _is_probable_secret(cls, value: str) -> bool:
+        """Whether a captured credential value looks like a real leaked secret.
+
+        Rejects placeholders ("required", "redacted", ...), short values, and
+        low-entropy words — the shapes a well-behaved auth-gated body produces.
+        A real key/token is long and mixes character classes.
+        """
+        stripped = value.strip().strip("'\"`<>*[]{}()")
+        if len(stripped) < 8:
+            return False
+        low = stripped.lower()
+        if any(word in low for word in cls._PLACEHOLDER_WORDS):
+            return False
+        classes = sum(
+            (
+                any(c.islower() for c in stripped),
+                any(c.isupper() for c in stripped),
+                any(c.isdigit() for c in stripped),
+                any(not c.isalnum() for c in stripped),
+            )
+        )
+        return classes >= 2 or len(stripped) >= 20
 
     @property
     def rule_name(self) -> str:
@@ -258,10 +325,16 @@ class ErrorDataLeakRule(BaseRule):
         # echoing the server's leaked secret back into our own output would
         # re-leak it. The count lets the server owner gauge severity.
         leaks_found = []
-        for pattern, leak_type in self.SENSITIVE_PATTERNS:
+        for pattern, leak_type in self.STRUCTURAL_PATTERNS:
             matches = re.findall(pattern, error_response, re.IGNORECASE)
             if matches:
                 leaks_found.append({"type": leak_type, "count": len(matches)})
+        for pattern, leak_type in self.CREDENTIAL_PATTERNS:
+            # A credential keyword is a leak only if its value is a real secret,
+            # not a placeholder ("Bearer token required", "password=redacted").
+            real = [m for m in re.findall(pattern, error_response, re.IGNORECASE) if self._is_probable_secret(m)]
+            if real:
+                leaks_found.append({"type": leak_type, "count": len(real)})
 
         if leaks_found:
             leak_types = ", ".join(dict.fromkeys(leak["type"] for leak in leaks_found))

--- a/mcpscore/rules/security.py
+++ b/mcpscore/rules/security.py
@@ -235,17 +235,25 @@ class ErrorDataLeakRule(BaseRule):
         (r"at \w+\.\w+ \([^)]+:\d+:\d+\)", "stack trace"),  # JavaScript stack trace
     ]
 
+    # The realistic alphabet of a leaked credential value. Covers RFC 6750
+    # b64token (base64 / base64url with optional `=` padding — `A-Za-z0-9`
+    # `-._~+/`) so an opaque bearer like `Ab1+/cDefGh==` is captured whole and
+    # not truncated to `Ab1` and dropped as "too short". `\w` supplies the
+    # alphanumerics and `_`.
+    _CRED_VALUE_RE: ClassVar[str] = r"[\w.~+/-]+=*"
+    _WIDE_CRED_VALUE_RE: ClassVar[str] = r"[\w!@#$%^&*.~+/-]+=*"  # passwords add shell/symbol chars
+
     # Credential leaks — a match is a leak only if the *captured value* (group
     # 1) looks like a real secret. This rule now scans live auth-gated error
     # bodies, which routinely say "Bearer token required" or
     # "password=redacted"; matching the keyword alone would fail well-behaved
     # servers that leak nothing. See _is_probable_secret.
     CREDENTIAL_PATTERNS: ClassVar[list[tuple[str, str]]] = [
-        (r'password["\']?\s*[:=]\s*["\']?([\w!@#$%^&*.\-]+)', "password"),
-        (r'secret["\']?\s*[:=]\s*["\']?([\w!@#$%^&*.\-]+)', "secret"),
-        (r'api[_-]?key["\']?\s*[:=]\s*["\']?([\w.\-]+)', "API key"),
-        (r'token["\']?\s*[:=]\s*["\']?([\w.\-]+)', "token"),
-        (r"Bearer\s+([\w.\-]+)", "auth token"),
+        (rf'password["\']?\s*[:=]\s*["\']?({_WIDE_CRED_VALUE_RE})', "password"),
+        (rf'secret["\']?\s*[:=]\s*["\']?({_WIDE_CRED_VALUE_RE})', "secret"),
+        (rf'api[_-]?key["\']?\s*[:=]\s*["\']?({_CRED_VALUE_RE})', "API key"),
+        (rf'token["\']?\s*[:=]\s*["\']?({_CRED_VALUE_RE})', "token"),
+        (rf"Bearer\s+({_CRED_VALUE_RE})", "auth token"),
     ]
 
     # Values that are descriptions of a secret, not a secret. A credential

--- a/mcpscore/rules/security.py
+++ b/mcpscore/rules/security.py
@@ -22,7 +22,7 @@ class TLSEnabledRule(BaseRule):
     This is a critical security check ensuring that the connection is encrypted
     and the TLS certificate is properly verified.
 
-    Scoring: 10 points (CRITICAL)
+    Scoring: 5 points (CRITICAL)
     """
 
     rule_id = "security_tls_enabled"
@@ -113,8 +113,12 @@ class MalformedRequestHandlingRule(BaseRule):
     """Check the normative JSON-RPC response to malformed JSON.
 
     JSON-RPC 2.0 requires Parse error (``-32700``) and a null response ID when
-    the request cannot be parsed. Its transport-agnostic specification does
-    not prescribe an HTTP status, so this rule deliberately does not either.
+    the request cannot be parsed. A *missing* id is accepted as equivalent to
+    null: the id is unknowable when the request never parsed, and no client
+    correlates a parse error by id (calibrated against the registry
+    2026-08-22 — several conforming servers omit it). The transport-agnostic
+    specification does not prescribe an HTTP status, so this rule does not
+    either.
 
     Scoring: 2 points (MEDIUM)
     """
@@ -156,15 +160,15 @@ class MalformedRequestHandlingRule(BaseRule):
             severity=self.severity,
             passed=passed,
             message=(
-                "✅ Malformed JSON returns JSON-RPC -32700 (Parse error) with a null ID"
+                "✅ Malformed JSON returns JSON-RPC -32700 (Parse error) with a null or absent ID"
                 if passed
-                else "❌ Malformed JSON does not return JSON-RPC -32700 (Parse error) with a null ID"
+                else "❌ Malformed JSON does not return JSON-RPC -32700 (Parse error) with a null or absent ID"
             ),
             details={
                 "spec": "https://www.jsonrpc.org/specification#response_object",
                 "http_status": probe.details.get("http_status"),
                 "error_code": probe.details.get("error_code"),
-                "response_id_is_null": probe.details.get("response_id_is_null"),
+                "response_id_absent_or_null": probe.details.get("response_id_absent_or_null"),
                 "control_http_status": probe.details.get("control_http_status"),
             },
         )
@@ -180,7 +184,7 @@ class ErrorDataLeakRule(BaseRule):
     - Credentials
     - API keys or tokens
 
-    Scoring: 5 points (MEDIUM)
+    Scoring: 2 points (MEDIUM)
     """
 
     rule_id = "security_error_data_leak"
@@ -190,16 +194,29 @@ class ErrorDataLeakRule(BaseRule):
     rule_order = 3
 
     def skip_reason(self, audit_data: AuditData) -> str | None:
-        """Skip when there is no remote error response whose contents can be judged.
+        """Skip unless the malformed-request probe captured a response body.
 
-        Unlike malformed-request behavior, content leakage can be judged from
-        an observed response even when the exact remote transport is unknown.
+        Leakage is judged from the body the malformed-JSON probe elicited —
+        the request most likely to make a server dump a stack trace or a file
+        path. What matters is only whether a body was captured, not the
+        probe's own parse-error verdict: an auth-gated server (probe
+        not-applicable) still returns a 401 body worth scanning. The probe is
+        HTTP-only, so stdio is the sole not-applicable case; no captured body
+        is insufficient data.
         """
         if audit_data.transport_type == MCPTransportType.STDIO:
             return SKIP_REASON_NOT_APPLICABLE
-        if audit_data.error_response is None:
+        probe = (audit_data.probes or {}).get(PROBE_MALFORMED_JSON)
+        if probe is None or self._probe_body(probe) is None:
             return SKIP_REASON_INSUFFICIENT_DATA
         return None
+
+    @staticmethod
+    def _probe_body(probe: object) -> str | None:
+        """Return the raw error body the probe carries on its payload, if any."""
+        payload = getattr(probe, "payload", None)
+        body = payload.get("error_body") if isinstance(payload, dict) else None
+        return body if isinstance(body, str) else None
 
     # Patterns that indicate sensitive data leakage
     SENSITIVE_PATTERNS: ClassVar[list[tuple[str, str]]] = [
@@ -223,33 +240,24 @@ class ErrorDataLeakRule(BaseRule):
     def severity(self) -> RuleSeverity:
         return RuleSeverity.MEDIUM
 
-    @requires_fields("error_response")
-    def check(self, error_response: str | None) -> RuleResult:  # type: ignore[override]
-        """Check if error responses leak sensitive data.
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """Scan the malformed-request response body for sensitive-data leaks."""
+        probe = (audit_data.probes or {})[PROBE_MALFORMED_JSON]
+        error_response = self._probe_body(probe)
+        assert error_response is not None  # noqa: S101 — skip_reason guarantees a captured body
 
-        Args:
-            error_response: Error response from server
-
-        Returns:
-            RuleResult indicating pass/fail
-
-        """
-        assert error_response is not None  # noqa: S101 — skip_reason guarantees a response to inspect
-
-        # Check for sensitive data patterns
+        # Record only the leak TYPE and a count — never the matched value.
+        # This report is shareable (the /s share page renders results), so
+        # echoing the server's leaked secret back into our own output would
+        # re-leak it. The count lets the server owner gauge severity.
         leaks_found = []
         for pattern, leak_type in self.SENSITIVE_PATTERNS:
             matches = re.findall(pattern, error_response, re.IGNORECASE)
             if matches:
-                leaks_found.append(
-                    {
-                        "type": leak_type,
-                        "matches": matches[:3],  # Limit to first 3 matches
-                    }
-                )
+                leaks_found.append({"type": leak_type, "count": len(matches)})
 
         if leaks_found:
-            leak_types = ", ".join({leak["type"] for leak in leaks_found})
+            leak_types = ", ".join(dict.fromkeys(leak["type"] for leak in leaks_found))
             return RuleResult(
                 rule_name=self.rule_name,
                 severity=self.severity,

--- a/mcpscore/rules/security.py
+++ b/mcpscore/rules/security.py
@@ -110,21 +110,28 @@ class TLSEnabledRule(BaseRule):
 
 @register_rule
 class MalformedRequestHandlingRule(BaseRule):
-    """Check the normative JSON-RPC response to malformed JSON.
+    """Check the JSON-RPC response to malformed JSON.
 
-    JSON-RPC 2.0 requires Parse error (``-32700``) and a null response ID when
-    the request cannot be parsed. A *missing* id is accepted as equivalent to
-    null: the id is unknowable when the request never parsed, and no client
-    correlates a parse error by id (calibrated against the registry
-    2026-08-22 — several conforming servers omit it). The transport-agnostic
-    specification does not prescribe an HTTP status, so this rule does not
-    either.
+    The **normative** requirement this rule enforces is the JSON-RPC 2.0 Parse
+    error code (``-32700``). Strict JSON-RPC additionally requires the response
+    ``id`` to be present and null when the request id cannot be detected; this
+    rule **deliberately relaxes that one point** and also accepts an *absent*
+    id — the id is genuinely unknowable when the request never parsed, no
+    client correlates a parse error by id, and a registry calibration
+    (2026-08-22) found conforming servers that omit it. This is a calibrated
+    interoperability allowance, not full JSON-RPC Response Object conformance.
+    The transport-agnostic specification does not prescribe an HTTP status, so
+    this rule does not either.
 
     Scoring: 2 points (MEDIUM)
     """
 
     rule_id = "security_malformed_request_handling"
-    basis = "JSON-RPC 2.0 §Response Object / §Error Object (-32700 Parse error; unknown id is null)"
+    basis = (
+        "JSON-RPC 2.0 §Response Object / §Error Object: -32700 Parse error (enforced). "
+        "Strict JSON-RPC requires the id present and null; a null OR absent id is accepted "
+        "as a calibrated interoperability allowance."
+    )
     group_name = "security"
     group_order = 3
     rule_order = 2

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -211,7 +211,7 @@ async def test_legacy_server_is_unsupported_but_observed():
     assert malformed.outcome is ProbeOutcome.SUPPORTED
     assert malformed.details["control_http_status"] == 400
     assert malformed.details["error_code"] == -32700
-    assert malformed.details["response_id_is_null"] is True
+    assert malformed.details["response_id_absent_or_null"] is True
 
     # No well-known metadata anywhere → UNSUPPORTED, with both locations tried.
     auth = results[PROBE_AUTH_METADATA]
@@ -370,7 +370,7 @@ async def test_malformed_json_probe_accepts_normative_error_at_any_http_status()
     assert result.outcome is ProbeOutcome.SUPPORTED
     assert result.details["http_status"] == 200
     assert result.details["error_code"] == -32700
-    assert result.details["response_id_is_null"] is True
+    assert result.details["response_id_absent_or_null"] is True
 
 
 async def test_malformed_json_probe_requires_null_id():
@@ -385,7 +385,29 @@ async def test_malformed_json_probe_requires_null_id():
 
     result = results[PROBE_MALFORMED_JSON]
     assert result.outcome is ProbeOutcome.UNSUPPORTED
-    assert result.details["response_id_is_null"] is False
+    assert result.details["response_id_absent_or_null"] is False
+
+
+async def test_malformed_json_probe_accepts_a_missing_id():
+    """A correct -32700 with the id field OMITTED is accepted as null-equivalent.
+
+    The id is unknowable on a parse error, and the registry has real conforming
+    servers that omit it (calibration 2026-08-22).
+    """
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        try:
+            json.loads(request.content) if request.method == "POST" else {}
+        except json.JSONDecodeError:
+            # No "id" key at all — not even null.
+            return httpx2.Response(400, json={"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}})
+        return _modern_server_handler(request)
+
+    results = await _run(handler)
+
+    result = results[PROBE_MALFORMED_JSON]
+    assert result.outcome is ProbeOutcome.SUPPORTED
+    assert result.details["response_id_absent_or_null"] is True
 
 
 async def test_origin_probe_cannot_judge_an_access_controlled_server():

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -410,6 +410,31 @@ async def test_malformed_json_probe_accepts_a_missing_id():
     assert result.details["response_id_absent_or_null"] is True
 
 
+async def test_malformed_json_probe_bounds_an_oversized_body():
+    """A hostile server returning a huge error body cannot exhaust memory.
+
+    The probe streams and stops reading at the 16 KB cap; the captured leak
+    body is bounded, and a leak near the start is still detected.
+    """
+    huge = "/home/user/secret.py leaked here " + ("A" * 5_000_000)
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        try:
+            json.loads(request.content) if request.method == "POST" else {}
+        except json.JSONDecodeError:
+            return httpx2.Response(400, content=huge, headers={"content-type": "text/plain"})
+        return _modern_server_handler(request)
+
+    async with _client(handler) as client:
+        response, text = await _HttpTarget(client, URL).post_raw(
+            b'{"jsonrpc":"2.0","id":13,', {"Content-Type": "application/json"}
+        )
+
+    assert len(text) <= 16_384  # bounded, not the 5 MB the server sent
+    assert "/home/user/secret.py" in text  # leak near the start survives the cap
+    assert response.status_code == 400
+
+
 async def test_origin_probe_cannot_judge_an_access_controlled_server():
     """A 403 to everything is not Origin validation.
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -426,14 +426,58 @@ async def test_malformed_json_probe_bounds_an_oversized_body():
         return _modern_server_handler(request)
 
     async with _client(handler) as client:
-        response, text, truncated = await _HttpTarget(client, URL).post_raw(
+        response, text, reason = await _HttpTarget(client, URL).post_raw(
             b'{"jsonrpc":"2.0","id":13,', {"Content-Type": "application/json"}
         )
 
+    assert text is not None
     assert len(text) <= 16_384  # bounded, not the 5 MB the server sent
     assert "/home/user/secret.py" in text  # leak near the start survives the cap
     assert response.status_code == 400
-    assert truncated is True
+    assert reason == "truncated"
+
+
+async def test_malformed_json_probe_requests_identity_encoding():
+    """The probe asks the server not to compress, so aiter_raw is plaintext."""
+    seen = {}
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        try:
+            json.loads(request.content) if request.method == "POST" else {}
+        except json.JSONDecodeError:
+            seen["accept_encoding"] = request.headers.get("accept-encoding")
+            return httpx2.Response(400, json={"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "x"}})
+        return _modern_server_handler(request)
+
+    await _run(handler)
+    assert seen["accept_encoding"] == "identity"
+
+
+async def test_malformed_json_probe_does_not_decode_a_content_encoded_body():
+    """A server that compresses despite the identity request is not decoded.
+
+    aiter_bytes would inflate a gzip/brotli bomb before any cap; we read raw
+    bytes and, on a Content-Encoding we did not ask for, report the body
+    unobservable rather than decompress it.
+    """
+    import gzip
+
+    bomb = gzip.compress(b'{"jsonrpc":"2.0","id":null,"error":{"code":-32700}}' + b"A" * 1000)
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        try:
+            json.loads(request.content) if request.method == "POST" else {}
+        except json.JSONDecodeError:
+            return httpx2.Response(400, content=bomb, headers={"content-encoding": "gzip"})
+        return _modern_server_handler(request)
+
+    results = await _run(handler)
+
+    result = results[PROBE_MALFORMED_JSON]
+    assert result.outcome is ProbeOutcome.NOT_APPLICABLE
+    assert "content-encoded" in result.details["reason"]
+    # No decoded body is offered to the leak scanner.
+    assert result.payload == {"error_body": None}
 
 
 async def test_malformed_json_probe_does_not_fail_a_truncated_valid_response():

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -426,13 +426,37 @@ async def test_malformed_json_probe_bounds_an_oversized_body():
         return _modern_server_handler(request)
 
     async with _client(handler) as client:
-        response, text = await _HttpTarget(client, URL).post_raw(
+        response, text, truncated = await _HttpTarget(client, URL).post_raw(
             b'{"jsonrpc":"2.0","id":13,', {"Content-Type": "application/json"}
         )
 
     assert len(text) <= 16_384  # bounded, not the 5 MB the server sent
     assert "/home/user/secret.py" in text  # leak near the start survives the cap
     assert response.status_code == 400
+    assert truncated is True
+
+
+async def test_malformed_json_probe_does_not_fail_a_truncated_valid_response():
+    """A valid -32700 padded beyond the 16 KB cap must not be scored UNSUPPORTED.
+
+    The prefix is unparsable (JSON cut mid-object), but the untruncated body
+    was valid — so the verdict is unobservable, not a protocol failure.
+    """
+    # A real -32700 envelope with a huge message, so the prefix is cut mid-string.
+    padded = '{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"' + ("x" * 5_000_000) + '"}}'
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        try:
+            json.loads(request.content) if request.method == "POST" else {}
+        except json.JSONDecodeError:
+            return httpx2.Response(400, content=padded, headers={"content-type": "application/json"})
+        return _modern_server_handler(request)
+
+    results = await _run(handler)
+
+    result = results[PROBE_MALFORMED_JSON]
+    assert result.outcome is ProbeOutcome.NOT_APPLICABLE
+    assert "scan cap" in result.details["reason"]
 
 
 async def test_origin_probe_cannot_judge_an_access_controlled_server():

--- a/tests/test_security_rules.py
+++ b/tests/test_security_rules.py
@@ -224,20 +224,45 @@ class TestErrorDataLeakRule:
         assert "stack trace" in result.message.lower()
 
     def test_password_leak_fails(self, rule):
-        """A password in the error body fails — and is NOT echoed into our report."""
-        result = rule.check(_leak_audit('Connection failed: password="secret123"'))
+        """A real password value in the error body fails — and is NOT echoed into our report."""
+        result = rule.check(_leak_audit('Connection failed: password="hunter2Xy9"'))
 
         assert result.passed is False
         assert "password" in result.message.lower()
         # The leaked value must never appear in our own (shareable) report.
-        assert "secret123" not in str(result.details)
+        assert "hunter2Xy9" not in str(result.details)
         assert result.message == "❌ Error messages leak sensitive data: password"
 
     def test_bearer_token_leak_fails(self, rule):
-        """A Bearer token in the error body fails."""
+        """A real Bearer token value in the error body fails."""
         result = rule.check(_leak_audit("Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"))
 
         assert result.passed is False
+
+    def test_api_key_leak_fails(self, rule):
+        """A real API key value fails."""
+        result = rule.check(_leak_audit("upstream error: api_key=sk-live-1a2B3c4D5e6F7g8H"))
+
+        assert result.passed is False
+        assert "api key" in result.message.lower()
+
+    def test_auth_placeholder_phrases_do_not_leak(self, rule):
+        """Live auth-gated bodies routinely name credentials without leaking one.
+
+        This is the whole reason the rule validates the captured value: matching
+        the keyword alone would fail well-behaved servers.
+        """
+        for safe in (
+            "Bearer token required",
+            "Unauthorized: missing api_key",
+            'password="redacted"',
+            "secret: <your-secret-here>",
+            "token=required",
+            "Provide a valid Bearer token to continue",
+            '{"error":"invalid_token","error_description":"The access token is invalid"}',
+        ):
+            result = rule.check(_leak_audit(safe))
+            assert result.passed is True, f"false positive on: {safe!r}"
 
     def test_non_json_html_body_is_scanned(self, rule):
         """A non-JSON HTML error page (payload could not parse it) is still scanned."""

--- a/tests/test_security_rules.py
+++ b/tests/test_security_rules.py
@@ -246,6 +246,18 @@ class TestErrorDataLeakRule:
         assert result.passed is False
         assert "api key" in result.message.lower()
 
+    def test_opaque_base64_bearer_token_is_captured_whole(self, rule):
+        """A bearer value with base64 chars (+ / =) must not be truncated and missed.
+
+        RFC 6750 b64tokens use the full base64 alphabet; a narrower class would
+        capture only the prefix before `+`, drop it as too short, and miss the
+        leak.
+        """
+        result = rule.check(_leak_audit("leaked upstream: Bearer Ab1+/cDefGhIjKl=="))
+
+        assert result.passed is False
+        assert "auth token" in result.message.lower()
+
     def test_auth_placeholder_phrases_do_not_leak(self, rule):
         """Live auth-gated bodies routinely name credentials without leaking one.
 

--- a/tests/test_security_rules.py
+++ b/tests/test_security_rules.py
@@ -172,6 +172,18 @@ class TestMalformedRequestHandlingRule:
         assert rule.skip_reason(audit_data) == SKIP_REASON_INSUFFICIENT_DATA
 
 
+def _leak_audit(body: str | None, *, outcome: ProbeOutcome = ProbeOutcome.UNSUPPORTED) -> AuditData:
+    """AuditData carrying a malformed-JSON probe with a captured error body.
+
+    The rule reads the raw body from the probe's ``payload`` (which is
+    excluded from reports) — the malformed request is where a server dumps a
+    stack trace or path. ``body=None`` models a probe that captured nothing.
+    """
+    payload = {"error_body": body} if body is not None else None
+    probe = ProbeResult(PROBE_MALFORMED_JSON, outcome, {}, payload=payload)
+    return AuditData(transport_type=MCPTransportType.STREAMABLE_HTTP, probes={PROBE_MALFORMED_JSON: probe})
+
+
 class TestErrorDataLeakRule:
     """Test ErrorDataLeakRule."""
 
@@ -180,9 +192,9 @@ class TestErrorDataLeakRule:
         return ErrorDataLeakRule()
 
     def test_no_leaks_passes(self, rule):
-        """Test that clean error responses pass."""
-        audit_data = AuditData(
-            error_response='{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null}'
+        """A clean JSON-RPC error body passes."""
+        audit_data = _leak_audit(
+            '{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}',
         )
 
         assert rule.skip_reason(audit_data) is None
@@ -193,65 +205,75 @@ class TestErrorDataLeakRule:
         assert "do not appear to leak" in result.message
 
     def test_file_path_leak_fails(self, rule):
-        """Test that file path leakage fails."""
-        audit_data = AuditData(error_response="Error at /home/user/server.py line 42")
-
-        result = rule.check(audit_data)
+        """A file path in the error body fails."""
+        result = rule.check(_leak_audit("Error at /home/user/server.py line 42"))
 
         assert result.passed is False
         assert "❌" in result.message
         assert "file path" in result.message.lower()
 
     def test_stack_trace_leak_fails(self, rule):
-        """Test that stack trace leakage fails."""
-        audit_data = AuditData(
-            error_response=(
+        """A stack trace in the error body fails."""
+        result = rule.check(
+            _leak_audit(
                 'Traceback (most recent call last):\n  File "server.py", line 10, in main\n    raise Exception("Error")'
             )
         )
 
-        result = rule.check(audit_data)
-
         assert result.passed is False
-        assert "❌" in result.message
         assert "stack trace" in result.message.lower()
 
     def test_password_leak_fails(self, rule):
-        """Test that password leakage fails."""
-        audit_data = AuditData(error_response='Connection failed: password="secret123"')
-
-        result = rule.check(audit_data)
+        """A password in the error body fails — and is NOT echoed into our report."""
+        result = rule.check(_leak_audit('Connection failed: password="secret123"'))
 
         assert result.passed is False
-        assert "❌" in result.message
         assert "password" in result.message.lower()
-
-    def test_api_key_leak_fails(self, rule):
-        """Test that API key leakage fails."""
-        audit_data = AuditData(error_response="Authentication failed: api_key=sk-1234567890abcdef")
-
-        result = rule.check(audit_data)
-
-        assert result.passed is False
-        assert "❌" in result.message
-        assert "api key" in result.message.lower()
+        # The leaked value must never appear in our own (shareable) report.
+        assert "secret123" not in str(result.details)
+        assert result.message == "❌ Error messages leak sensitive data: password"
 
     def test_bearer_token_leak_fails(self, rule):
-        """Test that Bearer token leakage fails."""
-        audit_data = AuditData(error_response="Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
-
-        result = rule.check(audit_data)
+        """A Bearer token in the error body fails."""
+        result = rule.check(_leak_audit("Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"))
 
         assert result.passed is False
-        assert "❌" in result.message
 
-    def test_no_error_response(self, rule):
-        """Test that an absent remote error response is insufficient data."""
-        audit_data = AuditData(error_response=None, transport_type=MCPTransportType.STREAMABLE_HTTP)
+    def test_non_json_html_body_is_scanned(self, rule):
+        """A non-JSON HTML error page (payload could not parse it) is still scanned."""
+        result = rule.check(
+            _leak_audit("<html><body><pre>Traceback (most recent call last): /home/app/x.py</pre></body></html>")
+        )
+
+        assert result.passed is False
+        assert "stack trace" in result.message.lower()
+
+    def test_absent_probe_is_insufficient_data(self, rule):
+        """No malformed probe at all — nothing to scan."""
+        audit_data = AuditData(transport_type=MCPTransportType.STREAMABLE_HTTP)
 
         assert rule.skip_reason(audit_data) == SKIP_REASON_INSUFFICIENT_DATA
 
+    def test_probe_without_body_is_insufficient_data(self, rule):
+        """The probe ran but captured no body (network error path)."""
+        assert rule.skip_reason(_leak_audit(None)) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_probe_error_is_insufficient_data(self, rule):
+        """A probe that errored at the network level captured no body."""
+        assert rule.skip_reason(_leak_audit(None, outcome=ProbeOutcome.ERROR)) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_not_applicable_probe_without_body_is_insufficient_data(self, rule):
+        """Parse verdict is irrelevant; no captured body is insufficient data."""
+        assert rule.skip_reason(_leak_audit(None, outcome=ProbeOutcome.NOT_APPLICABLE)) == SKIP_REASON_INSUFFICIENT_DATA
+
+    def test_not_applicable_probe_with_body_still_scans(self, rule):
+        """A server can leak even when its parse-error verdict is not judgeable."""
+        audit_data = _leak_audit("boom /home/user/secret.py", outcome=ProbeOutcome.NOT_APPLICABLE)
+
+        assert rule.skip_reason(audit_data) is None
+        assert rule.check(audit_data).passed is False
+
     def test_stdio_transport_not_applicable(self, rule):
-        audit_data = AuditData(error_response=None, transport_type=MCPTransportType.STDIO)
+        audit_data = AuditData(transport_type=MCPTransportType.STDIO)
 
         assert rule.skip_reason(audit_data) == SKIP_REASON_NOT_APPLICABLE


### PR DESCRIPTION
Follow-ups from the PR #105 review. Three changes, one dead rule brought back to life plus a calibrated strictness relaxation.

1. security_error_data_leak now runs (it was dead)

The rule read AuditData.error_response, a field no code path in the repo's history ever produced — so it silently skipped on every audit. It now scans the response body that the malformed-request probe (_probe_malformed_json) already elicits — the request most likely to make a server dump a stack trace, file path, or secret.

- The probe captures the raw body on its ProbeResult.payload (excluded from to_dict, so it never reaches a report); the rule reads it from there.
- Non-JSON bodies are scanned too (HTML stack-trace pages the parsed JSON payload can't carry), bounded at 16 KB.
- Leaked values are never echoed back into our report — only the leak type and a count. The report is shareable (/s), so echoing the server's secret would re-leak it.
- Skips as insufficient-data only when no body was captured; stdio is not-applicable.
- The dead error_response field is removed from AuditData (verified no other reader).

Score effect: servers that don't leak gain the 2 points they never had a chance to earn — e.g. DeepWiki 76/85 → 78/87.

2. Malformed-JSON rule: accept a missing id as null-equivalent

Registry calibration (250 healthy remote servers; analysis in the companion project/ doc) found the rule was sound — 82% of its failures are genuine defects (HTML error pages, non-JSON-RPC errors, wrong codes). But 7/250 conforming servers returned the correct -32700 Parse error while omitting id rather than setting it null, and the rule failed them on that technicality.

The id is genuinely unknowable when a request never parsed, and no client correlates a parse error by id — so null vs absent carries no observable difference. The check now uses payload.get("id") is None (true for missing or explicit null; a real value like 0 is still rejected). A non-null echoed id stays UNSUPPORTED by design. False-positive rate drops ~4.9% → ~0.8%.

3. Docstring nits

Two rule docstrings quoted an old ×2 severity scale (10 points (CRITICAL) → 5, 5 points (MEDIUM) → 2; weights are RuleSeverity CRITICAL 5 / HIGH 3 / MEDIUM 2 / LOW 1). Fixed the misindented HTTP_ONLY_PROBE_IDS continuation lines.

Verification

- make all green — 917 tests, 99.56% coverage, docs/rules.mdx drift-free.
- Live invariant: DeepWiki 78/87 (the +2/+2 is error_data_leak coming alive; the id relaxation doesn't move DeepWiki).
- New/rewritten tests prove each path: leak scanning incl. non-JSON bodies and no-re-leak; the probe/rule gating (insufficient-data vs not-applicable); missing-id acceptance vs non-null-id rejection.