### PR TITLE
Three catalog connection-independence rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Three catalog connection-independence rules.** Modern servers are checked
+  that the complete tools, resources, and prompts identity sets do not vary
+  across two independent connections carrying the same authorization context.
+  Comparisons ignore ordering, traverse pagination completely, bound reported
+  differences, and skip rather than fail when either observation is incomplete.
+  Each requirement is HIGH and scoped to MCP 2026-07-28, where catalog sets
+  MUST NOT vary per connection.
+
 ## [1.10.0] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 
 ## What it scores
 
-102 active rules in total: 96 server rules across the same four categories the report,
+105 active rules in total: 99 server rules across the same four categories the report,
 the JSON output, and [mcpscore.dev](https://mcpscore.dev) show, plus six separate
 packaging rules. Every rule cites the spec section or RFC it enforces; the full list is
 in the [rules reference](https://docs.mcpscore.dev/rules/).
@@ -58,7 +58,7 @@ in the [rules reference](https://docs.mcpscore.dev/rules/).
 name, title and version, advertised capabilities, and transport. Streamable HTTP is the
 current standard, so SSE-only servers get migration advice.
 
-**Tools Quality** (47 rules) — tool names (presence, uniqueness, format), titles,
+**Tools Quality** (50 rules) — tool names (presence, uniqueness, format), titles,
 descriptions of tools and their input properties, and JSON Schema validity of input and
 output schemas, including the 2026-07-28 `x-mcp-header` constraints — plus the
 equivalent catalog checks for prompts, resources, and resource templates: valid and

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -156,6 +156,9 @@ score whether it speaks MCP.
 | `pagination_resource_templates_invalid_cursor` | Resource Templates Invalid Pagination Cursor | LOW | 1 | all versions |
 | `pagination_prompts_invalid_cursor` | Prompts Invalid Pagination Cursor | LOW | 1 | all versions |
 | `pagination_cache_scope_consistent` | Pagination Cache Scope Consistent | HIGH | 3 | 2026-07-28 – … |
+| `tools_catalog_connection_independent` | Tools Catalog Connection Independent | HIGH | 3 | 2026-07-28 – … |
+| `resources_catalog_connection_independent` | Resources Catalog Connection Independent | HIGH | 3 | 2026-07-28 – … |
+| `prompts_catalog_connection_independent` | Prompts Catalog Connection Independent | HIGH | 3 | 2026-07-28 – … |
 
 ## Readiness rules
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -1843,8 +1843,9 @@ async def run_all_probes(
         select: Callable[[str], httpx2.AsyncClient],
         comparison_client: httpx2.AsyncClient | None,
     ) -> dict[str, ProbeResult]:
-        results = await asyncio.gather(*(run_one(probe_id, select(probe_id)) for probe_id in _SINGLE_TARGET_PROBE_IDS))
         primary_client = select(PROBE_DISCOVER)
+        # Compare pristine clients before any single-target response can mutate
+        # the primary client's cookie jar and create a different auth context.
         connection_results = (
             await _probe_catalog_connection_independence(
                 _HttpTarget(primary_client, url),
@@ -1856,6 +1857,7 @@ async def run_all_probes(
                 CATALOG_CONNECTION_PROBE_IDS,
             )
         )
+        results = await asyncio.gather(*(run_one(probe_id, select(probe_id)) for probe_id in _SINGLE_TARGET_PROBE_IDS))
         return {
             **{result.probe_id: result for result in results},
             **connection_results,

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -154,8 +154,11 @@ PROBE_RESOURCES_INVALID_CURSOR = "probe_resources_invalid_cursor"
 PROBE_RESOURCE_TEMPLATES_INVALID_CURSOR = "probe_resource_templates_invalid_cursor"
 PROBE_PROMPTS_INVALID_CURSOR = "probe_prompts_invalid_cursor"
 PROBE_PAGINATION_CACHE_SCOPE = "probe_pagination_cache_scope"
+PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT = "probe_tools_catalog_connection_independent"
+PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT = "probe_resources_catalog_connection_independent"
+PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT = "probe_prompts_catalog_connection_independent"
 
-PROBE_IDS: tuple[str, ...] = (
+_SINGLE_TARGET_PROBE_IDS: tuple[str, ...] = (
     PROBE_DISCOVER,
     PROBE_STATELESS_LIST,
     PROBE_MALFORMED_META,
@@ -180,6 +183,12 @@ PROBE_IDS: tuple[str, ...] = (
     PROBE_PROMPTS_INVALID_CURSOR,
     PROBE_PAGINATION_CACHE_SCOPE,
 )
+CATALOG_CONNECTION_PROBE_IDS: tuple[str, ...] = (
+    PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+    PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+    PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+)
+PROBE_IDS: tuple[str, ...] = (*_SINGLE_TARGET_PROBE_IDS, *CATALOG_CONNECTION_PROBE_IDS)
 """Stable identifiers of all probes."""
 
 HTTP_ONLY_PROBE_IDS: frozenset[str] = frozenset(
@@ -209,7 +218,7 @@ bodies. Over stdio they record
 malformed wire input through the SDK transport.
 """
 
-STDIO_PROBE_IDS: tuple[str, ...] = tuple(p for p in PROBE_IDS if p not in HTTP_ONLY_PROBE_IDS)
+STDIO_PROBE_IDS: tuple[str, ...] = tuple(p for p in _SINGLE_TARGET_PROBE_IDS if p not in HTTP_ONLY_PROBE_IDS)
 """Probes that run over stdio — the ones judging JSON-RPC, not HTTP."""
 
 _ANONYMOUS_PROBE_IDS = frozenset({PROBE_UNAUTHENTICATED, PROBE_AUTH_METADATA})
@@ -1069,6 +1078,159 @@ async def _probe_pagination_cache_scope(target: _ProbeTarget) -> ProbeResult:
     return ProbeResult(PROBE_PAGINATION_CACHE_SCOPE, ProbeOutcome.SUPPORTED, details)
 
 
+_CATALOG_CONNECTION_SURFACES: tuple[tuple[str, str, str, str], ...] = (
+    ("tools", "tools/list", "tools", PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT),
+    ("resources", "resources/list", "resources", PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT),
+    ("prompts", "prompts/list", "prompts", PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT),
+)
+"""Capability, method, result key, and probe ID for connection-stable catalogs."""
+
+
+async def _collect_catalog_identities(
+    target: _ProbeTarget,
+    *,
+    target_version: str,
+    method: str,
+    item_key: str,
+    request_id_base: int,
+) -> frozenset[str]:
+    """Collect one complete catalog as an order-independent identity set."""
+    identities: set[str] = set()
+    seen_cursors: set[str] = set()
+    cursor: str | None = None
+    deadline = time.monotonic() + PAGINATION_PROBE_TIMEOUT_S
+    identity_key = "uri" if item_key == "resources" else "name"
+
+    for page_number in range(PAGINATION_PROBE_MAX_PAGES):
+        remaining = max(deadline - time.monotonic(), 0)
+        if remaining == 0:
+            raise TimeoutError
+        params = {"cursor": cursor} if cursor is not None else None
+        response = await asyncio.wait_for(
+            target.post(
+                _request_body(
+                    method,
+                    request_id_base + page_number,
+                    _modern_meta(target_version),
+                    params=params,
+                ),
+                _request_headers(target_version, method),
+            ),
+            timeout=remaining,
+        )
+        result = response.result
+        if result is None:
+            msg = f"{method} did not return a result object"
+            raise TypeError(msg)
+        items = result.get(item_key)
+        if not isinstance(items, list):
+            msg = f"{method} did not return a {item_key} list"
+            raise TypeError(msg)
+        for item in items:
+            identity = item.get(identity_key) if isinstance(item, dict) else None
+            if not isinstance(identity, str) or not identity:
+                msg = f"{method} returned an item without a valid {identity_key}"
+                raise ValueError(msg)
+            identities.add(identity)
+
+        next_cursor = result.get("nextCursor")
+        if next_cursor is None:
+            return frozenset(identities)
+        if not isinstance(next_cursor, str) or not next_cursor or next_cursor in seen_cursors:
+            msg = f"{method} returned an invalid or repeated cursor"
+            raise ValueError(msg)
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+    msg = f"{method} exceeded the {PAGINATION_PROBE_MAX_PAGES}-page safety bound"
+    raise ValueError(msg)
+
+
+async def _probe_catalog_connection_independence(
+    first: _ProbeTarget,
+    second: _ProbeTarget,
+) -> dict[str, ProbeResult]:
+    """Compare complete modern catalogs over two independent connections."""
+    target_version = _target_version()
+    try:
+        discover = await first.post(
+            _request_body("server/discover", 2100, _modern_meta(target_version)),
+            _request_headers(target_version, "server/discover"),
+        )
+    except Exception as exc:  # noqa: BLE001 — probe transport failures are data
+        return {
+            probe_id: ProbeResult(
+                probe_id,
+                ProbeOutcome.ERROR,
+                {"exception": type(exc).__name__, "reason": str(exc)},
+            )
+            for probe_id in CATALOG_CONNECTION_PROBE_IDS
+        }
+    capabilities = discover.result.get("capabilities") if discover.result is not None else None
+    if not isinstance(capabilities, dict):
+        return not_applicable_results(
+            "modern declared catalog capabilities were not observable",
+            CATALOG_CONNECTION_PROBE_IDS,
+        )
+
+    async def compare(
+        surface_index: int,
+        capability: str,
+        method: str,
+        item_key: str,
+        probe_id: str,
+    ) -> ProbeResult:
+        if capabilities.get(capability) is None:
+            return ProbeResult(
+                probe_id,
+                ProbeOutcome.NOT_APPLICABLE,
+                {"reason": f"server does not declare the {capability} capability"},
+            )
+        try:
+            first_ids, second_ids = await asyncio.gather(
+                _collect_catalog_identities(
+                    first,
+                    target_version=target_version,
+                    method=method,
+                    item_key=item_key,
+                    request_id_base=2200 + surface_index * 300,
+                ),
+                _collect_catalog_identities(
+                    second,
+                    target_version=target_version,
+                    method=method,
+                    item_key=item_key,
+                    request_id_base=2300 + surface_index * 300,
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — incomplete evidence must skip, never fail
+            return ProbeResult(
+                probe_id,
+                ProbeOutcome.ERROR,
+                {"exception": type(exc).__name__, "reason": str(exc)},
+            )
+
+        only_first = sorted(first_ids - second_ids)
+        only_second = sorted(second_ids - first_ids)
+        outcome = ProbeOutcome.SUPPORTED if not only_first and not only_second else ProbeOutcome.UNSUPPORTED
+        return ProbeResult(
+            probe_id,
+            outcome,
+            {
+                "first_count": len(first_ids),
+                "second_count": len(second_ids),
+                "only_first": only_first[:10],
+                "only_second": only_second[:10],
+                "differences_truncated": len(only_first) > 10 or len(only_second) > 10,
+            },
+        )
+
+    results = await asyncio.gather(
+        *(compare(index, *surface) for index, surface in enumerate(_CATALOG_CONNECTION_SURFACES))
+    )
+    return {result.probe_id: result for result in results}
+
+
 async def _probe_unauthenticated(target: _HttpTarget) -> ProbeResult:
     """One unauthenticated request, recording status and ``WWW-Authenticate``.
 
@@ -1607,6 +1769,7 @@ def detect_era(session_protocol_version: str | None, probes: dict[str, ProbeResu
 async def run_all_probes(
     url: str,
     client: httpx2.AsyncClient | None = None,
+    fresh_client: httpx2.AsyncClient | None = None,
     headers: dict[str, str] | None = None,
 ) -> dict[str, ProbeResult]:
     """Run every probe against an HTTP(S) MCP endpoint.
@@ -1619,8 +1782,13 @@ async def run_all_probes(
         url: The MCP endpoint URL (http:// or https://)
         client: Optional preconfigured httpx client (tests inject a
             MockTransport-backed one); short-lived clients are created
-            otherwise. An injected client is used for every probe, including
-            the anonymous ones — the caller configures its headers.
+            otherwise. An injected client is used for every single-target
+            probe, including the anonymous ones — the caller configures its
+            headers.
+        fresh_client: A second independently configured client used only for
+            catalog connection-independence comparisons when ``client`` is
+            injected. Without it those comparisons are not observable and
+            skip; one client must never manufacture two-connection evidence.
         headers: Extra HTTP headers (e.g. an ``Authorization`` bearer) merged
             into the short-lived authenticated client's defaults; probes in
             ``_ANONYMOUS_PROBE_IDS`` run on a separate client that carries
@@ -1639,17 +1807,38 @@ async def run_all_probes(
             logger.info("Probe %s failed against %s: %s", probe_id, url, e)
             return ProbeResult(probe_id, ProbeOutcome.ERROR, {"exception": type(e).__name__})
 
-    async def run_with(select: Callable[[str], httpx2.AsyncClient]) -> dict[str, ProbeResult]:
-        results = await asyncio.gather(*(run_one(probe_id, select(probe_id)) for probe_id in PROBE_IDS))
-        return {result.probe_id: result for result in results}
+    async def run_with(
+        select: Callable[[str], httpx2.AsyncClient],
+        comparison_client: httpx2.AsyncClient | None,
+    ) -> dict[str, ProbeResult]:
+        results = await asyncio.gather(*(run_one(probe_id, select(probe_id)) for probe_id in _SINGLE_TARGET_PROBE_IDS))
+        connection_results = (
+            await _probe_catalog_connection_independence(
+                _HttpTarget(select(PROBE_DISCOVER), url),
+                _HttpTarget(comparison_client, url),
+            )
+            if comparison_client is not None
+            else not_applicable_results(
+                "a second independent probe client was not supplied",
+                CATALOG_CONNECTION_PROBE_IDS,
+            )
+        )
+        return {
+            **{result.probe_id: result for result in results},
+            **connection_results,
+        }
 
     if client is not None:
-        return await run_with(lambda _probe_id: client)
+        return await run_with(lambda _probe_id: client, fresh_client)
     async with (
         httpx2.AsyncClient(follow_redirects=True, headers=headers) as own_client,
+        httpx2.AsyncClient(follow_redirects=True, headers=headers) as fresh_client,
         httpx2.AsyncClient(follow_redirects=True) as anon_client,
     ):
-        return await run_with(lambda probe_id: anon_client if probe_id in _ANONYMOUS_PROBE_IDS else own_client)
+        return await run_with(
+            lambda probe_id: anon_client if probe_id in _ANONYMOUS_PROBE_IDS else own_client,
+            fresh_client,
+        )
 
 
 async def run_stdio_probes(params: StdioServerParameters) -> dict[str, ProbeResult]:
@@ -1694,12 +1883,18 @@ async def run_stdio_probes(params: StdioServerParameters) -> dict[str, ProbeResu
         async with stdio_client(params, errlog=errlog) as (read_stream, write_stream):
             target = _StdioTarget(read_stream, write_stream)
             results.extend([await run_one(probe_id, target) for probe_id in STDIO_PROBE_IDS])
+            async with stdio_client(params, errlog=errlog) as (fresh_read_stream, fresh_write_stream):
+                connection_results = await _probe_catalog_connection_independence(
+                    target,
+                    _StdioTarget(fresh_read_stream, fresh_write_stream),
+                )
+                results.extend(connection_results.values())
     except Exception as e:  # noqa: BLE001 — process startup/teardown failures are probe data
         logger.info("Stdio probe transport failed against %s: %s", params.command, e)
         completed = {result.probe_id for result in results}
         results.extend(
             ProbeResult(probe_id, ProbeOutcome.ERROR, {"exception": type(e).__name__})
-            for probe_id in STDIO_PROBE_IDS
+            for probe_id in (*STDIO_PROBE_IDS, *CATALOG_CONNECTION_PROBE_IDS)
             if probe_id not in completed
         )
 

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -1844,12 +1844,13 @@ async def run_all_probes(
         comparison_client: httpx2.AsyncClient | None,
     ) -> dict[str, ProbeResult]:
         results = await asyncio.gather(*(run_one(probe_id, select(probe_id)) for probe_id in _SINGLE_TARGET_PROBE_IDS))
+        primary_client = select(PROBE_DISCOVER)
         connection_results = (
             await _probe_catalog_connection_independence(
-                _HttpTarget(select(PROBE_DISCOVER), url),
+                _HttpTarget(primary_client, url),
                 _HttpTarget(comparison_client, url),
             )
-            if comparison_client is not None
+            if comparison_client is not None and comparison_client is not primary_client
             else not_applicable_results(
                 "a second independent probe client was not supplied",
                 CATALOG_CONNECTION_PROBE_IDS,

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -548,13 +548,12 @@ class _HttpTarget:
 class _StdioTarget:
     """A probe target reached through the SDK's cross-platform stdio transport.
 
-    One sibling process is used for the whole probe suite. It is separate from
-    the audit's SDK session, which has already sent ``initialize`` and pinned
-    that connection to the legacy lifecycle, but modern requests do not require
-    a fresh process apiece. Reusing one no-handshake connection avoids starting
-    the audited command once per probe — important for servers with expensive
-    or externally visible startup behavior — while every request still carries
-    its own complete modern envelope.
+    Each target owns one sibling process, separate from the audit's SDK session
+    that has already sent ``initialize`` and pinned its connection to the legacy
+    lifecycle. The probe suite reuses its primary target for all single-target
+    probes and starts one additional target for the connection-independence
+    comparisons. This avoids starting the audited command once per probe while
+    still providing two genuinely independent connections.
     """
 
     read_stream: Any
@@ -1801,8 +1800,9 @@ def detect_era(session_protocol_version: str | None, probes: dict[str, ProbeResu
 async def run_all_probes(
     url: str,
     client: httpx2.AsyncClient | None = None,
-    fresh_client: httpx2.AsyncClient | None = None,
     headers: dict[str, str] | None = None,
+    *,
+    fresh_client: httpx2.AsyncClient | None = None,
 ) -> dict[str, ProbeResult]:
     """Run every probe against an HTTP(S) MCP endpoint.
 
@@ -1817,15 +1817,15 @@ async def run_all_probes(
             otherwise. An injected client is used for every single-target
             probe, including the anonymous ones — the caller configures its
             headers.
-        fresh_client: A second independently configured client used only for
-            catalog connection-independence comparisons when ``client`` is
-            injected. Without it those comparisons are not observable and
-            skip; one client must never manufacture two-connection evidence.
         headers: Extra HTTP headers (e.g. an ``Authorization`` bearer) merged
             into the short-lived authenticated client's defaults; probes in
             ``_ANONYMOUS_PROBE_IDS`` run on a separate client that carries
             none of them. Ignored when ``client`` is supplied. Sensitive —
             never logged.
+        fresh_client: A second independently configured client used only for
+            catalog connection-independence comparisons when ``client`` is
+            injected. Without it those comparisons are not observable and
+            skip; one client must never manufacture two-connection evidence.
 
     Returns:
         Mapping of probe_id to its ProbeResult, covering all PROBE_IDS
@@ -1878,10 +1878,11 @@ async def run_stdio_probes(params: StdioServerParameters) -> dict[str, ProbeResu
 
     The modern lifecycle is stateless, so "does this server speak 2026-07-28?"
     is answerable over stdio exactly as over HTTP: send the request, read the
-    reply. The suite launches one short-lived sibling process and deliberately
-    stays below the SDK session layer, so no ``initialize`` handshake pins that
-    connection to the legacy lifecycle. Probes run sequentially on it because
-    a stdio stream has one reader; each request remains self-contained.
+    reply. The suite launches two short-lived sibling processes and deliberately
+    stays below the SDK session layer, so no ``initialize`` handshake pins those
+    connections to the legacy lifecycle. Single-target probes run sequentially
+    on the first process because a stdio stream has one reader; the second exists
+    only to compare catalogs across independent connections.
 
     Probes in :data:`HTTP_ONLY_PROBE_IDS` are recorded ``NOT_APPLICABLE``:
     their subject does not exist on this transport.

--- a/mcpscore/probes.py
+++ b/mcpscore/probes.py
@@ -1152,10 +1152,29 @@ async def _probe_catalog_connection_independence(
 ) -> dict[str, ProbeResult]:
     """Compare complete modern catalogs over two independent connections."""
     target_version = _target_version()
+
+    async def gather_pair(first_awaitable: Any, second_awaitable: Any) -> tuple[Any, Any]:
+        """Run work on independent targets, always draining a failed sibling."""
+        first_task = asyncio.create_task(first_awaitable)
+        second_task = asyncio.create_task(second_awaitable)
+        try:
+            return await asyncio.gather(first_task, second_task)
+        except BaseException:
+            first_task.cancel()
+            second_task.cancel()
+            await asyncio.gather(first_task, second_task, return_exceptions=True)
+            raise
+
     try:
-        discover = await first.post(
-            _request_body("server/discover", 2100, _modern_meta(target_version)),
-            _request_headers(target_version, "server/discover"),
+        first_discover, second_discover = await gather_pair(
+            first.post(
+                _request_body("server/discover", 2100, _modern_meta(target_version)),
+                _request_headers(target_version, "server/discover"),
+            ),
+            second.post(
+                _request_body("server/discover", 2101, _modern_meta(target_version)),
+                _request_headers(target_version, "server/discover"),
+            ),
         )
     except Exception as exc:  # noqa: BLE001 — probe transport failures are data
         return {
@@ -1166,10 +1185,11 @@ async def _probe_catalog_connection_independence(
             )
             for probe_id in CATALOG_CONNECTION_PROBE_IDS
         }
-    capabilities = discover.result.get("capabilities") if discover.result is not None else None
-    if not isinstance(capabilities, dict):
+    first_capabilities = first_discover.result.get("capabilities") if first_discover.result is not None else None
+    second_capabilities = second_discover.result.get("capabilities") if second_discover.result is not None else None
+    if not isinstance(first_capabilities, dict) or not isinstance(second_capabilities, dict):
         return not_applicable_results(
-            "modern declared catalog capabilities were not observable",
+            "modern declared catalog capabilities were not observable on both connections",
             CATALOG_CONNECTION_PROBE_IDS,
         )
 
@@ -1180,14 +1200,26 @@ async def _probe_catalog_connection_independence(
         item_key: str,
         probe_id: str,
     ) -> ProbeResult:
-        if capabilities.get(capability) is None:
+        first_declares = first_capabilities.get(capability) is not None
+        second_declares = second_capabilities.get(capability) is not None
+        if not first_declares and not second_declares:
             return ProbeResult(
                 probe_id,
                 ProbeOutcome.NOT_APPLICABLE,
                 {"reason": f"server does not declare the {capability} capability"},
             )
+        if first_declares != second_declares:
+            return ProbeResult(
+                probe_id,
+                ProbeOutcome.UNSUPPORTED,
+                {
+                    "first_declares_capability": first_declares,
+                    "second_declares_capability": second_declares,
+                    "reason": f"{capability} capability varies across client connections",
+                },
+            )
         try:
-            first_ids, second_ids = await asyncio.gather(
+            first_ids, second_ids = await gather_pair(
                 _collect_catalog_identities(
                     first,
                     target_version=target_version,
@@ -1225,9 +1257,9 @@ async def _probe_catalog_connection_independence(
             },
         )
 
-    results = await asyncio.gather(
-        *(compare(index, *surface) for index, surface in enumerate(_CATALOG_CONNECTION_SURFACES))
-    )
+    # A stdio target has one response stream. Keep surfaces sequential so two
+    # readers never race to consume a response intended for the other request.
+    results = [await compare(index, *surface) for index, surface in enumerate(_CATALOG_CONNECTION_SURFACES)]
     return {result.probe_id: result for result in results}
 
 

--- a/mcpscore/rules/__init__.py
+++ b/mcpscore/rules/__init__.py
@@ -38,6 +38,11 @@ from .capabilities import (
     CapabilityToolsListChangedRule,
     CapabilityToolsPresentRule,
 )
+from .catalog_stability import (
+    PromptsCatalogConnectionIndependentRule,
+    ResourcesCatalogConnectionIndependentRule,
+    ToolsCatalogConnectionIndependentRule,
+)
 from .packaging import (
     PACKAGING_GROUP,
     PackageDescriptionPresentRule,
@@ -194,6 +199,7 @@ __all__ = (
     "PromptsArgumentNamesPresentRule",
     "PromptsArgumentNamesUniqueRule",
     "PromptsArgumentsDocumentedRule",
+    "PromptsCatalogConnectionIndependentRule",
     "PromptsDescriptionPresentRule",
     "PromptsIconsValidRule",
     "PromptsInvalidCursorRule",
@@ -211,6 +217,7 @@ __all__ = (
     "ResourceTemplatesUniqueRule",
     "ResourceTemplatesUriTemplatesValidRule",
     "ResourcesAnnotationsValidRule",
+    "ResourcesCatalogConnectionIndependentRule",
     "ResourcesDescriptionPresentRule",
     "ResourcesIconsValidRule",
     "ResourcesInvalidCursorRule",
@@ -240,6 +247,7 @@ __all__ = (
     "ToolSchemaDialectReadinessRule",
     "ToolsAnnotationsPresentRule",
     "ToolsAtLeastOneRule",
+    "ToolsCatalogConnectionIndependentRule",
     "ToolsDescriptionPresentRule",
     "ToolsExecutionConsistentRule",
     "ToolsIconsValidRule",

--- a/mcpscore/rules/catalog_stability.py
+++ b/mcpscore/rules/catalog_stability.py
@@ -56,12 +56,8 @@ class CatalogConnectionIndependentRule(BaseRule):
                 else f"❌ {self.surface_label} varies across client connections"
             ),
             details={
+                **probe.details,
                 "spec": self.spec_url,
-                "first_count": probe.details.get("first_count"),
-                "second_count": probe.details.get("second_count"),
-                "only_first": probe.details.get("only_first", []),
-                "only_second": probe.details.get("only_second", []),
-                "differences_truncated": probe.details.get("differences_truncated", False),
             },
         )
 

--- a/mcpscore/rules/catalog_stability.py
+++ b/mcpscore/rules/catalog_stability.py
@@ -1,0 +1,120 @@
+"""Rules requiring modern catalogs to remain stable across connections."""
+
+from typing import ClassVar
+
+from mcpscore.probes import (
+    PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+    PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+    PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+    ProbeOutcome,
+)
+
+from .base import (
+    SKIP_REASON_INSUFFICIENT_DATA,
+    SKIP_REASON_NOT_APPLICABLE,
+    AuditData,
+    BaseRule,
+    RuleResult,
+    RuleSeverity,
+)
+from .registry import register_rule
+
+
+class CatalogConnectionIndependentRule(BaseRule):
+    """Require one catalog set for the same authorization across connections."""
+
+    min_spec_version = "2026-07-28"
+    uses_modern_probe_evidence = True
+    probe_id: ClassVar[str]
+    surface_label: ClassVar[str]
+    spec_url: ClassVar[str]
+
+    @property
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity.HIGH
+
+    def skip_reason(self, audit_data: AuditData) -> str | None:
+        """Skip absent catalog capabilities and incomplete comparisons."""
+        probe = (audit_data.probes or {}).get(self.probe_id)
+        if probe is None or probe.outcome is ProbeOutcome.ERROR:
+            return SKIP_REASON_INSUFFICIENT_DATA
+        if probe.outcome is ProbeOutcome.NOT_APPLICABLE:
+            return SKIP_REASON_NOT_APPLICABLE
+        return None
+
+    def check(self, audit_data: AuditData) -> RuleResult:
+        """Report whether two independent connections returned one identity set."""
+        probe = (audit_data.probes or {})[self.probe_id]
+        passed = probe.outcome is ProbeOutcome.SUPPORTED
+        return RuleResult(
+            rule_name=self.rule_name,
+            severity=self.severity,
+            passed=passed,
+            message=(
+                f"✅ {self.surface_label} is independent of the client connection"
+                if passed
+                else f"❌ {self.surface_label} varies across client connections"
+            ),
+            details={
+                "spec": self.spec_url,
+                "first_count": probe.details.get("first_count"),
+                "second_count": probe.details.get("second_count"),
+                "only_first": probe.details.get("only_first", []),
+                "only_second": probe.details.get("only_second", []),
+                "differences_truncated": probe.details.get("differences_truncated", False),
+            },
+        )
+
+
+@register_rule
+class ToolsCatalogConnectionIndependentRule(CatalogConnectionIndependentRule):
+    """Require the tools catalog to remain stable across connections."""
+
+    rule_id = "tools_catalog_connection_independent"
+    basis = "MCP 2026-07-28 Tools §Capabilities (tool set MUST NOT vary per-connection)"
+    group_name = "pagination"
+    group_order = 9
+    rule_order = 6
+    probe_id = PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT
+    surface_label = "Tools catalog"
+    spec_url = "https://modelcontextprotocol.io/specification/2026-07-28/server/tools#capabilities"
+
+    @property
+    def rule_name(self) -> str:
+        return "Tools Catalog Connection Independent"
+
+
+@register_rule
+class ResourcesCatalogConnectionIndependentRule(CatalogConnectionIndependentRule):
+    """Require the resources catalog to remain stable across connections."""
+
+    rule_id = "resources_catalog_connection_independent"
+    basis = "MCP 2026-07-28 Resources §Capabilities (resource set MUST NOT vary per-connection)"
+    group_name = "pagination"
+    group_order = 9
+    rule_order = 7
+    probe_id = PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT
+    surface_label = "Resources catalog"
+    spec_url = "https://modelcontextprotocol.io/specification/2026-07-28/server/resources#capabilities"
+
+    @property
+    def rule_name(self) -> str:
+        return "Resources Catalog Connection Independent"
+
+
+@register_rule
+class PromptsCatalogConnectionIndependentRule(CatalogConnectionIndependentRule):
+    """Require the prompts catalog to remain stable across connections."""
+
+    rule_id = "prompts_catalog_connection_independent"
+    basis = "MCP 2026-07-28 Prompts §Capabilities (prompt set MUST NOT vary per-connection)"
+    group_name = "pagination"
+    group_order = 9
+    rule_order = 8
+    probe_id = PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT
+    surface_label = "Prompts catalog"
+    spec_url = "https://modelcontextprotocol.io/specification/2026-07-28/server/prompts#capabilities"
+
+    @property
+    def rule_name(self) -> str:
+        return "Prompts Catalog Connection Independent"

--- a/tests/test_catalog_stability_rules.py
+++ b/tests/test_catalog_stability_rules.py
@@ -1,0 +1,103 @@
+"""Tests for catalog connection-independence rules."""
+
+import pytest
+
+from mcpscore.probes import (
+    PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+    PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+    PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+    ProbeOutcome,
+    ProbeResult,
+)
+from mcpscore.rules import AuditData, RuleSeverity
+from mcpscore.rules.base import SKIP_REASON_INSUFFICIENT_DATA, SKIP_REASON_NOT_APPLICABLE
+from mcpscore.rules.catalog_stability import (
+    PromptsCatalogConnectionIndependentRule,
+    ResourcesCatalogConnectionIndependentRule,
+    ToolsCatalogConnectionIndependentRule,
+)
+
+RULES = (
+    (ToolsCatalogConnectionIndependentRule, PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT, "Tools"),
+    (
+        ResourcesCatalogConnectionIndependentRule,
+        PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+        "Resources",
+    ),
+    (PromptsCatalogConnectionIndependentRule, PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT, "Prompts"),
+)
+
+
+@pytest.mark.parametrize(("rule_cls", "probe_id", "surface"), RULES)
+def test_connection_independence_rule_passes_equal_catalogs(rule_cls, probe_id, surface):
+    probe = ProbeResult(
+        probe_id,
+        ProbeOutcome.SUPPORTED,
+        {
+            "first_count": 2,
+            "second_count": 2,
+            "only_first": [],
+            "only_second": [],
+            "differences_truncated": False,
+        },
+    )
+    rule = rule_cls()
+
+    assert rule.skip_reason(AuditData(probes={probe_id: probe})) is None
+    result = rule.check(AuditData(probes={probe_id: probe}))
+
+    assert result.passed
+    assert result.severity is RuleSeverity.HIGH
+    assert surface in result.message
+    assert result.details["first_count"] == 2
+    assert result.details["spec"].startswith("https://modelcontextprotocol.io/specification/2026-07-28/")
+
+
+@pytest.mark.parametrize(("rule_cls", "probe_id", "surface"), RULES)
+def test_connection_independence_rule_fails_and_reports_bounded_differences(rule_cls, probe_id, surface):
+    probe = ProbeResult(
+        probe_id,
+        ProbeOutcome.UNSUPPORTED,
+        {
+            "first_count": 1,
+            "second_count": 1,
+            "only_first": ["before"],
+            "only_second": ["after"],
+            "differences_truncated": False,
+        },
+    )
+
+    result = rule_cls().check(AuditData(probes={probe_id: probe}))
+
+    assert not result.passed
+    assert surface in result.message
+    assert result.details["only_first"] == ["before"]
+    assert result.details["only_second"] == ["after"]
+
+
+@pytest.mark.parametrize(("rule_cls", "probe_id", "surface"), RULES)
+def test_connection_independence_rule_skips_unobservable_comparisons(rule_cls, probe_id, surface):
+    del surface
+    rule = rule_cls()
+
+    assert rule.skip_reason(AuditData()) == SKIP_REASON_INSUFFICIENT_DATA
+    assert (
+        rule.skip_reason(
+            AuditData(probes={probe_id: ProbeResult(probe_id, ProbeOutcome.ERROR, {"exception": "TimeoutError"})})
+        )
+        == SKIP_REASON_INSUFFICIENT_DATA
+    )
+    assert (
+        rule.skip_reason(AuditData(probes={probe_id: ProbeResult(probe_id, ProbeOutcome.NOT_APPLICABLE)}))
+        == SKIP_REASON_NOT_APPLICABLE
+    )
+
+
+@pytest.mark.parametrize(("rule_cls", "probe_id", "surface"), RULES)
+def test_connection_independence_rule_is_modern_only(rule_cls, probe_id, surface):
+    del probe_id, surface
+    rule = rule_cls()
+
+    assert not rule.applies_to("2025-11-25")
+    assert rule.applies_to("2026-07-28")
+    assert rule.uses_modern_probe_evidence

--- a/tests/test_catalog_stability_rules.py
+++ b/tests/test_catalog_stability_rules.py
@@ -75,6 +75,28 @@ def test_connection_independence_rule_fails_and_reports_bounded_differences(rule
     assert result.details["only_second"] == ["after"]
 
 
+def test_connection_independence_rule_preserves_capability_mismatch_evidence():
+    probe = ProbeResult(
+        PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+        ProbeOutcome.UNSUPPORTED,
+        {
+            "first_declares_capability": True,
+            "second_declares_capability": False,
+            "reason": "tools capability varies across client connections",
+        },
+    )
+
+    result = ToolsCatalogConnectionIndependentRule().check(
+        AuditData(probes={PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT: probe})
+    )
+
+    assert not result.passed
+    assert result.details is not None
+    assert result.details["first_declares_capability"] is True
+    assert result.details["second_declares_capability"] is False
+    assert result.details["reason"] == "tools capability varies across client connections"
+
+
 @pytest.mark.parametrize(("rule_cls", "probe_id", "surface"), RULES)
 def test_connection_independence_rule_skips_unobservable_comparisons(rule_cls, probe_id, surface):
     del surface

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -27,13 +27,16 @@ from mcpscore.probes import (
     PROBE_ORIGIN_VALIDATION,
     PROBE_PAGINATION_CACHE_SCOPE,
     PROBE_PROMPT_NAME_HEADER_MISMATCH,
+    PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
     PROBE_PROMPTS_INVALID_CURSOR,
     PROBE_REMOVED_METHOD,
     PROBE_RESOURCE_NAME_HEADER_MISMATCH,
     PROBE_RESOURCE_TEMPLATES_INVALID_CURSOR,
+    PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
     PROBE_RESOURCES_INVALID_CURSOR,
     PROBE_SESSION_ID_ECHO,
     PROBE_STATELESS_LIST,
+    PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
     PROBE_TOOLS_INVALID_CURSOR,
     PROBE_UNAUTHENTICATED,
     PROBE_UNKNOWN_METHOD,
@@ -43,6 +46,7 @@ from mcpscore.probes import (
     ProbeResult,
     _fetch_auth_server_metadata,
     _HttpTarget,
+    _probe_catalog_connection_independence,
     _traverse_cache_scope_surface,
     _well_known_urls,
     not_applicable_results,
@@ -178,16 +182,21 @@ def _client(handler) -> httpx2.AsyncClient:
 
 
 async def _run(handler) -> dict[str, ProbeResult]:
-    async with _client(handler) as client:
-        return await run_all_probes(URL, client=client)
+    async with _client(handler) as client, _client(handler) as fresh_client:
+        return await run_all_probes(URL, client=client, fresh_client=fresh_client)
 
 
 async def test_modern_server_supports_all_probed_behaviors():
     results = await _run(_modern_server_handler)
 
     assert set(results) == set(PROBE_IDS)
+    absent_catalogs = {
+        PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+        PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+    }
     for probe_id in PROBE_IDS:
-        assert results[probe_id].outcome is ProbeOutcome.SUPPORTED, probe_id
+        expected = ProbeOutcome.NOT_APPLICABLE if probe_id in absent_catalogs else ProbeOutcome.SUPPORTED
+        assert results[probe_id].outcome is expected, probe_id
 
     discover = results[PROBE_DISCOVER].details
     assert discover["supported_versions"] == ["2025-11-25", "2026-07-28"]
@@ -1619,9 +1628,35 @@ async def test_run_all_probes_creates_its_own_client_when_none_given(monkeypatch
 
     monkeypatch.setattr(probes_module, "_HTTP_PROBES", {pid: make_stub(pid) for pid in PROBE_IDS})
 
+    async def stub_connection_probes(first: object, second: object) -> dict[str, ProbeResult]:
+        del first, second
+        return {
+            probe_id: ProbeResult(probe_id, ProbeOutcome.SUPPORTED, {"stubbed": True})
+            for probe_id in (
+                PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+                PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+                PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+            )
+        }
+
+    monkeypatch.setattr(probes_module, "_probe_catalog_connection_independence", stub_connection_probes)
+
     results = await run_all_probes(URL)  # no client injected -> own-client branch
 
     assert set(results) == set(PROBE_IDS)
+
+
+async def test_one_injected_client_cannot_manufacture_connection_independence():
+    async with _client(_modern_server_handler) as client:
+        results = await run_all_probes(URL, client=client)
+
+    for probe_id in (
+        PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+        PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+        PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+    ):
+        assert results[probe_id].outcome is ProbeOutcome.NOT_APPLICABLE
+        assert results[probe_id].details["reason"] == "a second independent probe client was not supplied"
 
 
 class TestAnonymousProbes:
@@ -1726,3 +1761,101 @@ class TestAnonymousProbes:
 
         assert seen_auth["get"] is None
         assert results[PROBE_AUTH_METADATA].outcome is ProbeOutcome.SUPPORTED
+
+
+def _catalog_handler(catalogs: dict[str, list[dict]], *, malformed: str | None = None):
+    """Build a modern catalog handler for one independent client."""
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        body = json.loads(request.content)
+        request_id = body["id"]
+        method = body["method"]
+        if method == "server/discover":
+            return _rpc_result(
+                request_id,
+                {"capabilities": {"tools": {}, "resources": {}, "prompts": {}}},
+            )
+        result_keys = {
+            "tools/list": "tools",
+            "resources/list": "resources",
+            "prompts/list": "prompts",
+        }
+        item_key = result_keys[method]
+        if malformed == item_key:
+            return _rpc_result(request_id, {})
+        return _rpc_result(request_id, {item_key: catalogs[item_key]})
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_catalog_connection_probe_compares_identity_sets_without_order():
+    first_catalogs = {
+        "tools": [{"name": "search"}, {"name": "read"}],
+        "resources": [{"uri": "file:///a"}, {"uri": "file:///b"}],
+        "prompts": [{"name": "review"}, {"name": "summarize"}],
+    }
+    second_catalogs = {key: list(reversed(items)) for key, items in first_catalogs.items()}
+
+    async with (
+        _client(_catalog_handler(first_catalogs)) as first,
+        _client(_catalog_handler(second_catalogs)) as second,
+    ):
+        results = await _probe_catalog_connection_independence(
+            _HttpTarget(first, URL),
+            _HttpTarget(second, URL),
+        )
+
+    assert all(result.outcome is ProbeOutcome.SUPPORTED for result in results.values())
+    assert results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT].details["first_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_catalog_connection_probe_reports_surface_specific_differences():
+    first_catalogs = {
+        "tools": [{"name": "search"}],
+        "resources": [{"uri": "file:///a"}],
+        "prompts": [{"name": "review"}],
+    }
+    second_catalogs = {
+        **first_catalogs,
+        "tools": [{"name": "replace"}],
+    }
+
+    async with (
+        _client(_catalog_handler(first_catalogs)) as first,
+        _client(_catalog_handler(second_catalogs)) as second,
+    ):
+        results = await _probe_catalog_connection_independence(
+            _HttpTarget(first, URL),
+            _HttpTarget(second, URL),
+        )
+
+    tools = results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT]
+    assert tools.outcome is ProbeOutcome.UNSUPPORTED
+    assert tools.details["only_first"] == ["search"]
+    assert tools.details["only_second"] == ["replace"]
+    assert results[PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED
+    assert results[PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED
+
+
+@pytest.mark.asyncio
+async def test_catalog_connection_probe_errors_only_unobservable_surface():
+    catalogs = {
+        "tools": [{"name": "search"}],
+        "resources": [{"uri": "file:///a"}],
+        "prompts": [{"name": "review"}],
+    }
+
+    async with (
+        _client(_catalog_handler(catalogs)) as first,
+        _client(_catalog_handler(catalogs, malformed="resources")) as second,
+    ):
+        results = await _probe_catalog_connection_independence(
+            _HttpTarget(first, URL),
+            _HttpTarget(second, URL),
+        )
+
+    assert results[PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.ERROR
+    assert results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED
+    assert results[PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1674,6 +1674,43 @@ async def test_same_injected_client_cannot_manufacture_connection_independence()
         assert results[probe_id].details["reason"] == "a second independent probe client was not supplied"
 
 
+async def test_catalog_comparison_runs_before_single_probes_can_mutate_client_cookies(monkeypatch):
+    from mcpscore import probes as probes_module
+
+    def make_single_probe(probe_id: str):
+        async def single_probe(target: _HttpTarget) -> ProbeResult:
+            target.client.cookies.set("probe-state", "mutated")
+            return ProbeResult(probe_id, ProbeOutcome.SUPPORTED)
+
+        return single_probe
+
+    monkeypatch.setattr(
+        probes_module,
+        "_HTTP_PROBES",
+        {probe_id: make_single_probe(probe_id) for probe_id in probes_module._SINGLE_TARGET_PROBE_IDS},
+    )
+
+    async def compare(first: _HttpTarget, second: _HttpTarget) -> dict[str, ProbeResult]:
+        assert not first.client.cookies
+        assert not second.client.cookies
+        return {
+            probe_id: ProbeResult(probe_id, ProbeOutcome.SUPPORTED)
+            for probe_id in (
+                PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+                PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+                PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+            )
+        }
+
+    monkeypatch.setattr(probes_module, "_probe_catalog_connection_independence", compare)
+    async with _client(_modern_server_handler) as client, _client(_modern_server_handler) as fresh_client:
+        results = await run_all_probes(URL, client=client, fresh_client=fresh_client)
+
+    assert set(results) == set(PROBE_IDS)
+    assert client.cookies.get("probe-state") == "mutated"
+    assert not fresh_client.cookies
+
+
 async def test_run_all_probes_preserves_positional_headers_parameter():
     async with _client(_modern_server_handler) as client:
         results = await run_all_probes(URL, client, {"X-Api-Key": "ignored-for-injected-client"})

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1661,6 +1661,13 @@ async def test_one_injected_client_cannot_manufacture_connection_independence():
         assert results[probe_id].details["reason"] == "a second independent probe client was not supplied"
 
 
+async def test_run_all_probes_preserves_positional_headers_parameter():
+    async with _client(_modern_server_handler) as client:
+        results = await run_all_probes(URL, client, {"X-Api-Key": "ignored-for-injected-client"})
+
+    assert set(results) == set(PROBE_IDS)
+
+
 class TestAnonymousProbes:
     """The unauthenticated and metadata probes must not send a caller's bearer."""
 
@@ -1851,6 +1858,44 @@ async def test_catalog_connection_probe_reports_surface_specific_differences():
 
 
 @pytest.mark.asyncio
+async def test_catalog_connection_probe_compares_complete_paginated_catalogs():
+    requested_cursors: list[str | None] = []
+
+    def paginated_handler(last_tool: str):
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            body = json.loads(request.content)
+            request_id = body["id"]
+            if body["method"] == "server/discover":
+                return _rpc_result(request_id, {"capabilities": {"tools": {}}})
+            cursor = body.get("params", {}).get("cursor")
+            requested_cursors.append(cursor)
+            if cursor is None:
+                return _rpc_result(
+                    request_id,
+                    {"tools": [{"name": "shared"}], "nextCursor": "page-2"},
+                )
+            assert cursor == "page-2"
+            return _rpc_result(request_id, {"tools": [{"name": last_tool}]})
+
+        return handler
+
+    async with (
+        _client(paginated_handler("first-only")) as first,
+        _client(paginated_handler("second-only")) as second,
+    ):
+        results = await _probe_catalog_connection_independence(
+            _HttpTarget(first, URL),
+            _HttpTarget(second, URL),
+        )
+
+    tools = results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT]
+    assert tools.outcome is ProbeOutcome.UNSUPPORTED
+    assert tools.details["only_first"] == ["first-only"]
+    assert tools.details["only_second"] == ["second-only"]
+    assert requested_cursors.count("page-2") == 2
+
+
+@pytest.mark.asyncio
 async def test_catalog_connection_probe_detects_capability_difference():
     catalogs = {
         "tools": [{"name": "search"}],
@@ -1930,6 +1975,7 @@ async def test_catalog_connection_probe_cancels_failed_collection_sibling(monkey
             except asyncio.CancelledError:
                 sibling_cancelled.set()
                 raise
+            return frozenset()
 
         monkeypatch.setattr(probes_module, "_collect_catalog_identities", collect)
         results = await _probe_catalog_connection_independence(first, second)

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1661,6 +1661,19 @@ async def test_one_injected_client_cannot_manufacture_connection_independence():
         assert results[probe_id].details["reason"] == "a second independent probe client was not supplied"
 
 
+async def test_same_injected_client_cannot_manufacture_connection_independence():
+    async with _client(_modern_server_handler) as client:
+        results = await run_all_probes(URL, client=client, fresh_client=client)
+
+    for probe_id in (
+        PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT,
+        PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT,
+        PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT,
+    ):
+        assert results[probe_id].outcome is ProbeOutcome.NOT_APPLICABLE
+        assert results[probe_id].details["reason"] == "a second independent probe client was not supplied"
+
+
 async def test_run_all_probes_preserves_positional_headers_parameter():
     async with _client(_modern_server_handler) as client:
         results = await run_all_probes(URL, client, {"X-Api-Key": "ignored-for-injected-client"})

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,5 +1,6 @@
 """Tests for the sessionless probe layer."""
 
+import asyncio
 import json
 
 import httpx2
@@ -44,6 +45,7 @@ from mcpscore.probes import (
     UNKNOWN_METHOD_PREFIX,
     ProbeOutcome,
     ProbeResult,
+    _collect_catalog_identities,
     _fetch_auth_server_metadata,
     _HttpTarget,
     _probe_catalog_connection_independence,
@@ -1763,7 +1765,12 @@ class TestAnonymousProbes:
         assert results[PROBE_AUTH_METADATA].outcome is ProbeOutcome.SUPPORTED
 
 
-def _catalog_handler(catalogs: dict[str, list[dict]], *, malformed: str | None = None):
+def _catalog_handler(
+    catalogs: dict[str, list[dict]],
+    *,
+    malformed: str | None = None,
+    capabilities: dict | None = None,
+):
     """Build a modern catalog handler for one independent client."""
 
     def handler(request: httpx2.Request) -> httpx2.Response:
@@ -1773,7 +1780,11 @@ def _catalog_handler(catalogs: dict[str, list[dict]], *, malformed: str | None =
         if method == "server/discover":
             return _rpc_result(
                 request_id,
-                {"capabilities": {"tools": {}, "resources": {}, "prompts": {}}},
+                {
+                    "capabilities": capabilities
+                    if capabilities is not None
+                    else {"tools": {}, "resources": {}, "prompts": {}}
+                },
             )
         result_keys = {
             "tools/list": "tools",
@@ -1840,6 +1851,95 @@ async def test_catalog_connection_probe_reports_surface_specific_differences():
 
 
 @pytest.mark.asyncio
+async def test_catalog_connection_probe_detects_capability_difference():
+    catalogs = {
+        "tools": [{"name": "search"}],
+        "resources": [{"uri": "file:///a"}],
+        "prompts": [{"name": "review"}],
+    }
+
+    async with (
+        _client(_catalog_handler(catalogs)) as first,
+        _client(_catalog_handler(catalogs, capabilities={"resources": {}, "prompts": {}})) as second,
+    ):
+        results = await _probe_catalog_connection_independence(
+            _HttpTarget(first, URL),
+            _HttpTarget(second, URL),
+        )
+
+    tools = results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT]
+    assert tools.outcome is ProbeOutcome.UNSUPPORTED
+    assert tools.details["first_declares_capability"] is True
+    assert tools.details["second_declares_capability"] is False
+    assert results[PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED
+
+
+@pytest.mark.asyncio
+async def test_catalog_connection_probe_runs_surfaces_sequentially(monkeypatch):
+    from mcpscore import probes as probes_module
+
+    catalogs = {"tools": [], "resources": [], "prompts": []}
+    active_methods: list[str] = []
+
+    async def collect(target, *, method, **kwargs):
+        del target, kwargs
+        assert not active_methods or set(active_methods) == {method}
+        active_methods.append(method)
+        await asyncio.sleep(0)
+        active_methods.remove(method)
+        return frozenset()
+
+    monkeypatch.setattr(probes_module, "_collect_catalog_identities", collect)
+    async with (
+        _client(_catalog_handler(catalogs)) as first,
+        _client(_catalog_handler(catalogs)) as second,
+    ):
+        results = await _probe_catalog_connection_independence(
+            _HttpTarget(first, URL),
+            _HttpTarget(second, URL),
+        )
+
+    assert all(result.outcome is ProbeOutcome.SUPPORTED for result in results.values())
+
+
+@pytest.mark.asyncio
+async def test_catalog_connection_probe_cancels_failed_collection_sibling(monkeypatch):
+    from mcpscore import probes as probes_module
+
+    catalogs = {"tools": [], "resources": [], "prompts": []}
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+
+    async with (
+        _client(_catalog_handler(catalogs)) as first_client,
+        _client(_catalog_handler(catalogs)) as second_client,
+    ):
+        first = _HttpTarget(first_client, URL)
+        second = _HttpTarget(second_client, URL)
+
+        async def collect(target, *, method, **kwargs):
+            del kwargs
+            if method != "tools/list":
+                return frozenset()
+            if target is first:
+                await sibling_started.wait()
+                raise RuntimeError("first collection failed")
+            try:
+                sibling_started.set()
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+
+        monkeypatch.setattr(probes_module, "_collect_catalog_identities", collect)
+        results = await _probe_catalog_connection_independence(first, second)
+
+    assert results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.ERROR
+    assert sibling_cancelled.is_set()
+    assert results[PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED
+
+
+@pytest.mark.asyncio
 async def test_catalog_connection_probe_errors_only_unobservable_surface():
     catalogs = {
         "tools": [{"name": "search"}],
@@ -1859,3 +1959,44 @@ async def test_catalog_connection_probe_errors_only_unobservable_surface():
     assert results[PROBE_RESOURCES_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.ERROR
     assert results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED
     assert results[PROBE_PROMPTS_CATALOG_CONNECTION_INDEPENDENT].outcome is ProbeOutcome.SUPPORTED
+
+
+@pytest.mark.asyncio
+async def test_catalog_collection_stops_when_total_deadline_is_exhausted(monkeypatch):
+    from mcpscore import probes as probes_module
+
+    # A pre-exhausted total budget must stop before touching the target.
+    monkeypatch.setattr(probes_module, "PAGINATION_PROBE_TIMEOUT_S", -1.0)
+
+    async with _client(lambda request: pytest.fail(f"unexpected request: {request}")) as client:
+        with pytest.raises(TimeoutError):
+            await _collect_catalog_identities(
+                _HttpTarget(client, URL),
+                target_version="2026-07-28",
+                method="tools/list",
+                item_key="tools",
+                request_id_base=1,
+            )
+
+
+@pytest.mark.asyncio
+async def test_catalog_connection_probe_rejects_items_without_identity():
+    catalogs = {
+        "tools": [{}],
+        "resources": [{"uri": "file:///a"}],
+        "prompts": [{"name": "review"}],
+    }
+
+    async with (
+        _client(_catalog_handler(catalogs)) as first,
+        _client(_catalog_handler(catalogs)) as second,
+    ):
+        results = await _probe_catalog_connection_independence(
+            _HttpTarget(first, URL),
+            _HttpTarget(second, URL),
+        )
+
+    tools = results[PROBE_TOOLS_CATALOG_CONNECTION_INDEPENDENT]
+    assert tools.outcome is ProbeOutcome.ERROR
+    assert tools.details["exception"] == "ValueError"
+    assert tools.details["reason"] == "tools/list returned an item without a valid name"

--- a/tests/test_stdio_probes.py
+++ b/tests/test_stdio_probes.py
@@ -150,12 +150,13 @@ class TestModernStdioServer:
         assert auditor.audit_data.probes[PROBE_DISCOVER].outcome is ProbeOutcome.SUPPORTED
         assert auditor.era is Era.DUAL
 
-    async def test_probe_suite_launches_one_sibling_process(self, monkeypatch):
-        """Modern requests are stateless, but do not require one process each.
+    async def test_probe_suite_launches_two_sibling_processes(self, monkeypatch):
+        """Modern requests share one process except the fresh-connection comparison.
 
         Starting the audited command once per probe can repeat expensive or
-        externally visible startup behavior. The suite needs one connection
-        without a legacy handshake, not independent processes per probe.
+        externally visible startup behavior. The suite needs one primary
+        no-handshake connection plus one independent comparison connection,
+        not an independent process for every probe.
         """
         from mcpscore import probes as probes_module
 
@@ -176,7 +177,7 @@ class TestModernStdioServer:
 
         results = await run_stdio_probes(_params())
 
-        assert launches == 1
+        assert launches == 2
         assert results[PROBE_DISCOVER].outcome is ProbeOutcome.SUPPORTED
 
 


### PR DESCRIPTION
 Modern servers are checked that the complete tools, resources, and prompts identity sets do not vary
  across two independent connections carrying the same authorization context.
  Comparisons ignore ordering, traverse pagination completely, bound reported
  differences, and skip rather than fail when either observation is incomplete.
  Each requirement is HIGH and scoped to MCP 2026-07-28, where catalog sets
  MUST NOT vary per connection.