### PR TITLE
Smoke mode: --smoke invokes your own server's tools after the audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,10 @@
   for missing observations.
 - **Probes must never invoke `tools/call`** against a target server — audits must be
   free of tool side effects. Probes never raise; network failures are
-  `ProbeOutcome.ERROR` data.
+  `ProbeOutcome.ERROR` data. The ONE surface allowed to call tools is the opt-in
+  `--smoke` mode (`smoke.py`, CLI-only): its results never enter the score, it never
+  runs from probes/rules or the web service, and its safety default (readOnlyHint-only
+  unless `--call-all`) must not be weakened.
 - `docs/rules.mdx` is generated — edit `scripts/generate_rules_doc.py` and run
   `make docs-rules`, never the file itself. CI fails on drift.
 - Docs are MDX served by Mintlify from `docs/` — pages need frontmatter; validate with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `readOnlyHint: true` are called; `--call-all` is the explicit consent for
   the rest — so unannotated tools visibly cost smoke coverage. Argument
   synthesis is deterministic (defaults / const / examples / enum-first / type
-  zero-values — never an LLM). Verdicts are pass/fail/skip, and a tool whose
+  zero-values — never an LLM) and tolerates broken schemas: malformed
+  non-string `required` entries are ignored rather than aborting the smoke
+  run. Verdicts are pass/fail/skip, and a tool whose
   upstream is down reports as *skip*: someone else's outage should not fail
   the build. Results land in a new `smoke` section of the `--json` report and
   never touch `score`/`max_score`; any smoke failure exits with the new code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Smoke mode: `--smoke` invokes your own server's tools after the audit.**
+  The audit itself still never calls `tools/call`; smoke mode is the separate,
+  opt-in surface for developers testing a server they operate (typically in
+  CI). It verifies what listing alone cannot: that a declared `outputSchema`
+  is honored by real `structuredContent` (per MCP 2025-11-25 Tools §Output
+  Schema, a MUST), that schema-invalid arguments are rejected with an
+  `isError` result or a protocol error, and that unknown tool names get a
+  protocol error rather than a result. By default only tools annotated
+  `readOnlyHint: true` are called; `--call-all` is the explicit consent for
+  the rest — so unannotated tools visibly cost smoke coverage. Argument
+  synthesis is deterministic (defaults / const / examples / enum-first / type
+  zero-values — never an LLM). Verdicts are pass/fail/skip, and a tool whose
+  upstream is down reports as *skip*: someone else's outage should not fail
+  the build. Results land in a new `smoke` section of the `--json` report and
+  never touch `score`/`max_score`; any smoke failure exits with the new code
+  **4** (a failed `--fail-under` gate still takes precedence with 3). The
+  web service deliberately has no smoke mode — CLI (and the GitHub Action,
+  in a coming release) only.
+
 - **Modern-only stdio servers are now fully auditable.** When a local server
   rejects the legacy `initialize` handshake but answers MCP 2026-07-28
   stateless requests, mcpscore retains its resolved launch command, probes it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Schema, a MUST — an explicit empty `{}` schema still requires the field to
   be present), that schema-invalid arguments are rejected with an `isError`
   result or a protocol error, and that unknown tool names get a JSON-RPC
-  error rather than a result (any error code counts as a rejection except a
-  hang, a closed connection, or `-32603` internal error — those are crashes,
-  not rejections). The probed unknown name is derived deterministically to be
+  error rather than a result. For both rejection checks, any error code
+  counts as a rejection except a hang, a closed connection, or `-32603`
+  internal error — those are crashes, not rejections.
+  The probed unknown name is derived deterministically to be
   provably absent from the server's own catalog; when the tool listing is
   missing or incomplete, that check skips rather than risk invoking a real
   tool. By default only tools annotated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opt-in surface for developers testing a server they operate (typically in
   CI). It verifies what listing alone cannot: that a declared `outputSchema`
   is honored by real `structuredContent` (per MCP 2025-11-25 Tools §Output
-  Schema, a MUST), that schema-invalid arguments are rejected with an
-  `isError` result or a protocol error, and that unknown tool names get a
-  protocol error rather than a result. By default only tools annotated
+  Schema, a MUST — an explicit empty `{}` schema still requires the field to
+  be present), that schema-invalid arguments are rejected with an `isError`
+  result or a protocol error, and that unknown tool names get a JSON-RPC
+  error rather than a result (any error code counts as a rejection except a
+  hang, a closed connection, or `-32603` internal error — those are crashes,
+  not rejections). The probed unknown name is derived deterministically to be
+  provably absent from the server's own catalog; when the tool listing is
+  missing or incomplete, that check skips rather than risk invoking a real
+  tool. By default only tools annotated
   `readOnlyHint: true` are called; `--call-all` is the explicit consent for
   the rest — so unannotated tools visibly cost smoke coverage. Argument
   synthesis is deterministic (defaults / const / examples / enum-first / type

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The final score is reported as `earned/maximum` — higher means a better-qualit
 - **Real handshake verification**: A connection only counts once the server completes the MCP `initialize` handshake — pointing it at a non-MCP endpoint fails cleanly
 - **Any-language**: Audits MCP servers in any language via STDIO — `.py`/`.js` files directly, everything else (Go, Java, C#, Rust, ...) via `--stdio <command>`
 - **Package audits**: `--package npm:<name>` / `pypi:<name>` scores how a server is *published* — resolves, versioned, not withdrawn, source-linked, licensed, described — from registry metadata alone. The package is never downloaded and never executed
+- **Smoke mode**: `--smoke` invokes your *own* server's tools after the audit (only `readOnlyHint: true` tools unless `--call-all`) and verifies what listing alone cannot — declared output schemas are honored, schema-invalid arguments are rejected, unknown tool names are rejected. Reported outside the score; any smoke failure exits with its own code (4) so CI can gate on it independently
 - **Severity-based reporting**: Rules categorized as CRITICAL, HIGH, MEDIUM, or LOW
 - **Library-friendly**: Fully typed (`py.typed`); use `MCPClient` + `MCPAuditor` programmatically
 
@@ -129,6 +130,12 @@ mcpscore path/to/your/server.py --json > report.json
 
 # Gate any CI on a score threshold: exit code 3 when the percentage is below it
 mcpscore https://example.com/mcp --fail-under 80
+
+# Smoke-test YOUR OWN server in CI: audits as usual, then actually calls its
+# tools — by default only those annotated readOnlyHint: true. Exit code 4 on
+# any smoke failure; smoke results never change the score.
+mcpscore path/to/your/server.py --smoke
+mcpscore path/to/your/server.py --smoke --call-all   # consent to call every tool
 ```
 
 ### Example output

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,6 +28,7 @@
       {
         "group": "Use in CI",
         "pages": [
+          "smoke-mode",
           "github-action"
         ]
       },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -114,6 +114,9 @@ Readiness for MCP 2026-07-28: 3/13 (informative — not part of the main score; 
   <Card title="Authenticated Servers" icon="lock" href="/authenticated-servers">
     Audit behind OAuth and API keys — or score the observable surface
   </Card>
+  <Card title="Smoke Mode" icon="vial" href="/smoke-mode">
+    Verify after every change that your server still works — its tools actually run
+  </Card>
   <Card title="GitHub Action" icon="github" href="/github-action">
     Gate pull requests on quality, with a report comment
   </Card>

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -66,9 +66,9 @@ unobserved. A dedicated presence rule can still judge whether a complete catalog
    latest spec revision's stateless lifecycle. Probes are read-only by design:
    **an audit never invokes `tools/call` against your server**, so it can never
    trigger tool side effects. (The one deliberate exception is the CLI's opt-in
-   `--smoke` flag, which exists for developers to smoke-test their *own* server
-   in CI by actually calling its tools; smoke results are reported separately
-   and never enter the score. The web service has no such mode.)
+   [smoke mode](/smoke-mode), which exists for developers to smoke-test their
+   *own* server in CI by actually calling its tools; smoke results are reported
+   separately and never enter the score. The web service has no such mode.)
 
    Several probes are *deliberately* malformed or security-relevant, because the
    spec defines how a server must answer them. Expect an audit to send a foreign
@@ -209,10 +209,11 @@ safely from the outside is not yet possible:
   accumulation) — not observable from a server audit.
 - **Tool behavior** — the audit never calls your tools, so the *score* cannot
   judge what they do, only how they are described and typed. The CLI's opt-in
-  `--smoke` flag exists for exactly this gap on your own server: it invokes
-  tools (only `readOnlyHint: true` ones unless `--call-all`) and verifies
-  declared output schemas, invalid-argument rejection, and unknown-tool
-  rejection — reported outside the score, with its own exit code (4).
+  [smoke mode](/smoke-mode) exists for exactly this gap on your own server: it
+  invokes tools (only `readOnlyHint: true` ones unless `--call-all`) and
+  verifies declared output schemas, invalid-argument rejection, and
+  unknown-tool rejection — reported outside the score, with its own exit
+  code (4).
 
 ## Stability contract
 

--- a/docs/methodology.mdx
+++ b/docs/methodology.mdx
@@ -64,8 +64,11 @@ unobserved. A dedicated presence rule can still judge whether a complete catalog
 3. **Probe** — a set of sessionless requests observing
    behavior outside the negotiated session, e.g. whether the server also speaks the
    latest spec revision's stateless lifecycle. Probes are read-only by design:
-   **mcpscore never invokes `tools/call` against your server**, so an audit can never
-   trigger tool side effects.
+   **an audit never invokes `tools/call` against your server**, so it can never
+   trigger tool side effects. (The one deliberate exception is the CLI's opt-in
+   `--smoke` flag, which exists for developers to smoke-test their *own* server
+   in CI by actually calling its tools; smoke results are reported separately
+   and never enter the score. The web service has no such mode.)
 
    Several probes are *deliberately* malformed or security-relevant, because the
    spec defines how a server must answer them. Expect an audit to send a foreign
@@ -204,8 +207,12 @@ safely from the outside is not yet possible:
 - **Tasks and MCP Apps extensions** — they version independently of the core spec.
 - **Client-side OAuth obligations** (issuer validation, credential binding, scope
   accumulation) — not observable from a server audit.
-- **Tool behavior** — mcpscore never calls your tools, so it cannot judge what they
-  *do*, only how they are described and typed.
+- **Tool behavior** — the audit never calls your tools, so the *score* cannot
+  judge what they do, only how they are described and typed. The CLI's opt-in
+  `--smoke` flag exists for exactly this gap on your own server: it invokes
+  tools (only `readOnlyHint: true` ones unless `--call-all`) and verifies
+  declared output schemas, invalid-argument rejection, and unknown-tool
+  rejection — reported outside the score, with its own exit code (4).
 
 ## Stability contract
 

--- a/docs/smoke-mode.mdx
+++ b/docs/smoke-mode.mdx
@@ -1,0 +1,158 @@
+---
+title: "Smoke Mode"
+description: "Verify on every change that your MCP server still works — connects, lists, and its tools actually run — with one command in CI."
+icon: "vial"
+---
+
+You changed your server — a refactor, a dependency bump, a new tool. Does it
+still work? Not "does it compile": does an agent connecting right now get the
+tools you think you ship, with schemas that match what the handlers actually
+return, and sane errors when a call goes wrong? Every change can quietly
+break that contract, and nothing in a typical build pipeline notices —
+teams end up hand-rolling a bespoke MCP test client just to check their own
+server still responds.
+
+Smoke mode makes that check one command. `--smoke` runs the normal audit,
+then **actually calls your server's tools** over the same connection and
+verifies they behave:
+
+```bash
+# One CI step: does my server still work?
+mcpscore path/to/your/server.py --smoke
+
+# Any-language servers and deployed servers work the same way
+mcpscore --smoke --stdio ./my-go-server
+mcpscore https://your-server.example/mcp --smoke --token $TOKEN
+
+# Explicit consent to call every tool, not only read-only ones
+mcpscore path/to/your/server.py --smoke --call-all
+```
+
+One run answers three questions: *does it connect and speak MCP well?* (the
+audit and its score), *are the tools honestly described?* (schema checks),
+and *do the tools actually run and fail properly?* (the smoke calls).
+
+<Warning>
+  `--smoke` really invokes `tools/call` on the target. Use it only against
+  servers **you operate** and are willing to execute. For anyone else's
+  server, the ordinary audit is the right tool — it never calls tools.
+</Warning>
+
+## What it verifies on every run
+
+Every check verdict is **pass**, **fail**, or **skip** — skip meaning the
+check could not be exercised, never that the server failed it.
+
+| Check (`check_id`) | The regression it catches |
+|---|---|
+| `smoke_structured_content` | A handler drifted away from its declared `outputSchema`: every callable tool declaring one is invoked, and the result must carry `structuredContent` that conforms (a spec MUST). An explicitly empty `{}` schema still requires the field to be present. |
+| `smoke_invalid_arguments` | Input validation stopped working: each callable tool is invoked with deliberately schema-invalid arguments and must **reject** them — an `isError` tool result or a JSON-RPC error both count. Accepting them, hanging, or crashing fails. |
+| `smoke_unknown_tool` | Routing broke: `tools/call` on a provably nonexistent name must be rejected with a JSON-RPC error — not executed, and not an internal error. |
+
+For the two rejection checks, any JSON-RPC error code your server sends
+counts as a rejection **except** the three that are crashes wearing an
+error's clothes: a request timeout, a closed connection, and `-32603`
+internal error (the server tried to run the call and broke).
+
+## The safety model
+
+- **Only tools annotated `readOnlyHint: true` are called by default.** An
+  absent annotation defaults to *false* per the spec, so unannotated tools
+  are skipped, never called — and each skip is reported, which makes missing
+  annotations a visible cost.
+- **`--call-all` is the explicit second consent** for everything else. It is
+  never implied by another flag and has no environment-variable form.
+- **The unknown-tool probe cannot hit a real tool.** Its name is derived
+  deterministically to be absent from your server's own collected catalog;
+  if the tool listing failed or is incomplete, the check skips rather than
+  gamble on a name.
+- **Argument synthesis is deterministic and never an LLM** — sample values
+  come from the input schema itself (`default` → `const` → first example →
+  first enum entry → type zero-values), so the same server sees the same
+  calls on every run. Malformed schema fragments are tolerated rather than
+  aborting the run.
+
+## Outage semantics: skip, not fail
+
+A tool that returns an error result when called with valid synthesized
+arguments reports as **skip** — it may be rejecting the synthesized sample,
+or its upstream dependency may be down, and *someone else's outage should
+not fail your build*. Only behavior your server owns can fail a smoke check.
+
+## Gating CI on it
+
+A smoke failure exits with its **own code, 4**, distinct from the score
+gate's 3 — so CI can tell "the server scored badly" apart from "the tools
+are broken":
+
+```bash
+# Fail the build on score OR broken tools, distinguishably
+mcpscore ./server.py --fail-under 80 --smoke
+# exit 0: score ≥ 80 and every smoke check passed or skipped
+# exit 3: score below 80 (takes precedence if both gates fail)
+# exit 4: score fine, but a smoke check failed
+```
+
+The full exit-code contract is in the
+[stability contract](/stability#cli-interface). Skips never gate: a server
+with no `readOnlyHint: true` tools exits 0 (and tells you what it skipped
+and why).
+
+## Results never touch the score
+
+Determinism is the score's contract — same server, same score — and tool
+calls depend on upstreams and environment. So smoke results live in their
+own `smoke` section of the [JSON report](/stability#report-schema) and are
+never counted in `score`/`max_score`:
+
+```json
+"smoke": {
+  "executed": true,
+  "reason": null,
+  "call_all": false,
+  "summary": { "passed": 4, "failed": 2, "skipped": 3 },
+  "checks": [
+    {
+      "check_id": "smoke_structured_content",
+      "tool_name": "get_weather",
+      "verdict": "fail",
+      "message": "declared outputSchema is not honored: 'result' is a required property",
+      "details": { "basis": "MCP 2025-11-25 Tools §Output Schema (structured results MUST conform to the declared schema)" }
+    }
+  ]
+}
+```
+
+When `--smoke` is requested but no session exists to call tools on — a
+[partial audit](/authenticated-servers) of an auth-gated server, or a
+modern-only probe audit — the section reports `"executed": false` with the
+reason, instead of silently vanishing.
+
+## What smoke mode is not
+
+- **Not available on [mcpscore.dev](https://mcpscore.dev)** — invoking tools
+  on arbitrary third-party URLs from our infrastructure is what the security
+  posture forbids. Smoke mode is CLI-only (GitHub Action support is
+  planned).
+- **Not a replacement for your test suite.** It proves the MCP contract —
+  honest schemas, proper rejections, tools that answer — not your business
+  logic.
+- **Not part of the score**, ever. A perfectly passing smoke run adds zero
+  points; a failing one subtracts none.
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="GitHub Action" icon="github" href="/github-action">
+    Gate PRs on the score today; smoke input coming
+  </Card>
+  <Card title="Stability Contract" icon="file-contract" href="/stability">
+    Exit codes and the `smoke` report section
+  </Card>
+  <Card title="Scoring Methodology" icon="scale-balanced" href="/methodology">
+    Why the audit itself never calls tools
+  </Card>
+  <Card title="Authenticated Servers" icon="lock" href="/authenticated-servers">
+    Pass credentials so smoke can reach behind the gate
+  </Card>
+</CardGroup>

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -68,8 +68,9 @@ For a package audit `transport` is `null` and `spec.negotiated_version` is
   no fallback available; **3** the audit completed but a `--fail-under` /
   `--fail-under-readiness` threshold was not met (a partial audit always
   fails a `--fail-under` gate — its score cannot demonstrate the threshold);
-  **4** the audit completed but an opt-in `--smoke` check failed. When both
-  a threshold gate and a smoke check fail in one run, 3 takes precedence.
+  **4** the audit completed but an opt-in [`--smoke`](/smoke-mode) check
+  failed. When both a threshold gate and a smoke check fail in one run, 3
+  takes precedence.
   Without those flags, 0 keeps its meaning exactly.
 - `--json` writes exactly one JSON document to stdout; all logs go to
   stderr. Pipelines may rely on stdout being clean JSON.

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -34,7 +34,8 @@ The report's top-level shape: `schema_version`, `mcpscore_version`,
 `generated_at`, `target`, `transport`, `score`, `max_score`,
 `authenticated`, `partial`, `partial_reason`, `incomplete_listings[]`,
 `server_info`, `package`, `summary`, `results[]`, `skipped_rules[]`, `spec`,
-`readiness`.
+`readiness` — plus `smoke`, present only when the run was invoked with
+[`--smoke`](/smoke-mode).
 
 `server_info` is either `null` when server identity could not be observed, or
 an object containing the `name` and `version` reported by the server during
@@ -53,6 +54,17 @@ records that the package was read from its registry, never downloaded or run.
 
 For a package audit `transport` is `null` and `spec.negotiated_version` is
 `null`: a coordinate names something installable, not something running.
+
+`smoke` is **absent** unless the run was invoked with
+[`--smoke`](/smoke-mode) — consumers must not require it. When present it
+carries `executed` (false when no session was available to call tools on,
+with the explanation in `reason`), `call_all`, a `summary` of
+`passed`/`failed`/`skipped` counts, and `checks[]` — each check an object of
+`check_id`, `tool_name` (`null` for server-level checks), `verdict`
+(`pass`/`fail`/`skip`), `message`, and `details`. `check_id` values are
+stable identifiers in the same way `rule_id`s are. Smoke results are never
+counted in `score`/`max_score`, and a smoke failure is reported through exit
+code 4, not through the report's score fields.
 
 ### CLI interface
 

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -67,7 +67,9 @@ For a package audit `transport` is `null` and `spec.negotiated_version` is
   token-exchange failure); **2** connection failure to the target server with
   no fallback available; **3** the audit completed but a `--fail-under` /
   `--fail-under-readiness` threshold was not met (a partial audit always
-  fails a `--fail-under` gate — its score cannot demonstrate the threshold).
+  fails a `--fail-under` gate — its score cannot demonstrate the threshold);
+  **4** the audit completed but an opt-in `--smoke` check failed. When both
+  a threshold gate and a smoke check fail in one run, 3 takes precedence.
   Without those flags, 0 keeps its meaning exactly.
 - `--json` writes exactly one JSON document to stdout; all logs go to
   stderr. Pipelines may rely on stdout being clean JSON.

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -17,6 +17,7 @@ from mcpscore.enums import ConnectionErrorReason
 from mcpscore.mcp_auditor import has_authorization_credential
 from mcpscore.packages import InvalidCoordinateError, PackageCoordinate
 from mcpscore.probes import observed_auth_status
+from mcpscore.smoke import SmokeReport, SmokeVerdict, run_smoke_checks
 
 if TYPE_CHECKING:
     from mcpscore import MCPTransportType
@@ -149,6 +150,28 @@ def build_parser() -> argparse.ArgumentParser:
             "Exit with code 3 when the readiness percentage for the latest spec revision is "
             "below PCT. Skipped when readiness was not assessed at all (nothing to gate on), "
             "matching the GitHub Action's min-readiness input."
+        ),
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help=(
+            "After the audit, smoke-test the server by actually invoking its tools (tools/call): "
+            "verifies that declared output schemas are honored, that schema-invalid arguments are "
+            "rejected, and that unknown tool names are rejected. For servers YOU operate (e.g. in "
+            "CI) — by default only tools annotated readOnlyHint: true are called; see --call-all. "
+            "Smoke results never affect the score; any smoke failure exits with code 4. "
+            "Needs a live session, so it is unavailable with --package and does not run on "
+            "partial or modern-only probe audits. Put it before --stdio."
+        ),
+    )
+    parser.add_argument(
+        "--call-all",
+        action="store_true",
+        help=(
+            "With --smoke: call every tool, not only those annotated readOnlyHint: true. "
+            "This is explicit consent to trigger side effects — use it only against a server "
+            "whose tools you are willing to execute."
         ),
     )
     parser.add_argument(
@@ -308,11 +331,15 @@ def resolve_target(args: argparse.Namespace) -> str | StdioCommand | PackageCoor
         ValueError: On any invalid combination (message is user-facing).
 
     """
+    if args.call_all and not args.smoke:
+        raise ValueError("--call-all only applies together with --smoke")
     if args.package is not None:
         if args.target is not None or args.stdio is not None:
             raise ValueError("give either a target, --stdio, or --package — not more than one")
         if args.env:
             raise ValueError("--env only applies to --stdio servers; --package never runs the package")
+        if args.smoke:
+            raise ValueError("--smoke needs a running server to call tools on; --package never runs the package")
         try:
             return PackageCoordinate.parse(args.package)
         except InvalidCoordinateError as e:
@@ -442,18 +469,29 @@ def finish_server_audit(
     auditor: MCPAuditor,
     target_display: str,
     transport: MCPTransportType | None,
+    smoke: SmokeReport | None = None,
 ) -> None:
-    """Finish a server audit: log the outcome, emit --json, apply the gate.
+    """Finish a server audit: log the outcome, emit --json, apply the gates.
 
     The shared tail of every completed server audit (full, partial, and
-    modern-only). Exits with code 3 when a --fail-under gate fails;
-    returns normally otherwise so ungated behavior is unchanged.
+    modern-only). Exits with code 3 when a --fail-under gate fails, else
+    code 4 when any --smoke check failed (the score gate takes precedence —
+    it is the primary contract, and one exit carries one code); returns
+    normally otherwise so ungated behavior is unchanged.
     """
     log_audit_outcome(auditor)
+    if smoke is not None:
+        log_smoke_outcome(smoke)
     if args.json:
         report = build_report(target_display, transport, auditor)
+        if smoke is not None:
+            report["smoke"] = smoke.to_dict()
         sys.stdout.write(json.dumps(report, indent=2, default=str) + "\n")
-    if code := fail_under_exit_code(args, auditor.get_audit_report()):
+    code = fail_under_exit_code(args, auditor.get_audit_report())
+    if code == 0 and smoke is not None and smoke.failed:
+        logger.error("Gate failed — --smoke: %d smoke check(s) failed", smoke.failed)
+        code = 4
+    if code:
         sys.exit(code)
 
 
@@ -521,6 +559,47 @@ def log_audit_outcome(auditor: MCPAuditor) -> None:
             "Readiness for MCP %s: not assessed (no usable probe observations)",
             spec["readiness_target"],
         )
+
+
+def log_smoke_outcome(smoke: SmokeReport) -> None:
+    """Log the human-readable smoke outcome: summary line, failures, skips.
+
+    Failures log as errors with their full message; skips log individually
+    too — the safety default skipping unannotated tools is a visible cost of
+    not annotating, and hiding it would make the coverage look better than
+    it is.
+    """
+    logger.info("")
+    if not smoke.executed:
+        logger.warning("Smoke checks did not run: %s", smoke.reason)
+        return
+    logger.info(
+        "Smoke checks (tools/call): %d passed, %d failed, %d skipped — %s. Never counted in the score.",
+        smoke.passed,
+        smoke.failed,
+        smoke.skipped,
+        "every tool called (--call-all)" if smoke.call_all else "only readOnlyHint: true tools called (see --call-all)",
+    )
+    for check in smoke.checks:
+        subject = f" [{check.tool_name}]" if check.tool_name else ""
+        if check.verdict is SmokeVerdict.FAIL:
+            logger.error("  FAIL %s%s: %s", check.check_id, subject, check.message)
+        elif check.verdict is SmokeVerdict.SKIP:
+            logger.info("  skip %s%s: %s", check.check_id, subject, check.message)
+
+
+async def run_smoke_phase(args: argparse.Namespace, client: MCPClient, auditor: MCPAuditor) -> SmokeReport:
+    """Run the --smoke checks on the audit's still-open session.
+
+    Runs after ``auditor.audit(client)`` and before cleanup — the auditor
+    never closes the session, so the smoke calls reuse the exact connection
+    the audit observed.
+    """
+    if client.session is None:  # pragma: no cover — audit() succeeded, so a session exists
+        return SmokeReport.not_executed("no active session to call tools on")
+    logger.info("")
+    logger.info("Running smoke checks — invoking tools/call, as requested with --smoke...")
+    return await run_smoke_checks(client.session, auditor.audit_data.tools, call_all=args.call_all)
 
 
 def build_report(target: str, transport: MCPTransportType | None, auditor: MCPAuditor) -> dict:
@@ -604,8 +683,9 @@ async def async_main() -> None:
     (2026-07-28 stateless lifecycle) support and audited via probes if so.
 
     Exits with code 1 on usage errors, code 2 if connection fails and the
-    server shows no modern-lifecycle support either, or code 3 when the audit
-    completed but a --fail-under / --fail-under-readiness gate failed.
+    server shows no modern-lifecycle support either, code 3 when the audit
+    completed but a --fail-under / --fail-under-readiness gate failed, or
+    code 4 when the audit completed but a --smoke check failed.
     """
     # Parse before greeting: --version and --help exit during parsing, and
     # neither should be preceded by a banner.
@@ -671,7 +751,14 @@ async def async_main() -> None:
                     logger.info(
                         "Modern-only MCP server detected: audited via stateless probes (no legacy session available)."
                     )
-                    finish_server_audit(args, auditor, target_display, auditor.audit_data.transport_type)
+                    smoke = (
+                        SmokeReport.not_executed(
+                            "smoke checks need an established session; the modern-only probe audit has none"
+                        )
+                        if args.smoke
+                        else None
+                    )
+                    finish_server_audit(args, auditor, target_display, auditor.audit_data.transport_type, smoke=smoke)
                     return
 
             if http_url is not None:
@@ -750,7 +837,14 @@ async def async_main() -> None:
                             "only — pass a token to audit behind the gate."
                         )
                     await auditor.audit_partial(http_url, reason=partial_reason)
-                    finish_server_audit(args, auditor, target_display, auditor.audit_data.transport_type)
+                    smoke = (
+                        SmokeReport.not_executed(
+                            "smoke checks need an authenticated session; the partial audit has none"
+                        )
+                        if args.smoke
+                        else None
+                    )
+                    finish_server_audit(args, auditor, target_display, auditor.audit_data.transport_type, smoke=smoke)
                     return
             elif failure is not None and failure.detail is not None:
                 # Generic handshake failures are held back while probing: a
@@ -765,9 +859,10 @@ async def async_main() -> None:
 
         logger.info("Starting the audit...")
         await auditor.audit(client)
+        smoke = await run_smoke_phase(args, client, auditor) if args.smoke else None
         # A gate failure exits inside the try and still reaches cleanup() via
         # finally; the happy path returns normally (no SystemExit(0)).
-        finish_server_audit(args, auditor, target_display, transport)
+        finish_server_audit(args, auditor, target_display, transport, smoke=smoke)
     finally:
         await client.cleanup()
 

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -599,7 +599,12 @@ async def run_smoke_phase(args: argparse.Namespace, client: MCPClient, auditor: 
         return SmokeReport.not_executed("no active session to call tools on")
     logger.info("")
     logger.info("Running smoke checks — invoking tools/call, as requested with --smoke...")
-    return await run_smoke_checks(client.session, auditor.audit_data.tools, call_all=args.call_all)
+    return await run_smoke_checks(
+        client.session,
+        auditor.audit_data.tools,
+        call_all=args.call_all,
+        catalog_complete="tools" not in auditor.audit_data.incomplete_listings,
+    )
 
 
 def build_report(target: str, transport: MCPTransportType | None, auditor: MCPAuditor) -> dict:

--- a/mcpscore/smoke.py
+++ b/mcpscore/smoke.py
@@ -1,0 +1,444 @@
+"""Smoke checks: opt-in ``tools/call`` verification behind the ``--smoke`` flag.
+
+The audit never invokes ``tools/call`` — that invariant is what makes it safe
+to point mcpscore at anyone's server. Smoke mode is the separate surface for
+developers running mcpscore against their OWN server (typically in CI), where
+invoking tools is the point: it verifies what listing alone cannot prove.
+
+Checks (verdicts are pass / fail / skip — skip when a check could not be
+exercised, e.g. an upstream outage must not fail the build):
+
+- **Structured-content honesty**: every callable tool declaring an
+  ``outputSchema`` is invoked; the result must carry conforming
+  ``structuredContent`` (MCP 2025-11-25 Tools §Output Schema: servers MUST
+  provide structured results that conform to the schema).
+- **Invalid-argument rejection**: each callable tool is invoked with
+  deliberately schema-invalid arguments and must reject them — an
+  ``isError`` tool result or a JSON-RPC error are both proper rejections
+  (MCP 2025-11-25 Tools §Error Handling); accepting them, hanging, or
+  crashing fails.
+- **Unknown-tool rejection**: ``tools/call`` on a nonexistent name must be
+  rejected with a protocol error (MCP 2025-11-25 Tools §Error Handling,
+  e.g. ``-32602 Unknown tool``), not executed and not a server crash.
+
+Safety default: only tools annotated ``readOnlyHint: true`` are called;
+``--call-all`` is the explicit second consent for everything else. Argument
+synthesis is deterministic (defaults / const / examples / enum-first / type
+zero-values — never an LLM), so the same server sees the same calls.
+
+Smoke results never enter the 0-100 score and are reported in their own
+``smoke`` report section; a smoke failure is its own CLI exit code (4). This
+module is used by the CLI only — the web service never invokes tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mcp.shared.exceptions import MCPError
+from mcp_types import REQUEST_TIMEOUT, CallToolResult
+
+from .probes import ERROR_INVALID_PARAMS, ERROR_METHOD_NOT_FOUND
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from mcp import ClientSession
+    from mcp_types import Tool
+
+logger = logging.getLogger(__name__)
+
+SMOKE_CALL_TIMEOUT_S = 30.0
+"""Per-call deadline. A tool that cannot answer within this is reported as a
+hang (invalid-argument check) or as unexercisable (structured-content check)."""
+
+UNKNOWN_TOOL_NAME = "mcpscore_smoke_nonexistent_tool"
+"""Deliberately fixed, not random: deterministic calls are part of the smoke
+contract (same server, same calls), and no real server plausibly names a tool
+this way."""
+
+CHECK_STRUCTURED_CONTENT = "smoke_structured_content"
+CHECK_INVALID_ARGUMENTS = "smoke_invalid_arguments"
+CHECK_UNKNOWN_TOOL = "smoke_unknown_tool"
+
+BASIS_OUTPUT_SCHEMA = "MCP 2025-11-25 Tools §Output Schema (structured results MUST conform to the declared schema)"
+BASIS_ERROR_HANDLING = "MCP 2025-11-25 Tools §Error Handling (isError tool result or JSON-RPC protocol error)"
+BASIS_UNKNOWN_TOOL = "MCP 2025-11-25 Tools §Error Handling (unknown tool → protocol error, e.g. -32602)"
+
+_SAFETY_SKIP_REASON = "not called under the safety default (readOnlyHint is not true); pass --call-all to include it"
+
+_SYNTHESIS_MAX_DEPTH = 4
+"""Recursion bound for nested object synthesis. Shallow by design: sample
+values come from the schema's own hints, not from exploring its full space."""
+
+
+class SmokeVerdict(StrEnum):
+    """Outcome of one smoke check observation."""
+
+    PASS = "pass"  # noqa: S105 — a verdict label, not a password
+    """The server exhibited the required behavior."""
+
+    FAIL = "fail"
+    """The server violated the checked contract."""
+
+    SKIP = "skip"
+    """The check could not be exercised (no schema declared, tool not callable
+    under the safety default, upstream outage). Never a failure: someone
+    else's outage must not fail the build."""
+
+
+@dataclass(frozen=True)
+class SmokeCheckResult:
+    """Recorded outcome of one smoke check against one subject."""
+
+    check_id: str
+    """Stable identifier of the check that produced this result."""
+
+    verdict: SmokeVerdict
+
+    message: str
+    """Human-readable explanation of the verdict."""
+
+    tool_name: str | None = None
+    """The tool this observation is about, or None for server-level checks."""
+
+    details: dict[str, Any] = field(default_factory=dict)
+    """Raw observations (JSON-RPC error codes, spec basis) kept small — the
+    same policy as ``ProbeResult.details``."""
+
+    def to_dict(self) -> dict:
+        """Serialize this result for the machine-readable report."""
+        return {
+            "check_id": self.check_id,
+            "tool_name": self.tool_name,
+            "verdict": self.verdict.value,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+@dataclass
+class SmokeReport:
+    """Every smoke observation from one ``--smoke`` run.
+
+    Deliberately not part of the scored report: smoke verdicts depend on
+    upstreams and environment, and determinism ("same server, same score") is
+    the audit's contract. The CLI reports smoke in its own section and its
+    own exit code.
+    """
+
+    executed: bool
+    """False when --smoke was requested but no session was available to call
+    tools on (partial and modern-only audits have none)."""
+
+    reason: str | None = None
+    """Why the checks did not run; None when ``executed``."""
+
+    call_all: bool = False
+    """Whether --call-all lifted the readOnlyHint safety default."""
+
+    checks: list[SmokeCheckResult] = field(default_factory=list)
+
+    @classmethod
+    def not_executed(cls, reason: str) -> SmokeReport:
+        """Build the report for a --smoke request that had no session to run on."""
+        return cls(executed=False, reason=reason)
+
+    def _count(self, verdict: SmokeVerdict) -> int:
+        return sum(1 for check in self.checks if check.verdict is verdict)
+
+    @property
+    def passed(self) -> int:
+        """Number of checks that passed."""
+        return self._count(SmokeVerdict.PASS)
+
+    @property
+    def failed(self) -> int:
+        """Number of checks that failed."""
+        return self._count(SmokeVerdict.FAIL)
+
+    @property
+    def skipped(self) -> int:
+        """Number of checks that could not be exercised."""
+        return self._count(SmokeVerdict.SKIP)
+
+    def to_dict(self) -> dict:
+        """Serialize the smoke section for the machine-readable report."""
+        return {
+            "executed": self.executed,
+            "reason": self.reason,
+            "call_all": self.call_all,
+            "summary": {"passed": self.passed, "failed": self.failed, "skipped": self.skipped},
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+def synthesize_value(schema: object, depth: int = 0) -> Any:
+    """Derive one deterministic sample value from a JSON Schema fragment.
+
+    Preference order: ``default`` > ``const`` > first example > first enum
+    entry > first ``anyOf``/``oneOf`` branch > the type's zero value. Nested
+    objects recurse (required properties only) down to a shallow bound;
+    anything unresolvable becomes None — the server may then reject the call,
+    which reports as a skip, never a wrong verdict.
+    """
+    if depth >= _SYNTHESIS_MAX_DEPTH or not isinstance(schema, dict):
+        return None
+    if "default" in schema:
+        return schema["default"]
+    if "const" in schema:
+        return schema["const"]
+    examples = schema.get("examples")
+    if isinstance(examples, list) and examples:
+        return examples[0]
+    enum = schema.get("enum")
+    if isinstance(enum, list) and enum:
+        return enum[0]
+    for branch_key in ("anyOf", "oneOf"):
+        branches = schema.get(branch_key)
+        if isinstance(branches, list) and branches:
+            return synthesize_value(branches[0], depth + 1)
+    declared = schema.get("type")
+    if isinstance(declared, list) and declared:
+        declared = declared[0]
+    zero_values: dict[str, Any] = {"string": "", "number": 0, "integer": 0, "boolean": False, "array": [], "null": None}
+    if declared == "object":
+        return _synthesize_object(schema, depth + 1)
+    return zero_values.get(declared) if isinstance(declared, str) else None
+
+
+def _synthesize_object(schema: dict[str, Any], depth: int) -> dict[str, Any]:
+    """Build an object with a sample value for each required, declared property."""
+    properties = schema.get("properties")
+    required = schema.get("required")
+    if not isinstance(properties, dict) or not isinstance(required, list):
+        return {}
+    return {
+        name: synthesize_value(properties.get(name), depth)
+        for name in required
+        if isinstance(properties.get(name), dict)
+    }
+
+
+def synthesize_arguments(input_schema: object) -> dict[str, Any]:
+    """Derive deterministic, schema-satisfying ``tools/call`` arguments.
+
+    Required properties only: optional ones add nothing to whether the call
+    can be exercised, and fewer synthesized values mean fewer chances to feed
+    a tool something its runtime validation rejects.
+    """
+    if not isinstance(input_schema, dict):
+        return {}
+    return _synthesize_object(input_schema, 0)
+
+
+_WRONG_TYPED_VALUES: dict[str, Any] = {
+    "string": 42,
+    "number": "not-a-number",
+    "integer": "not-an-integer",
+    "boolean": "not-a-boolean",
+    "array": {"invalid": True},
+    "object": "not-an-object",
+    "null": 0,
+}
+"""For each single declared JSON type, a value violating it."""
+
+
+def synthesize_invalid_arguments(input_schema: object) -> dict[str, Any] | None:
+    """Derive arguments that violate the tool's input schema, or None.
+
+    Valid arguments with exactly one deliberate violation: the first declared
+    property with a single, violable type gets a value of the wrong type. A
+    schema that constrains nothing (no typed properties — e.g. the bare
+    ``{"type": "object"}``) offers nothing to violate, and the check must
+    skip rather than send arguments the server is entitled to accept.
+    """
+    if not isinstance(input_schema, dict):
+        return None
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict):
+        return None
+    for name, subschema in properties.items():
+        if not isinstance(subschema, dict):
+            continue
+        declared = subschema.get("type")
+        if isinstance(declared, str) and declared in _WRONG_TYPED_VALUES:
+            arguments = synthesize_arguments(input_schema)
+            arguments[name] = _WRONG_TYPED_VALUES[declared]
+            return arguments
+    return None
+
+
+def _tool_skip_reason(tool: Tool, *, call_all: bool) -> str | None:
+    """Why this tool is not callable, or None when it is.
+
+    The safety default calls only tools that affirmatively annotate
+    ``readOnlyHint: true`` — an absent annotation defaults to false per the
+    spec, so unannotated tools are skipped, never called. That skipped
+    coverage is the visible cost of not annotating.
+    """
+    if call_all:
+        return None
+    annotations = tool.annotations
+    if annotations is not None and annotations.read_only_hint is True:
+        return None
+    return _SAFETY_SKIP_REASON
+
+
+async def _check_structured_content(session: ClientSession, tool: Tool, skip_reason: str | None) -> SmokeCheckResult:
+    """Verify a tool honors its declared ``outputSchema`` when actually called."""
+    details = {"basis": BASIS_OUTPUT_SCHEMA}
+
+    def result(verdict: SmokeVerdict, message: str, **extra: Any) -> SmokeCheckResult:
+        return SmokeCheckResult(CHECK_STRUCTURED_CONTENT, verdict, message, tool.name, {**details, **extra})
+
+    if skip_reason is not None:
+        return result(SmokeVerdict.SKIP, skip_reason)
+    if not tool.output_schema:
+        return result(SmokeVerdict.SKIP, "no outputSchema declared — nothing to verify against")
+    try:
+        # The SDK validates a successful result's structuredContent against
+        # the declared outputSchema and raises RuntimeError on a violation —
+        # the exact failure a schema-compiling client would hit in production.
+        call_result = await session.call_tool(
+            tool.name,
+            synthesize_arguments(tool.input_schema),
+            read_timeout_seconds=SMOKE_CALL_TIMEOUT_S,
+            allow_input_required=True,
+            allow_claimed=True,
+        )
+    except RuntimeError as exc:
+        # The SDK's message embeds jsonschema's multi-line validation dump;
+        # its first line carries the diagnosis and the rest is noise in a
+        # log line or a JSON report field.
+        first_line = str(exc).partition("\n")[0]
+        return result(SmokeVerdict.FAIL, f"declared outputSchema is not honored: {first_line}")
+    except MCPError as exc:
+        return result(
+            SmokeVerdict.SKIP,
+            f"tools/call answered JSON-RPC error {exc.code} — the schema could not be exercised "
+            "(the server may have rejected the synthesized arguments)",
+            error_code=exc.code,
+        )
+    except Exception as exc:  # noqa: BLE001 — a smoke check never aborts the run
+        return result(SmokeVerdict.SKIP, f"tools/call raised {type(exc).__name__} — the schema could not be exercised")
+    if not isinstance(call_result, CallToolResult):
+        return result(SmokeVerdict.SKIP, "tool requested interactive input — not judgeable in an unattended run")
+    if call_result.is_error:
+        return result(
+            SmokeVerdict.SKIP,
+            "tool returned an error result (an upstream outage, or the synthesized arguments were rejected) — "
+            "someone else's outage must not fail the build",
+        )
+    return result(SmokeVerdict.PASS, "structuredContent conforms to the declared outputSchema")
+
+
+async def _check_invalid_arguments(session: ClientSession, tool: Tool, skip_reason: str | None) -> SmokeCheckResult:
+    """Verify a tool rejects deliberately schema-invalid arguments."""
+    details = {"basis": BASIS_ERROR_HANDLING}
+
+    def result(verdict: SmokeVerdict, message: str, **extra: Any) -> SmokeCheckResult:
+        return SmokeCheckResult(CHECK_INVALID_ARGUMENTS, verdict, message, tool.name, {**details, **extra})
+
+    if skip_reason is not None:
+        return result(SmokeVerdict.SKIP, skip_reason)
+    invalid_arguments = synthesize_invalid_arguments(tool.input_schema)
+    if invalid_arguments is None:
+        return result(SmokeVerdict.SKIP, "inputSchema declares no typed property to violate — nothing invalid to send")
+    try:
+        call_result = await session.call_tool(
+            tool.name,
+            invalid_arguments,
+            read_timeout_seconds=SMOKE_CALL_TIMEOUT_S,
+            allow_input_required=True,
+            allow_claimed=True,
+        )
+    except MCPError as exc:
+        if exc.code == REQUEST_TIMEOUT:
+            return result(
+                SmokeVerdict.FAIL,
+                f"no answer within {SMOKE_CALL_TIMEOUT_S:.0f}s of a schema-invalid call — a hang, not a rejection",
+                error_code=exc.code,
+            )
+        return result(SmokeVerdict.PASS, f"rejected with JSON-RPC error {exc.code}", error_code=exc.code)
+    except RuntimeError:
+        # The SDK's output-schema validation fired, meaning the server
+        # produced a (broken) success result for schema-invalid input.
+        return result(SmokeVerdict.FAIL, "accepted schema-invalid arguments (returned a result, not a rejection)")
+    except Exception as exc:  # noqa: BLE001 — a smoke check never aborts the run
+        return result(SmokeVerdict.FAIL, f"tools/call with schema-invalid arguments crashed: {type(exc).__name__}")
+    if isinstance(call_result, CallToolResult) and call_result.is_error:
+        return result(SmokeVerdict.PASS, "rejected with an isError tool result")
+    if not isinstance(call_result, CallToolResult):
+        return result(SmokeVerdict.FAIL, "accepted schema-invalid arguments (requested further input, not a rejection)")
+    return result(SmokeVerdict.FAIL, "accepted schema-invalid arguments (returned a success result)")
+
+
+async def _check_unknown_tool(session: ClientSession) -> SmokeCheckResult:
+    """Verify the server rejects a nonexistent tool name with a protocol error."""
+    details = {"basis": BASIS_UNKNOWN_TOOL, "requested_tool": UNKNOWN_TOOL_NAME}
+
+    def result(verdict: SmokeVerdict, message: str, **extra: Any) -> SmokeCheckResult:
+        return SmokeCheckResult(CHECK_UNKNOWN_TOOL, verdict, message, None, {**details, **extra})
+
+    try:
+        call_result = await session.call_tool(
+            UNKNOWN_TOOL_NAME,
+            {},
+            read_timeout_seconds=SMOKE_CALL_TIMEOUT_S,
+            allow_input_required=True,
+            allow_claimed=True,
+        )
+    except MCPError as exc:
+        if exc.code in (ERROR_INVALID_PARAMS, ERROR_METHOD_NOT_FOUND):
+            return result(SmokeVerdict.PASS, f"rejected with JSON-RPC error {exc.code}", error_code=exc.code)
+        if exc.code == REQUEST_TIMEOUT:
+            return result(
+                SmokeVerdict.FAIL,
+                f"no answer within {SMOKE_CALL_TIMEOUT_S:.0f}s of calling a nonexistent tool — a hang, not a rejection",
+                error_code=exc.code,
+            )
+        return result(
+            SmokeVerdict.FAIL,
+            f"answered JSON-RPC error {exc.code} instead of a method/params protocol error "
+            f"({ERROR_METHOD_NOT_FOUND}/{ERROR_INVALID_PARAMS})",
+            error_code=exc.code,
+        )
+    except Exception as exc:  # noqa: BLE001 — a smoke check never aborts the run
+        return result(SmokeVerdict.FAIL, f"tools/call on a nonexistent tool crashed: {type(exc).__name__}")
+    if isinstance(call_result, CallToolResult) and call_result.is_error:
+        return result(
+            SmokeVerdict.FAIL,
+            "reported a tool execution error (isError) for a nonexistent tool — the spec's unknown-tool "
+            "example is a protocol error, and an isError result claims the tool exists and ran",
+        )
+    return result(SmokeVerdict.FAIL, "answered a nonexistent tool name with a result instead of rejecting it")
+
+
+async def run_smoke_checks(session: ClientSession, tools: Sequence[Tool] | None, *, call_all: bool) -> SmokeReport:
+    """Run every smoke check sequentially on the audit's established session.
+
+    Sequential on purpose: one in-flight ``tools/call`` at a time keeps the
+    server's observed behavior attributable to one request, and keeps the
+    order of calls deterministic.
+
+    Args:
+        session: The live session the audit connected (never closed by the
+            auditor; the CLI's cleanup closes it afterwards).
+        tools: The audit's collected tool listing (None when listing failed —
+            the server-level unknown-tool check still runs).
+        call_all: Lift the readOnlyHint safety default (--call-all).
+
+    """
+    report = SmokeReport(executed=True, call_all=call_all)
+    for tool in tools or []:
+        skip_reason = _tool_skip_reason(tool, call_all=call_all)
+        report.checks.append(await _check_structured_content(session, tool, skip_reason))
+    for tool in tools or []:
+        skip_reason = _tool_skip_reason(tool, call_all=call_all)
+        report.checks.append(await _check_invalid_arguments(session, tool, skip_reason))
+    report.checks.append(await _check_unknown_tool(session))
+    return report

--- a/mcpscore/smoke.py
+++ b/mcpscore/smoke.py
@@ -251,21 +251,18 @@ _WRONG_TYPED_VALUES: dict[str, Any] = {
 }
 """For each single declared JSON type, a value violating it."""
 
+_ENUM_VIOLATION_CANDIDATES: tuple[Any, ...] = ("mcpscore-smoke-invalid-value", 42, False, [], {"mcpscore": "invalid"})
+"""Deterministic ladder for violating an enum/const constraint: the first
+value the constraint does not allow is used. An enum pathological enough to
+allow every candidate simply is not violated via that property."""
 
-def synthesize_invalid_arguments(input_schema: object) -> dict[str, Any] | None:
-    """Derive arguments that violate the tool's input schema, or None.
+UNEXPECTED_PROPERTY_NAME = "mcpscore_smoke_unexpected_property"
+"""Base name of the extra argument sent to violate ``additionalProperties:
+false``; deterministically suffixed if the schema really declares it."""
 
-    Valid arguments with exactly one deliberate violation: the first declared
-    property with a single, violable type gets a value of the wrong type. A
-    schema that constrains nothing (no typed properties — e.g. the bare
-    ``{"type": "object"}``) offers nothing to violate, and the check must
-    skip rather than send arguments the server is entitled to accept.
-    """
-    if not isinstance(input_schema, dict):
-        return None
-    properties = input_schema.get("properties")
-    if not isinstance(properties, dict):
-        return None
+
+def _wrong_typed_violation(input_schema: dict[str, Any], properties: dict[str, Any]) -> dict[str, Any] | None:
+    """Give the first single-typed property a value of the wrong type."""
     for name, subschema in properties.items():
         if not isinstance(subschema, dict):
             continue
@@ -274,6 +271,80 @@ def synthesize_invalid_arguments(input_schema: object) -> dict[str, Any] | None:
             arguments = synthesize_arguments(input_schema)
             arguments[name] = _WRONG_TYPED_VALUES[declared]
             return arguments
+    return None
+
+
+def _enum_violation(input_schema: dict[str, Any], properties: dict[str, Any]) -> dict[str, Any] | None:
+    """Give the first enum/const-constrained property a value outside the constraint."""
+    for name, subschema in properties.items():
+        if not isinstance(subschema, dict):
+            continue
+        enum = subschema.get("enum")
+        if isinstance(enum, list) and enum:
+            allowed = enum
+        elif "const" in subschema:
+            allowed = [subschema["const"]]
+        else:
+            continue
+        for candidate in _ENUM_VIOLATION_CANDIDATES:
+            if candidate not in allowed:
+                arguments = synthesize_arguments(input_schema)
+                arguments[name] = candidate
+                return arguments
+    return None
+
+
+def _missing_required_violation(input_schema: dict[str, Any]) -> dict[str, Any] | None:
+    """Omit the first required property from otherwise-valid arguments."""
+    required = input_schema.get("required")
+    if not isinstance(required, list):
+        return None
+    for name in required:
+        if isinstance(name, str):
+            arguments = synthesize_arguments(input_schema)
+            arguments.pop(name, None)
+            return arguments
+    return None
+
+
+def _unexpected_property_violation(input_schema: dict[str, Any], properties: dict[str, Any]) -> dict[str, Any] | None:
+    """Add an undeclared property when the schema forbids additional ones."""
+    if input_schema.get("additionalProperties") is not False:
+        return None
+    name = UNEXPECTED_PROPERTY_NAME
+    while name in properties:
+        name = f"{name}_x"
+    arguments = synthesize_arguments(input_schema)
+    arguments[name] = True
+    return arguments
+
+
+def synthesize_invalid_arguments(input_schema: object) -> dict[str, Any] | None:
+    """Derive arguments that violate the tool's input schema, or None.
+
+    Otherwise-valid arguments with exactly one deliberate violation, trying
+    constraint kinds in a fixed order: a wrong-typed value for the first
+    single-typed property; a value outside the first enum/const constraint;
+    omitting the first required property; an undeclared extra property when
+    ``additionalProperties`` is false. A schema that constrains nothing
+    (e.g. the bare ``{"type": "object"}``) offers nothing to violate, and
+    the check must skip rather than send arguments the server is entitled
+    to accept.
+    """
+    if not isinstance(input_schema, dict):
+        return None
+    raw_properties = input_schema.get("properties")
+    properties = raw_properties if isinstance(raw_properties, dict) else {}
+    # `is not None`, never truthiness: omitting the only required property
+    # legitimately yields {} — an empty dict IS the violation.
+    for violation in (
+        _wrong_typed_violation(input_schema, properties),
+        _enum_violation(input_schema, properties),
+        _missing_required_violation(input_schema),
+        _unexpected_property_violation(input_schema, properties),
+    ):
+        if violation is not None:
+            return violation
     return None
 
 
@@ -361,7 +432,7 @@ async def _check_invalid_arguments(session: ClientSession, tool: Tool, skip_reas
             f"could not derive schema-invalid arguments ({type(exc).__name__}) — nothing invalid to send",
         )
     if invalid_arguments is None:
-        return result(SmokeVerdict.SKIP, "inputSchema declares no typed property to violate — nothing invalid to send")
+        return result(SmokeVerdict.SKIP, "inputSchema declares no violable constraint — nothing invalid to send")
     try:
         call_result = await session.call_tool(
             tool.name,

--- a/mcpscore/smoke.py
+++ b/mcpscore/smoke.py
@@ -375,6 +375,16 @@ async def _check_invalid_arguments(session: ClientSession, tool: Tool, skip_reas
                 "connection closed on a schema-invalid call — a crash, not a rejection",
                 error_code=exc.code,
             )
+        if exc.code == ERROR_INTERNAL:
+            # Same stance as the unknown-tool check: an internal error means
+            # the server tried to run the call and broke, not that it
+            # rejected the arguments.
+            return result(
+                SmokeVerdict.FAIL,
+                f"answered JSON-RPC internal error {exc.code} to schema-invalid arguments — a server-side "
+                "crash, not a rejection",
+                error_code=exc.code,
+            )
         return result(SmokeVerdict.PASS, f"rejected with JSON-RPC error {exc.code}", error_code=exc.code)
     except RuntimeError:
         # The SDK's output-schema validation fired, meaning the server

--- a/mcpscore/smoke.py
+++ b/mcpscore/smoke.py
@@ -217,10 +217,14 @@ def _synthesize_object(schema: dict[str, Any], depth: int) -> dict[str, Any]:
     required = schema.get("required")
     if not isinstance(properties, dict) or not isinstance(required, list):
         return {}
+    # Required entries must be strings before any dict lookup: a model-accepted
+    # but malformed schema (e.g. required: [[]]) would otherwise raise TypeError
+    # and abort the whole smoke run from the invalid-arguments path, which
+    # synthesizes outside its try.
     return {
         name: synthesize_value(properties.get(name), depth)
         for name in required
-        if isinstance(properties.get(name), dict)
+        if isinstance(name, str) and isinstance(properties.get(name), dict)
     }
 
 
@@ -349,7 +353,13 @@ async def _check_invalid_arguments(session: ClientSession, tool: Tool, skip_reas
 
     if skip_reason is not None:
         return result(SmokeVerdict.SKIP, skip_reason)
-    invalid_arguments = synthesize_invalid_arguments(tool.input_schema)
+    try:
+        invalid_arguments = synthesize_invalid_arguments(tool.input_schema)
+    except Exception as exc:  # noqa: BLE001 — a smoke check never aborts the run
+        return result(
+            SmokeVerdict.SKIP,
+            f"could not derive schema-invalid arguments ({type(exc).__name__}) — nothing invalid to send",
+        )
     if invalid_arguments is None:
         return result(SmokeVerdict.SKIP, "inputSchema declares no typed property to violate — nothing invalid to send")
     try:

--- a/mcpscore/smoke.py
+++ b/mcpscore/smoke.py
@@ -39,9 +39,9 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp.shared.exceptions import MCPError
-from mcp_types import REQUEST_TIMEOUT, CallToolResult
+from mcp_types import CONNECTION_CLOSED, INTERNAL_ERROR as ERROR_INTERNAL, REQUEST_TIMEOUT, CallToolResult
 
-from .probes import ERROR_INVALID_PARAMS, ERROR_METHOD_NOT_FOUND
+from .probes import ERROR_INVALID_PARAMS
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -56,9 +56,10 @@ SMOKE_CALL_TIMEOUT_S = 30.0
 hang (invalid-argument check) or as unexercisable (structured-content check)."""
 
 UNKNOWN_TOOL_NAME = "mcpscore_smoke_nonexistent_tool"
-"""Deliberately fixed, not random: deterministic calls are part of the smoke
-contract (same server, same calls), and no real server plausibly names a tool
-this way."""
+"""Deliberately fixed base name, not random: deterministic calls are part of
+the smoke contract (same server, same calls). It is nevertheless a *legal*
+tool name, so ``derive_unknown_tool_name`` proves absence against the
+collected catalog instead of trusting implausibility."""
 
 CHECK_STRUCTURED_CONTENT = "smoke_structured_content"
 CHECK_INVALID_ARGUMENTS = "smoke_invalid_arguments"
@@ -297,7 +298,10 @@ async def _check_structured_content(session: ClientSession, tool: Tool, skip_rea
 
     if skip_reason is not None:
         return result(SmokeVerdict.SKIP, skip_reason)
-    if not tool.output_schema:
+    # `is None`, not truthiness: an empty {} is a declared, valid schema that
+    # anything conforms to, but the spec still requires structuredContent to
+    # be PRESENT for it — the check must run.
+    if tool.output_schema is None:
         return result(SmokeVerdict.SKIP, "no outputSchema declared — nothing to verify against")
     try:
         # The SDK validates a successful result's structuredContent against
@@ -363,6 +367,14 @@ async def _check_invalid_arguments(session: ClientSession, tool: Tool, skip_reas
                 f"no answer within {SMOKE_CALL_TIMEOUT_S:.0f}s of a schema-invalid call — a hang, not a rejection",
                 error_code=exc.code,
             )
+        if exc.code == CONNECTION_CLOSED:
+            # The SDK reports a dead transport as this MCPError — a crash,
+            # not the server rejecting anything.
+            return result(
+                SmokeVerdict.FAIL,
+                "connection closed on a schema-invalid call — a crash, not a rejection",
+                error_code=exc.code,
+            )
         return result(SmokeVerdict.PASS, f"rejected with JSON-RPC error {exc.code}", error_code=exc.code)
     except RuntimeError:
         # The SDK's output-schema validation fired, meaning the server
@@ -377,36 +389,66 @@ async def _check_invalid_arguments(session: ClientSession, tool: Tool, skip_reas
     return result(SmokeVerdict.FAIL, "accepted schema-invalid arguments (returned a success result)")
 
 
-async def _check_unknown_tool(session: ClientSession) -> SmokeCheckResult:
+def derive_unknown_tool_name(tools: Sequence[Tool]) -> str:
+    """Derive a deterministic tool name provably absent from the catalog.
+
+    The base name is fixed for determinism, but it is a *legal* MCP tool name
+    a server could really expose — and calling a real tool here would bypass
+    the readOnlyHint safety default. Deterministic suffixes sidestep any
+    collision; the input is the server's own catalog, so the same server
+    state still yields the same call.
+    """
+    existing = {tool.name for tool in tools}
+    candidate = UNKNOWN_TOOL_NAME
+    suffix = 2
+    while candidate in existing:
+        candidate = f"{UNKNOWN_TOOL_NAME}_{suffix}"
+        suffix += 1
+    return candidate
+
+
+async def _check_unknown_tool(session: ClientSession, unknown_name: str) -> SmokeCheckResult:
     """Verify the server rejects a nonexistent tool name with a protocol error."""
-    details = {"basis": BASIS_UNKNOWN_TOOL, "requested_tool": UNKNOWN_TOOL_NAME}
+    details = {"basis": BASIS_UNKNOWN_TOOL, "requested_tool": unknown_name}
 
     def result(verdict: SmokeVerdict, message: str, **extra: Any) -> SmokeCheckResult:
         return SmokeCheckResult(CHECK_UNKNOWN_TOOL, verdict, message, None, {**details, **extra})
 
     try:
         call_result = await session.call_tool(
-            UNKNOWN_TOOL_NAME,
+            unknown_name,
             {},
             read_timeout_seconds=SMOKE_CALL_TIMEOUT_S,
             allow_input_required=True,
             allow_claimed=True,
         )
     except MCPError as exc:
-        if exc.code in (ERROR_INVALID_PARAMS, ERROR_METHOD_NOT_FOUND):
-            return result(SmokeVerdict.PASS, f"rejected with JSON-RPC error {exc.code}", error_code=exc.code)
+        # The spec's unknown-tool example is -32602, but the code is
+        # exemplary, not mandated — any JSON-RPC error the server sends is a
+        # rejection. The failures are the non-rejections: a hang, a dead
+        # transport (the SDK surfaces it as CONNECTION_CLOSED), and an
+        # internal error (the server tried to execute the name and broke —
+        # the "500" this check exists to catch).
         if exc.code == REQUEST_TIMEOUT:
             return result(
                 SmokeVerdict.FAIL,
                 f"no answer within {SMOKE_CALL_TIMEOUT_S:.0f}s of calling a nonexistent tool — a hang, not a rejection",
                 error_code=exc.code,
             )
-        return result(
-            SmokeVerdict.FAIL,
-            f"answered JSON-RPC error {exc.code} instead of a method/params protocol error "
-            f"({ERROR_METHOD_NOT_FOUND}/{ERROR_INVALID_PARAMS})",
-            error_code=exc.code,
-        )
+        if exc.code == CONNECTION_CLOSED:
+            return result(
+                SmokeVerdict.FAIL,
+                "connection closed on a nonexistent tool call — a crash, not a rejection",
+                error_code=exc.code,
+            )
+        if exc.code == ERROR_INTERNAL:
+            return result(
+                SmokeVerdict.FAIL,
+                f"answered JSON-RPC internal error {exc.code} — a server-side crash, not a rejection "
+                f"(the spec's unknown-tool example is {ERROR_INVALID_PARAMS})",
+                error_code=exc.code,
+            )
+        return result(SmokeVerdict.PASS, f"rejected with JSON-RPC error {exc.code}", error_code=exc.code)
     except Exception as exc:  # noqa: BLE001 — a smoke check never aborts the run
         return result(SmokeVerdict.FAIL, f"tools/call on a nonexistent tool crashed: {type(exc).__name__}")
     if isinstance(call_result, CallToolResult) and call_result.is_error:
@@ -418,7 +460,13 @@ async def _check_unknown_tool(session: ClientSession) -> SmokeCheckResult:
     return result(SmokeVerdict.FAIL, "answered a nonexistent tool name with a result instead of rejecting it")
 
 
-async def run_smoke_checks(session: ClientSession, tools: Sequence[Tool] | None, *, call_all: bool) -> SmokeReport:
+async def run_smoke_checks(
+    session: ClientSession,
+    tools: Sequence[Tool] | None,
+    *,
+    call_all: bool,
+    catalog_complete: bool,
+) -> SmokeReport:
     """Run every smoke check sequentially on the audit's established session.
 
     Sequential on purpose: one in-flight ``tools/call`` at a time keeps the
@@ -428,9 +476,13 @@ async def run_smoke_checks(session: ClientSession, tools: Sequence[Tool] | None,
     Args:
         session: The live session the audit connected (never closed by the
             auditor; the CLI's cleanup closes it afterwards).
-        tools: The audit's collected tool listing (None when listing failed —
-            the server-level unknown-tool check still runs).
+        tools: The audit's collected tool listing (None when listing failed).
         call_all: Lift the readOnlyHint safety default (--call-all).
+        catalog_complete: Whether ``tools`` is the server's complete catalog.
+            The unknown-tool check calls a name chosen for being absent from
+            it; with a missing or incomplete catalog, nonexistence cannot be
+            established and the probe could invoke a real, unannotated tool —
+            so that check skips instead.
 
     """
     report = SmokeReport(executed=True, call_all=call_all)
@@ -440,5 +492,17 @@ async def run_smoke_checks(session: ClientSession, tools: Sequence[Tool] | None,
     for tool in tools or []:
         skip_reason = _tool_skip_reason(tool, call_all=call_all)
         report.checks.append(await _check_invalid_arguments(session, tool, skip_reason))
-    report.checks.append(await _check_unknown_tool(session))
+    if tools is None or not catalog_complete:
+        report.checks.append(
+            SmokeCheckResult(
+                CHECK_UNKNOWN_TOOL,
+                SmokeVerdict.SKIP,
+                "tool catalog unavailable or incomplete — a name cannot be proven nonexistent, and calling a "
+                "possibly-real tool would bypass the safety default",
+                None,
+                {"basis": BASIS_UNKNOWN_TOOL},
+            )
+        )
+    else:
+        report.checks.append(await _check_unknown_tool(session, derive_unknown_tool_name(tools)))
     return report

--- a/tests/stdio_smoke_server.py
+++ b/tests/stdio_smoke_server.py
@@ -1,0 +1,128 @@
+"""Stdlib-only legacy MCP stdio server for the real-process smoke-mode test.
+
+Speaks enough of the legacy (stateful) protocol over newline-delimited
+JSON-RPC to complete the initialize handshake, list a small tool catalog, and
+answer ``tools/call`` — the surface the ``--smoke`` checks exercise. Each tool
+scripts one smoke outcome:
+
+- ``honest``    — readOnlyHint, outputSchema honored, invalid args rejected.
+- ``dishonest`` — readOnlyHint, structuredContent violates its outputSchema.
+- ``sloppy``    — readOnlyHint, no outputSchema, accepts schema-invalid args.
+- ``writer``    — unannotated: the safety default must never call it (calling
+  it is wired to crash the process so a violation cannot pass unnoticed).
+
+Unknown tool names are rejected with the spec's exemplary protocol error
+(-32602). Deliberately stdlib-only, like its sibling fixtures: the point is a
+fixed, readable wire contract, not a re-test of the MCP SDK.
+
+Not a test module (no ``test_`` prefix): pytest never collects it; it is only
+ever launched as a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+STRING_ARG_SCHEMA = {
+    "type": "object",
+    "properties": {"q": {"type": "string"}},
+    "required": ["q"],
+}
+
+RESULT_SCHEMA = {
+    "type": "object",
+    "properties": {"result": {"type": "string"}},
+    "required": ["result"],
+}
+
+READ_ONLY = {"readOnlyHint": True}
+
+TOOLS = [
+    {"name": "honest", "inputSchema": STRING_ARG_SCHEMA, "outputSchema": RESULT_SCHEMA, "annotations": READ_ONLY},
+    {"name": "dishonest", "inputSchema": STRING_ARG_SCHEMA, "outputSchema": RESULT_SCHEMA, "annotations": READ_ONLY},
+    {"name": "sloppy", "inputSchema": STRING_ARG_SCHEMA, "annotations": READ_ONLY},
+    {"name": "writer", "inputSchema": STRING_ARG_SCHEMA, "outputSchema": RESULT_SCHEMA},
+]
+
+
+def _error(request_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def _result(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _tool_result(request_id: Any, structured: dict[str, Any] | None) -> dict[str, Any]:
+    result: dict[str, Any] = {"content": [{"type": "text", "text": json.dumps(structured or {})}]}
+    if structured is not None:
+        result["structuredContent"] = structured
+    return _result(request_id, result)
+
+
+def _handle_call(request_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+
+    if name == "writer":
+        # The safety default must never let this run; dying loudly turns a
+        # violation into an unmistakable transport failure in the test.
+        sys.exit(13)
+
+    if name not in ("honest", "dishonest", "sloppy"):
+        return _error(request_id, -32602, f"Unknown tool: {name}")
+
+    if name == "sloppy":  # accepts anything, returns a bare success
+        return _tool_result(request_id, None)
+    if not isinstance(arguments.get("q"), str):
+        return _error(request_id, -32602, "Invalid arguments: q must be a string")
+    if name == "dishonest":
+        return _tool_result(request_id, {"wrong_key": 1})
+    return _tool_result(request_id, {"result": "ok"})
+
+
+def _handle(message: dict[str, Any]) -> dict[str, Any] | None:
+    request_id = message.get("id")
+    if request_id is None:  # a notification: nothing to answer
+        return None
+    method = message.get("method")
+    params = message.get("params") or {}
+
+    if method == "initialize":
+        return _result(
+            request_id,
+            {
+                "protocolVersion": params["protocolVersion"],
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "stdio-smoke-server", "version": "1.0.0"},
+            },
+        )
+    if method == "tools/list":
+        return _result(request_id, {"tools": TOOLS})
+    if method == "tools/call":
+        return _handle_call(request_id, params)
+    return _error(request_id, -32601, "Method not found")
+
+
+def main() -> None:
+    """Serve one request per line until stdin closes."""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(message, dict):
+            continue
+        response = _handle(message)
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2235,7 +2235,9 @@ class TestSmokeCliFlow:
             await async_main()
 
         assert exc_info.value.code == 4
-        fake_run.assert_awaited_once_with(mock_client.session, mock_auditor.audit_data.tools, call_all=False)
+        fake_run.assert_awaited_once_with(
+            mock_client.session, mock_auditor.audit_data.tools, call_all=False, catalog_complete=True
+        )
         mock_client.cleanup.assert_awaited_once()
 
     async def test_call_all_is_propagated(
@@ -2255,7 +2257,9 @@ class TestSmokeCliFlow:
         ):
             await async_main()
 
-        fake_run.assert_awaited_once_with(mock_client.session, mock_auditor.audit_data.tools, call_all=True)
+        fake_run.assert_awaited_once_with(
+            mock_client.session, mock_auditor.audit_data.tools, call_all=True, catalog_complete=True
+        )
 
     async def test_without_smoke_the_phase_never_runs(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ from mcpscore.cli import (
 )
 from mcpscore.enums import ConnectionErrorReason
 from mcpscore.packages import PackageCoordinate, PackageMetadata, PackageOutcome
+from mcpscore.smoke import CHECK_UNKNOWN_TOOL, SmokeCheckResult, SmokeReport, SmokeVerdict
 
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
@@ -2079,3 +2080,222 @@ class TestFailUnderValidationAndPackages:
 
         # 3/13 = 23% >= 20%.
         assert fail_under_exit_code(args, _report_payload()) == 0
+
+
+def _smoke_check(verdict: SmokeVerdict, tool_name: str | None = "reader") -> SmokeCheckResult:
+    return SmokeCheckResult("smoke_structured_content", verdict, f"scripted {verdict.value}", tool_name)
+
+
+def _smoke_report(*verdicts: SmokeVerdict, call_all: bool = False) -> SmokeReport:
+    return SmokeReport(executed=True, call_all=call_all, checks=[_smoke_check(verdict) for verdict in verdicts])
+
+
+class TestSmokeCliFlow:
+    """--smoke: flag validation, the exit-4 gate, reporting, and the no-session paths."""
+
+    def test_call_all_without_smoke_is_a_usage_error(self) -> None:
+        args = build_parser().parse_args(["https://example.com/mcp", "--call-all"])
+        with pytest.raises(ValueError, match="only applies together with --smoke"):
+            resolve_target(args)
+
+    def test_smoke_with_package_is_a_usage_error(self) -> None:
+        args = build_parser().parse_args(["--package", "npm:server", "--smoke"])
+        with pytest.raises(ValueError, match="never runs the package"):
+            resolve_target(args)
+
+    def test_smoke_flags_parse_alongside_a_target(self) -> None:
+        args = build_parser().parse_args(["https://example.com/mcp", "--smoke", "--call-all"])
+        assert args.smoke is True
+        assert args.call_all is True
+        assert resolve_target(args) == "https://example.com/mcp"
+
+    def test_smoke_failure_exits_4(self, mock_auditor: MagicMock, caplog: LogCaptureFixture) -> None:
+        from mcpscore.cli import finish_server_audit
+
+        args = build_parser().parse_args(["https://example.com/mcp", "--smoke"])
+        smoke = _smoke_report(SmokeVerdict.PASS, SmokeVerdict.FAIL)
+
+        with caplog.at_level(logging.ERROR), pytest.raises(SystemExit) as exc_info:
+            finish_server_audit(args, mock_auditor, "https://example.com/mcp", None, smoke=smoke)
+
+        assert exc_info.value.code == 4
+        assert "--smoke: 1 smoke check(s) failed" in caplog.text
+
+    def test_fail_under_takes_precedence_over_smoke(self, mock_auditor: MagicMock) -> None:
+        """When both gates fail, the score gate's 3 wins — one exit carries one code."""
+        from mcpscore.cli import finish_server_audit
+
+        args = build_parser().parse_args(["https://example.com/mcp", "--smoke", "--fail-under", "90"])
+        smoke = _smoke_report(SmokeVerdict.FAIL)
+
+        with pytest.raises(SystemExit) as exc_info:
+            finish_server_audit(args, mock_auditor, "https://example.com/mcp", None, smoke=smoke)
+
+        assert exc_info.value.code == 3
+
+    def test_all_passing_smoke_returns_normally(self, mock_auditor: MagicMock) -> None:
+        from mcpscore.cli import finish_server_audit
+
+        args = build_parser().parse_args(["https://example.com/mcp", "--smoke"])
+        smoke = _smoke_report(SmokeVerdict.PASS, SmokeVerdict.SKIP)
+
+        finish_server_audit(args, mock_auditor, "https://example.com/mcp", None, smoke=smoke)  # no SystemExit
+
+    def test_skips_never_gate(self, mock_auditor: MagicMock) -> None:
+        """All-skip smoke (e.g. nothing annotated readOnlyHint) exits 0, not 4."""
+        from mcpscore.cli import finish_server_audit
+
+        args = build_parser().parse_args(["https://example.com/mcp", "--smoke"])
+        smoke = _smoke_report(SmokeVerdict.SKIP, SmokeVerdict.SKIP)
+
+        finish_server_audit(args, mock_auditor, "https://example.com/mcp", None, smoke=smoke)  # no SystemExit
+
+    def test_json_report_carries_the_smoke_section(
+        self, mock_auditor: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from mcpscore.cli import finish_server_audit
+
+        args = build_parser().parse_args(["https://example.com/mcp", "--smoke", "--json"])
+        smoke = _smoke_report(SmokeVerdict.PASS)
+
+        finish_server_audit(args, mock_auditor, "https://example.com/mcp", None, smoke=smoke)
+
+        report = json.loads(capsys.readouterr().out)
+        assert report["smoke"]["executed"] is True
+        assert report["smoke"]["summary"] == {"passed": 1, "failed": 0, "skipped": 0}
+        assert report["smoke"]["checks"][0]["verdict"] == "pass"
+
+    def test_json_report_has_no_smoke_key_without_the_flag(
+        self, mock_auditor: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from mcpscore.cli import finish_server_audit
+
+        args = build_parser().parse_args(["https://example.com/mcp", "--json"])
+
+        finish_server_audit(args, mock_auditor, "https://example.com/mcp", None)
+
+        assert "smoke" not in json.loads(capsys.readouterr().out)
+
+    def test_log_smoke_outcome_reports_failures_and_skips(self, caplog: LogCaptureFixture) -> None:
+        from mcpscore.cli import log_smoke_outcome
+
+        smoke = SmokeReport(
+            executed=True,
+            checks=[
+                _smoke_check(SmokeVerdict.PASS),
+                _smoke_check(SmokeVerdict.FAIL),
+                _smoke_check(SmokeVerdict.SKIP),
+                SmokeCheckResult(CHECK_UNKNOWN_TOOL, SmokeVerdict.FAIL, "server-level failure", None),
+            ],
+        )
+
+        with caplog.at_level(logging.INFO):
+            log_smoke_outcome(smoke)
+
+        assert "1 passed, 2 failed, 1 skipped" in caplog.text
+        assert "FAIL smoke_structured_content [reader]: scripted fail" in caplog.text
+        assert "skip smoke_structured_content [reader]: scripted skip" in caplog.text
+        # A server-level check has no [tool] suffix.
+        assert "FAIL smoke_unknown_tool: server-level failure" in caplog.text
+        assert "only readOnlyHint: true tools called" in caplog.text
+
+    def test_log_smoke_outcome_call_all_variant(self, caplog: LogCaptureFixture) -> None:
+        from mcpscore.cli import log_smoke_outcome
+
+        with caplog.at_level(logging.INFO):
+            log_smoke_outcome(_smoke_report(SmokeVerdict.PASS, call_all=True))
+
+        assert "every tool called (--call-all)" in caplog.text
+
+    def test_log_smoke_outcome_not_executed_warns(self, caplog: LogCaptureFixture) -> None:
+        from mcpscore.cli import log_smoke_outcome
+
+        with caplog.at_level(logging.WARNING):
+            log_smoke_outcome(SmokeReport.not_executed("no session available"))
+
+        assert "Smoke checks did not run: no session available" in caplog.text
+
+    async def test_full_audit_with_smoke_runs_checks_and_exits_4(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        """The smoke phase runs on the audit's session and its failure gates the run."""
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://example.com/mcp", "--smoke"])
+        mock_client.session = MagicMock()
+        fake_run = AsyncMock(return_value=_smoke_report(SmokeVerdict.FAIL))
+        monkeypatch.setattr("mcpscore.cli.run_smoke_checks", fake_run)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            await async_main()
+
+        assert exc_info.value.code == 4
+        fake_run.assert_awaited_once_with(mock_client.session, mock_auditor.audit_data.tools, call_all=False)
+        mock_client.cleanup.assert_awaited_once()
+
+    async def test_call_all_is_propagated(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["mcpscore", "https://example.com/mcp", "--smoke", "--call-all"])
+        mock_client.session = MagicMock()
+        fake_run = AsyncMock(return_value=_smoke_report(SmokeVerdict.PASS))
+        monkeypatch.setattr("mcpscore.cli.run_smoke_checks", fake_run)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        fake_run.assert_awaited_once_with(mock_client.session, mock_auditor.audit_data.tools, call_all=True)
+
+    async def test_without_smoke_the_phase_never_runs(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["mcpscore", "https://example.com/mcp"])
+        fake_run = AsyncMock()
+        monkeypatch.setattr("mcpscore.cli.run_smoke_checks", fake_run)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+        ):
+            await async_main()
+
+        fake_run.assert_not_awaited()
+
+    async def test_modern_only_audit_reports_smoke_as_not_executed(
+        self,
+        monkeypatch: MonkeyPatch,
+        mock_client: MagicMock,
+        mock_auditor: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+        caplog: LogCaptureFixture,
+    ) -> None:
+        """A probe-only audit has no session; --smoke reports that instead of silently vanishing."""
+        monkeypatch.setattr(sys, "argv", ["mcpscore", "https://modern.example/mcp", "--smoke", "--json"])
+        mock_client.detect_and_connect = AsyncMock(return_value=(False, None))
+        mock_auditor.audit_modern_only = AsyncMock(return_value=True)
+
+        with (
+            patch("mcpscore.cli.MCPClient", return_value=mock_client),
+            patch("mcpscore.cli.MCPAuditor", return_value=mock_auditor),
+            caplog.at_level(logging.INFO),
+        ):
+            await async_main()  # not-executed smoke has no failures: no SystemExit
+
+        report = json.loads(capsys.readouterr().out)
+        assert report["smoke"]["executed"] is False
+        assert "modern-only" in report["smoke"]["reason"]
+        assert "Smoke checks did not run" in caplog.text

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -24,6 +24,7 @@ from mcpscore.smoke import (
     SmokeCheckResult,
     SmokeReport,
     SmokeVerdict,
+    derive_unknown_tool_name,
     run_smoke_checks,
     synthesize_arguments,
     synthesize_invalid_arguments,
@@ -33,6 +34,7 @@ from mcpscore.smoke import (
 ERROR_INVALID_PARAMS = -32602
 ERROR_METHOD_NOT_FOUND = -32601
 ERROR_INTERNAL = -32603
+ERROR_CONNECTION_CLOSED = -32000  # the SDK's code for a dead transport
 
 
 class FakeSession:
@@ -83,7 +85,7 @@ OUTPUT_SCHEMA = {"type": "object", "properties": {"result": {"type": "string"}},
 
 async def single_check(session: FakeSession, tool: Tool, check_id: str, *, call_all: bool = False) -> SmokeCheckResult:
     """Run the smoke suite for one tool and return its result for one check."""
-    report = await run_smoke_checks(session, [tool], call_all=call_all)  # type: ignore[arg-type]
+    report = await run_smoke_checks(session, [tool], call_all=call_all, catalog_complete=True)  # type: ignore[arg-type]
     matches = [check for check in report.checks if check.check_id == check_id]
     assert len(matches) == 1
     return matches[0]
@@ -261,6 +263,22 @@ class TestStructuredContentCheck:
         await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
         assert ("reader", {"q": ""}) in session.calls
 
+    async def test_empty_output_schema_is_still_exercised(self) -> None:
+        """{} is a declared schema anything conforms to — but structuredContent must be PRESENT."""
+        tool = read_only_tool(output_schema={})
+        session = FakeSession(
+            {"reader": RuntimeError("Tool reader has an output schema but did not return structured content")}
+        )
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "not honored" in check.message
+
+    async def test_empty_output_schema_with_structured_content_passes(self) -> None:
+        tool = read_only_tool(output_schema={})
+        session = FakeSession({"reader": CallToolResult(content=[], structured_content={"anything": True})})
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.PASS
+
 
 class TestInvalidArgumentsCheck:
     async def test_jsonrpc_rejection_passes(self) -> None:
@@ -286,6 +304,12 @@ class TestInvalidArgumentsCheck:
         check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
         assert check.verdict is SmokeVerdict.FAIL
         assert "hang" in check.message
+
+    async def test_connection_closed_fails_as_crash_not_rejection(self) -> None:
+        session = FakeSession({"reader": MCPError(code=ERROR_CONNECTION_CLOSED, message="Connection closed")})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "crash" in check.message
 
     async def test_sdk_validation_error_fails_as_acceptance(self) -> None:
         # The server produced a (schema-violating) success result for invalid
@@ -321,45 +345,99 @@ class TestInvalidArgumentsCheck:
 
 
 class TestUnknownToolCheck:
-    @pytest.mark.parametrize("code", [ERROR_INVALID_PARAMS, ERROR_METHOD_NOT_FOUND])
-    async def test_protocol_error_passes(self, code: int) -> None:
+    # -32050 stands in for a server-defined rejection code: the spec's
+    # unknown-tool -32602 is exemplary, so any JSON-RPC error is a rejection
+    # (except the SDK-reserved timeout/connection-closed/internal codes).
+    @pytest.mark.parametrize("code", [ERROR_INVALID_PARAMS, ERROR_METHOD_NOT_FOUND, -32050])
+    async def test_any_rejection_error_passes(self, code: int) -> None:
         session = FakeSession(default=MCPError(code=code, message="Unknown tool"))
-        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         (check,) = report.checks
         assert check.check_id == CHECK_UNKNOWN_TOOL
         assert check.verdict is SmokeVerdict.PASS
         assert check.tool_name is None
         assert session.calls == [(UNKNOWN_TOOL_NAME, {})]
 
-    async def test_other_error_code_fails(self) -> None:
+    async def test_internal_error_fails_as_server_crash(self) -> None:
         session = FakeSession(default=MCPError(code=ERROR_INTERNAL, message="oops"))
-        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         assert report.checks[0].verdict is SmokeVerdict.FAIL
         assert str(ERROR_INTERNAL) in report.checks[0].message
+        assert "crash" in report.checks[0].message
+
+    async def test_connection_closed_fails_as_crash(self) -> None:
+        """Treat the SDK's dead-transport MCPError(-32000) as a crash.
+
+        Accepting it as a 'rejection' would let a crashed server pass.
+        """
+        session = FakeSession(default=MCPError(code=ERROR_CONNECTION_CLOSED, message="Connection closed"))
+        report = await run_smoke_checks(session, [], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
+        assert report.checks[0].verdict is SmokeVerdict.FAIL
+        assert "crash" in report.checks[0].message
 
     async def test_timeout_fails_as_hang(self) -> None:
         session = FakeSession(default=MCPError(code=REQUEST_TIMEOUT, message="timed out"))
-        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         assert report.checks[0].verdict is SmokeVerdict.FAIL
         assert "hang" in report.checks[0].message
 
     async def test_success_result_fails(self) -> None:
         session = FakeSession(default=CallToolResult(content=[]))
-        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         assert report.checks[0].verdict is SmokeVerdict.FAIL
         assert "instead of rejecting" in report.checks[0].message
 
     async def test_is_error_result_fails(self) -> None:
         session = FakeSession(default=CallToolResult(content=[], is_error=True))
-        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         assert report.checks[0].verdict is SmokeVerdict.FAIL
         assert "isError" in report.checks[0].message
 
     async def test_transport_crash_fails(self) -> None:
         session = FakeSession(default=ConnectionError("boom"))
-        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         assert report.checks[0].verdict is SmokeVerdict.FAIL
         assert "crashed" in report.checks[0].message
+
+
+class TestUnknownToolNameSafety:
+    """A nonexistent name must be proven nonexistent, never assumed."""
+
+    def test_derivation_is_deterministic_and_collision_free(self) -> None:
+        assert derive_unknown_tool_name([]) == UNKNOWN_TOOL_NAME
+        colliding = [read_only_tool(UNKNOWN_TOOL_NAME), read_only_tool(f"{UNKNOWN_TOOL_NAME}_2")]
+        assert derive_unknown_tool_name(colliding) == f"{UNKNOWN_TOOL_NAME}_3"
+
+    async def test_a_real_tool_with_the_base_name_is_never_called(self) -> None:
+        """Dodge a real tool that legally uses the base name.
+
+        Calling it would invoke an unannotated tool past the safety default.
+        """
+        real_tool = Tool(name=UNKNOWN_TOOL_NAME, input_schema={"type": "object"})
+        session = FakeSession(default=MCPError(code=ERROR_INVALID_PARAMS, message="Unknown tool"))
+        report = await run_smoke_checks(session, [real_tool], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
+        unknown = next(check for check in report.checks if check.check_id == CHECK_UNKNOWN_TOOL)
+        assert unknown.verdict is SmokeVerdict.PASS
+        assert unknown.details["requested_tool"] == f"{UNKNOWN_TOOL_NAME}_2"
+        assert session.calls == [(f"{UNKNOWN_TOOL_NAME}_2", {})]
+
+    async def test_missing_catalog_skips_the_check(self) -> None:
+        session = FakeSession()
+        report = await run_smoke_checks(session, None, call_all=False, catalog_complete=True)  # type: ignore[arg-type]
+        (check,) = report.checks
+        assert check.check_id == CHECK_UNKNOWN_TOOL
+        assert check.verdict is SmokeVerdict.SKIP
+        assert "safety default" in check.message
+        assert session.calls == []
+
+    async def test_incomplete_catalog_skips_the_check(self) -> None:
+        session = FakeSession({"reader": MCPError(code=ERROR_INVALID_PARAMS, message="bad")})
+        report = await run_smoke_checks(session, [read_only_tool()], call_all=False, catalog_complete=False)  # type: ignore[arg-type]
+        unknown = next(check for check in report.checks if check.check_id == CHECK_UNKNOWN_TOOL)
+        assert unknown.verdict is SmokeVerdict.SKIP
+        assert "incomplete" in unknown.message
+        # The listed tool is still exercised; only the unknown-name probe is off.
+        assert all(name == "reader" for name, _ in session.calls)
 
 
 class TestSafetyDefault:
@@ -374,7 +452,7 @@ class TestSafetyDefault:
             name="writer", input_schema={"type": "object"}, output_schema=OUTPUT_SCHEMA, annotations=annotations
         )
         session = FakeSession()
-        report = await run_smoke_checks(session, [tool], call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [tool], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         per_tool = [check for check in report.checks if check.tool_name == "writer"]
         assert len(per_tool) == 2
         assert all(check.verdict is SmokeVerdict.SKIP for check in per_tool)
@@ -388,7 +466,7 @@ class TestSafetyDefault:
             output_schema=OUTPUT_SCHEMA,
         )
         session = FakeSession({"writer": CallToolResult(content=[], structured_content={"result": "ok"})})
-        report = await run_smoke_checks(session, [tool], call_all=True)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, [tool], call_all=True, catalog_complete=True)  # type: ignore[arg-type]
         assert report.call_all is True
         called_tools = {name for name, _ in session.calls}
         assert "writer" in called_tools
@@ -404,7 +482,7 @@ class TestRunSmokeChecks:
             },
             default=MCPError(code=ERROR_INVALID_PARAMS, message="Unknown tool"),
         )
-        report = await run_smoke_checks(session, tools, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, tools, call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         assert [(check.check_id, check.tool_name) for check in report.checks] == [
             (CHECK_STRUCTURED_CONTENT, "alpha"),
             (CHECK_STRUCTURED_CONTENT, "beta"),
@@ -421,7 +499,7 @@ class TestRunSmokeChecks:
             {"alpha": CallToolResult(content=[], structured_content={"result": "ok"})},
             default=MCPError(code=ERROR_INVALID_PARAMS, message="Unknown tool"),
         )
-        report = await run_smoke_checks(session, tools, call_all=False)  # type: ignore[arg-type]
+        report = await run_smoke_checks(session, tools, call_all=False, catalog_complete=True)  # type: ignore[arg-type]
         # alpha: structured-content pass; invalid-arguments... alpha returns a
         # success result for the invalid call → fail. Unknown tool → pass.
         assert (report.passed, report.failed, report.skipped) == (2, 1, 0)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -164,6 +164,16 @@ class TestSynthesizeArguments:
         schema = {"type": "object", "properties": {"a": {"type": "string"}, "b": True}, "required": ["a", "b", "c"]}
         assert synthesize_arguments(schema) == {"a": ""}
 
+    def test_malformed_required_entries_are_ignored(self) -> None:
+        """Non-string required entries must not abort synthesis with TypeError.
+
+        A model-accepted schema can still carry garbage in ``required`` (e.g.
+        nested lists). Dict lookup would raise; smoke mode must keep going.
+        """
+        schema = {"type": "object", "properties": {"q": {"type": "string"}}, "required": [[], {"not": "a-name"}, "q"]}
+        assert synthesize_arguments(schema) == {"q": ""}
+        assert synthesize_arguments({"properties": {"q": {"type": "string"}}, "required": [[]]}) == {}
+
 
 class TestSynthesizeInvalidArguments:
     @pytest.mark.parametrize(
@@ -203,6 +213,11 @@ class TestSynthesizeInvalidArguments:
     )
     def test_nothing_violable_yields_none(self, schema: Any) -> None:
         assert synthesize_invalid_arguments(schema) is None
+
+    def test_malformed_required_does_not_abort_invalid_synthesis(self) -> None:
+        """Wrong-typed violation still works when required is garbage."""
+        schema = {"type": "object", "properties": {"q": {"type": "string"}}, "required": [[]]}
+        assert synthesize_invalid_arguments(schema) == {"q": 42}
 
 
 class TestStructuredContentCheck:
@@ -349,6 +364,31 @@ class TestInvalidArgumentsCheck:
         check = await single_check(session, tool, CHECK_INVALID_ARGUMENTS)
         assert check.verdict is SmokeVerdict.SKIP
         assert "nothing invalid to send" in check.message
+
+    async def test_malformed_required_does_not_abort_the_run(self) -> None:
+        """A broken required array must yield a verdict, never raise out of run_smoke_checks."""
+        tool = read_only_tool(
+            input_schema={"type": "object", "properties": {"q": {"type": "string"}}, "required": [[]]}
+        )
+        session = FakeSession({"reader": MCPError(code=ERROR_INVALID_PARAMS, message="bad args")})
+        report = await run_smoke_checks(session, [tool], call_all=False, catalog_complete=True)  # type: ignore[arg-type]
+        invalid = next(check for check in report.checks if check.check_id == CHECK_INVALID_ARGUMENTS)
+        assert invalid.verdict is SmokeVerdict.PASS
+        assert ("reader", {"q": 42}) in session.calls
+
+    async def test_synthesis_exception_skips_instead_of_aborting(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Defense in depth: any unexpected synthesis raise becomes a skip verdict."""
+        from mcpscore import smoke
+
+        def boom(_schema: object) -> dict[str, Any] | None:
+            raise RuntimeError("synthetic boom")
+
+        monkeypatch.setattr(smoke, "synthesize_invalid_arguments", boom)
+        session = FakeSession()
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.SKIP
+        assert "could not derive" in check.message
+        assert all(name != "reader" or args != {"q": 42} for name, args in session.calls)
 
     async def test_wrong_typed_value_is_sent(self) -> None:
         session = FakeSession({"reader": MCPError(code=ERROR_INVALID_PARAMS, message="bad args")})

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -219,6 +219,74 @@ class TestSynthesizeInvalidArguments:
         schema = {"type": "object", "properties": {"q": {"type": "string"}}, "required": [[]]}
         assert synthesize_invalid_arguments(schema) == {"q": 42}
 
+    def test_required_without_properties_omits_the_required_property(self) -> None:
+        """A schema whose only constraint is `required` is violated by {}."""
+        schema = {"type": "object", "required": ["token"]}
+        assert synthesize_invalid_arguments(schema) == {}
+
+    def test_required_untyped_property_is_omitted(self) -> None:
+        schema = {"type": "object", "properties": {"token": {}}, "required": ["token"]}
+        assert synthesize_invalid_arguments(schema) == {}
+
+    def test_enum_only_property_gets_a_value_outside_the_enum(self) -> None:
+        schema = {"type": "object", "properties": {"color": {"enum": ["red", "green"]}}}
+        assert synthesize_invalid_arguments(schema) == {"color": "mcpscore-smoke-invalid-value"}
+
+    def test_enum_containing_the_first_candidate_uses_the_next(self) -> None:
+        schema = {"type": "object", "properties": {"color": {"enum": ["mcpscore-smoke-invalid-value"]}}}
+        assert synthesize_invalid_arguments(schema) == {"color": 42}
+
+    def test_const_only_property_gets_a_different_value(self) -> None:
+        schema = {"type": "object", "properties": {"mode": {"const": "fast"}}}
+        assert synthesize_invalid_arguments(schema) == {"mode": "mcpscore-smoke-invalid-value"}
+
+    def test_enum_allowing_every_candidate_is_not_violated(self) -> None:
+        """Exhaust the candidate ladder without inventing a violation.
+
+        A pathological enum containing every ladder value cannot be violated
+        through that property; with nothing else to violate, synthesis skips.
+        """
+        every_candidate = ["mcpscore-smoke-invalid-value", 42, False, [], {"mcpscore": "invalid"}]
+        schema = {"type": "object", "properties": {"p": {"enum": every_candidate}}}
+        assert synthesize_invalid_arguments(schema) is None
+
+    def test_additional_properties_false_gets_an_unexpected_property(self) -> None:
+        schema = {"type": "object", "additionalProperties": False}
+        assert synthesize_invalid_arguments(schema) == {"mcpscore_smoke_unexpected_property": True}
+
+    def test_unexpected_property_name_dodges_a_declared_collision(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"mcpscore_smoke_unexpected_property": True},
+            "additionalProperties": False,
+        }
+        assert synthesize_invalid_arguments(schema) == {"mcpscore_smoke_unexpected_property_x": True}
+
+    def test_violation_strategies_apply_in_a_fixed_order(self) -> None:
+        """One deterministic violation per schema, in fixed strategy order.
+
+        Wrong type beats enum, enum beats missing-required, and
+        missing-required beats additionalProperties.
+        """
+        typed_and_enum = {
+            "type": "object",
+            "properties": {"color": {"enum": ["red"]}, "q": {"type": "string"}},
+            "required": ["q"],
+            "additionalProperties": False,
+        }
+        assert synthesize_invalid_arguments(typed_and_enum) == {"q": 42}
+
+        enum_and_required = {
+            "type": "object",
+            "properties": {"color": {"enum": ["red"]}},
+            "required": ["token"],
+            "additionalProperties": False,
+        }
+        assert synthesize_invalid_arguments(enum_and_required) == {"color": "mcpscore-smoke-invalid-value"}
+
+        required_and_additional = {"type": "object", "required": ["token"], "additionalProperties": False}
+        assert synthesize_invalid_arguments(required_and_additional) == {}
+
 
 class TestStructuredContentCheck:
     async def test_conforming_result_passes(self) -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -311,6 +311,18 @@ class TestInvalidArgumentsCheck:
         assert check.verdict is SmokeVerdict.FAIL
         assert "crash" in check.message
 
+    async def test_internal_error_fails_as_crash_not_rejection(self) -> None:
+        """Fail -32603 like the unknown-tool check does.
+
+        An internal error means the server ran the schema-invalid call and
+        broke — not that it rejected it.
+        """
+        session = FakeSession({"reader": MCPError(code=ERROR_INTERNAL, message="boom")})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "crash" in check.message
+        assert check.details["error_code"] == ERROR_INTERNAL
+
     async def test_sdk_validation_error_fails_as_acceptance(self) -> None:
         # The server produced a (schema-violating) success result for invalid
         # input — the defect is the acceptance, not the content.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,452 @@
+"""Tests for the --smoke check module.
+
+Covers the deterministic argument synthesis, the verdict logic of each check
+against a scripted fake session (every pass/fail/skip branch), and the
+report/serialization shapes. The CLI wiring (flags, exit code 4, the smoke
+report section) is tested in test_cli.py; the real-process integration runs
+in test_smoke_stdio_e2e.py against a fixture server.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.shared.exceptions import MCPError
+from mcp_types import REQUEST_TIMEOUT, CallToolResult, Tool, ToolAnnotations
+import pytest
+
+from mcpscore.smoke import (
+    CHECK_INVALID_ARGUMENTS,
+    CHECK_STRUCTURED_CONTENT,
+    CHECK_UNKNOWN_TOOL,
+    SMOKE_CALL_TIMEOUT_S,
+    UNKNOWN_TOOL_NAME,
+    SmokeCheckResult,
+    SmokeReport,
+    SmokeVerdict,
+    run_smoke_checks,
+    synthesize_arguments,
+    synthesize_invalid_arguments,
+    synthesize_value,
+)
+
+ERROR_INVALID_PARAMS = -32602
+ERROR_METHOD_NOT_FOUND = -32601
+ERROR_INTERNAL = -32603
+
+
+class FakeSession:
+    """Scripted stand-in for mcp.ClientSession.call_tool.
+
+    ``behaviors`` maps a tool name to either an exception instance (raised) or
+    a return value. Records every call for assertions on order, arguments,
+    and the safety default.
+    """
+
+    def __init__(self, behaviors: dict[str, Any] | None = None, default: Any = None) -> None:
+        self.behaviors = behaviors or {}
+        self.default = default if default is not None else CallToolResult(content=[])
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        read_timeout_seconds: float | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        assert read_timeout_seconds == SMOKE_CALL_TIMEOUT_S
+        assert kwargs == {"allow_input_required": True, "allow_claimed": True}
+        self.calls.append((name, arguments))
+        behavior = self.behaviors.get(name, self.default)
+        if isinstance(behavior, BaseException):
+            raise behavior
+        return behavior
+
+
+def read_only_tool(
+    name: str = "reader",
+    *,
+    input_schema: dict[str, Any] | None = None,
+    output_schema: dict[str, Any] | None = None,
+) -> Tool:
+    return Tool(
+        name=name,
+        input_schema=input_schema or {"type": "object", "properties": {"q": {"type": "string"}}, "required": ["q"]},
+        output_schema=output_schema,
+        annotations=ToolAnnotations(read_only_hint=True),
+    )
+
+
+OUTPUT_SCHEMA = {"type": "object", "properties": {"result": {"type": "string"}}, "required": ["result"]}
+
+
+async def single_check(session: FakeSession, tool: Tool, check_id: str, *, call_all: bool = False) -> SmokeCheckResult:
+    """Run the smoke suite for one tool and return its result for one check."""
+    report = await run_smoke_checks(session, [tool], call_all=call_all)  # type: ignore[arg-type]
+    matches = [check for check in report.checks if check.check_id == check_id]
+    assert len(matches) == 1
+    return matches[0]
+
+
+class TestSynthesizeValue:
+    """The deterministic sample-value derivation, hint by hint."""
+
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            ({"type": "integer", "default": 7}, 7),
+            ({"type": "string", "const": "fixed"}, "fixed"),
+            ({"type": "string", "examples": ["first", "second"]}, "first"),
+            ({"type": "string", "enum": ["red", "green"]}, "red"),
+            ({"anyOf": [{"type": "integer"}, {"type": "string"}]}, 0),
+            ({"oneOf": [{"type": "boolean"}]}, False),
+            ({"type": "string"}, ""),
+            ({"type": "number"}, 0),
+            ({"type": "integer"}, 0),
+            ({"type": "boolean"}, False),
+            ({"type": "array"}, []),
+            ({"type": "null"}, None),
+            ({"type": ["string", "integer"]}, ""),
+            ({"type": []}, None),
+            ({}, None),
+            ("not-a-schema", None),
+        ],
+    )
+    def test_hint_preference_and_zero_values(self, schema: Any, expected: Any) -> None:
+        assert synthesize_value(schema) == expected
+
+    def test_default_wins_over_every_other_hint(self) -> None:
+        schema = {"default": "d", "const": "c", "examples": ["e"], "enum": ["n"], "type": "string"}
+        assert synthesize_value(schema) == "d"
+
+    def test_empty_examples_and_enum_fall_through_to_type(self) -> None:
+        assert synthesize_value({"type": "integer", "examples": [], "enum": []}) == 0
+
+    def test_nested_object_recurses_required_properties_only(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"inner": {"type": "string"}, "optional": {"type": "integer"}},
+            "required": ["inner"],
+        }
+        assert synthesize_value(schema) == {"inner": ""}
+
+    def test_recursion_depth_is_bounded(self) -> None:
+        schema: dict[str, Any] = {"type": "string"}
+        for _ in range(10):
+            schema = {"type": "object", "properties": {"n": schema}, "required": ["n"]}
+        value = synthesize_value(schema)
+        # The bound truncates the nesting to None instead of recursing forever.
+        depth = 0
+        while isinstance(value, dict):
+            value = value.get("n")
+            depth += 1
+        assert value is None
+        assert depth < 10
+
+
+class TestSynthesizeArguments:
+    def test_object_schema_yields_required_arguments(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "count": {"type": "integer", "default": 3}},
+            "required": ["name", "count"],
+        }
+        assert synthesize_arguments(schema) == {"name": "", "count": 3}
+
+    @pytest.mark.parametrize("schema", [None, "x", {"type": "object"}, {"type": "object", "properties": {}}])
+    def test_unconstrained_or_invalid_schemas_yield_empty_arguments(self, schema: Any) -> None:
+        assert synthesize_arguments(schema) == {}
+
+    def test_required_name_without_a_property_schema_is_omitted(self) -> None:
+        schema = {"type": "object", "properties": {"a": {"type": "string"}, "b": True}, "required": ["a", "b", "c"]}
+        assert synthesize_arguments(schema) == {"a": ""}
+
+
+class TestSynthesizeInvalidArguments:
+    @pytest.mark.parametrize(
+        ("declared", "wrong"),
+        [
+            ("string", 42),
+            ("number", "not-a-number"),
+            ("integer", "not-an-integer"),
+            ("boolean", "not-a-boolean"),
+            ("array", {"invalid": True}),
+            ("object", "not-an-object"),
+            ("null", 0),
+        ],
+    )
+    def test_first_typed_property_gets_a_wrong_typed_value(self, declared: str, wrong: Any) -> None:
+        schema = {"type": "object", "properties": {"p": {"type": declared}}, "required": ["p"]}
+        assert synthesize_invalid_arguments(schema) == {"p": wrong}
+
+    def test_other_required_properties_stay_valid(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"first": {"type": "string"}, "second": {"type": "integer"}},
+            "required": ["first", "second"],
+        }
+        assert synthesize_invalid_arguments(schema) == {"first": 42, "second": 0}
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            None,
+            {"type": "object"},
+            {"type": "object", "properties": {}},
+            {"type": "object", "properties": {"untyped": {}}},
+            {"type": "object", "properties": {"union": {"type": ["string", "integer"]}}},
+            {"type": "object", "properties": {"bool_schema": True}},
+        ],
+    )
+    def test_nothing_violable_yields_none(self, schema: Any) -> None:
+        assert synthesize_invalid_arguments(schema) is None
+
+
+class TestStructuredContentCheck:
+    async def test_conforming_result_passes(self) -> None:
+        tool = read_only_tool(output_schema=OUTPUT_SCHEMA)
+        session = FakeSession({"reader": CallToolResult(content=[], structured_content={"result": "ok"})})
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.PASS
+        assert check.tool_name == "reader"
+
+    async def test_sdk_validation_error_fails(self) -> None:
+        tool = read_only_tool(output_schema=OUTPUT_SCHEMA)
+        session = FakeSession({"reader": RuntimeError("Invalid structured content returned by tool reader")})
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "not honored" in check.message
+
+    async def test_no_output_schema_skips(self) -> None:
+        session = FakeSession()
+        check = await single_check(session, read_only_tool(), CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.SKIP
+        assert "no outputSchema" in check.message
+        # The tool is never called with valid arguments: only the
+        # invalid-arguments check (wrong-typed q) touched it.
+        assert ("reader", {"q": ""}) not in session.calls
+
+    async def test_error_result_skips_as_possible_outage(self) -> None:
+        tool = read_only_tool(output_schema=OUTPUT_SCHEMA)
+        session = FakeSession({"reader": CallToolResult(content=[], is_error=True)})
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.SKIP
+        assert "outage" in check.message
+
+    async def test_jsonrpc_error_skips_with_code(self) -> None:
+        tool = read_only_tool(output_schema=OUTPUT_SCHEMA)
+        session = FakeSession({"reader": MCPError(code=ERROR_INVALID_PARAMS, message="bad args")})
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.SKIP
+        assert check.details["error_code"] == ERROR_INVALID_PARAMS
+
+    async def test_transport_exception_skips(self) -> None:
+        tool = read_only_tool(output_schema=OUTPUT_SCHEMA)
+        session = FakeSession({"reader": ConnectionError("boom")})
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.SKIP
+        assert "ConnectionError" in check.message
+
+    async def test_interactive_result_skips(self) -> None:
+        tool = read_only_tool(output_schema=OUTPUT_SCHEMA)
+        session = FakeSession({"reader": object()})
+        check = await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert check.verdict is SmokeVerdict.SKIP
+        assert "interactive" in check.message
+
+    async def test_synthesized_arguments_are_sent(self) -> None:
+        tool = read_only_tool(output_schema=OUTPUT_SCHEMA)
+        session = FakeSession({"reader": CallToolResult(content=[], structured_content={"result": "ok"})})
+        await single_check(session, tool, CHECK_STRUCTURED_CONTENT)
+        assert ("reader", {"q": ""}) in session.calls
+
+
+class TestInvalidArgumentsCheck:
+    async def test_jsonrpc_rejection_passes(self) -> None:
+        session = FakeSession({"reader": MCPError(code=ERROR_INVALID_PARAMS, message="bad args")})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.PASS
+        assert check.details["error_code"] == ERROR_INVALID_PARAMS
+
+    async def test_is_error_rejection_passes(self) -> None:
+        session = FakeSession({"reader": CallToolResult(content=[], is_error=True)})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.PASS
+        assert "isError" in check.message
+
+    async def test_success_result_fails(self) -> None:
+        session = FakeSession({"reader": CallToolResult(content=[])})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "accepted schema-invalid arguments" in check.message
+
+    async def test_timeout_fails_as_hang(self) -> None:
+        session = FakeSession({"reader": MCPError(code=REQUEST_TIMEOUT, message="timed out")})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "hang" in check.message
+
+    async def test_sdk_validation_error_fails_as_acceptance(self) -> None:
+        # The server produced a (schema-violating) success result for invalid
+        # input — the defect is the acceptance, not the content.
+        session = FakeSession({"reader": RuntimeError("Invalid structured content")})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "accepted schema-invalid arguments" in check.message
+
+    async def test_transport_crash_fails(self) -> None:
+        session = FakeSession({"reader": ConnectionError("boom")})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "crashed" in check.message
+
+    async def test_interactive_result_fails(self) -> None:
+        session = FakeSession({"reader": object()})
+        check = await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.FAIL
+        assert "further input" in check.message
+
+    async def test_unconstrained_schema_skips(self) -> None:
+        tool = read_only_tool(input_schema={"type": "object"})
+        session = FakeSession()
+        check = await single_check(session, tool, CHECK_INVALID_ARGUMENTS)
+        assert check.verdict is SmokeVerdict.SKIP
+        assert "nothing invalid to send" in check.message
+
+    async def test_wrong_typed_value_is_sent(self) -> None:
+        session = FakeSession({"reader": MCPError(code=ERROR_INVALID_PARAMS, message="bad args")})
+        await single_check(session, read_only_tool(), CHECK_INVALID_ARGUMENTS)
+        assert ("reader", {"q": 42}) in session.calls
+
+
+class TestUnknownToolCheck:
+    @pytest.mark.parametrize("code", [ERROR_INVALID_PARAMS, ERROR_METHOD_NOT_FOUND])
+    async def test_protocol_error_passes(self, code: int) -> None:
+        session = FakeSession(default=MCPError(code=code, message="Unknown tool"))
+        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        (check,) = report.checks
+        assert check.check_id == CHECK_UNKNOWN_TOOL
+        assert check.verdict is SmokeVerdict.PASS
+        assert check.tool_name is None
+        assert session.calls == [(UNKNOWN_TOOL_NAME, {})]
+
+    async def test_other_error_code_fails(self) -> None:
+        session = FakeSession(default=MCPError(code=ERROR_INTERNAL, message="oops"))
+        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        assert report.checks[0].verdict is SmokeVerdict.FAIL
+        assert str(ERROR_INTERNAL) in report.checks[0].message
+
+    async def test_timeout_fails_as_hang(self) -> None:
+        session = FakeSession(default=MCPError(code=REQUEST_TIMEOUT, message="timed out"))
+        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        assert report.checks[0].verdict is SmokeVerdict.FAIL
+        assert "hang" in report.checks[0].message
+
+    async def test_success_result_fails(self) -> None:
+        session = FakeSession(default=CallToolResult(content=[]))
+        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        assert report.checks[0].verdict is SmokeVerdict.FAIL
+        assert "instead of rejecting" in report.checks[0].message
+
+    async def test_is_error_result_fails(self) -> None:
+        session = FakeSession(default=CallToolResult(content=[], is_error=True))
+        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        assert report.checks[0].verdict is SmokeVerdict.FAIL
+        assert "isError" in report.checks[0].message
+
+    async def test_transport_crash_fails(self) -> None:
+        session = FakeSession(default=ConnectionError("boom"))
+        report = await run_smoke_checks(session, None, call_all=False)  # type: ignore[arg-type]
+        assert report.checks[0].verdict is SmokeVerdict.FAIL
+        assert "crashed" in report.checks[0].message
+
+
+class TestSafetyDefault:
+    """Only readOnlyHint: true tools are called unless --call-all lifts it."""
+
+    @pytest.mark.parametrize(
+        "annotations",
+        [None, ToolAnnotations(), ToolAnnotations(read_only_hint=False), ToolAnnotations(destructive_hint=False)],
+    )
+    async def test_tools_without_the_hint_are_skipped_not_called(self, annotations: ToolAnnotations | None) -> None:
+        tool = Tool(
+            name="writer", input_schema={"type": "object"}, output_schema=OUTPUT_SCHEMA, annotations=annotations
+        )
+        session = FakeSession()
+        report = await run_smoke_checks(session, [tool], call_all=False)  # type: ignore[arg-type]
+        per_tool = [check for check in report.checks if check.tool_name == "writer"]
+        assert len(per_tool) == 2
+        assert all(check.verdict is SmokeVerdict.SKIP for check in per_tool)
+        assert all("--call-all" in check.message for check in per_tool)
+        assert session.calls == [(UNKNOWN_TOOL_NAME, {})]  # only the server-level check called anything
+
+    async def test_call_all_lifts_the_default(self) -> None:
+        tool = Tool(
+            name="writer",
+            input_schema={"type": "object", "properties": {"q": {"type": "string"}}, "required": ["q"]},
+            output_schema=OUTPUT_SCHEMA,
+        )
+        session = FakeSession({"writer": CallToolResult(content=[], structured_content={"result": "ok"})})
+        report = await run_smoke_checks(session, [tool], call_all=True)  # type: ignore[arg-type]
+        assert report.call_all is True
+        called_tools = {name for name, _ in session.calls}
+        assert "writer" in called_tools
+
+
+class TestRunSmokeChecks:
+    async def test_checks_are_grouped_and_ordered(self) -> None:
+        tools = [read_only_tool("alpha", output_schema=OUTPUT_SCHEMA), read_only_tool("beta")]
+        session = FakeSession(
+            {
+                "alpha": CallToolResult(content=[], structured_content={"result": "ok"}),
+                "beta": MCPError(code=ERROR_INVALID_PARAMS, message="bad"),
+            },
+            default=MCPError(code=ERROR_INVALID_PARAMS, message="Unknown tool"),
+        )
+        report = await run_smoke_checks(session, tools, call_all=False)  # type: ignore[arg-type]
+        assert [(check.check_id, check.tool_name) for check in report.checks] == [
+            (CHECK_STRUCTURED_CONTENT, "alpha"),
+            (CHECK_STRUCTURED_CONTENT, "beta"),
+            (CHECK_INVALID_ARGUMENTS, "alpha"),
+            (CHECK_INVALID_ARGUMENTS, "beta"),
+            (CHECK_UNKNOWN_TOOL, None),
+        ]
+        assert report.executed is True
+        assert report.reason is None
+
+    async def test_counts_and_to_dict(self) -> None:
+        tools = [read_only_tool("alpha", output_schema=OUTPUT_SCHEMA)]
+        session = FakeSession(
+            {"alpha": CallToolResult(content=[], structured_content={"result": "ok"})},
+            default=MCPError(code=ERROR_INVALID_PARAMS, message="Unknown tool"),
+        )
+        report = await run_smoke_checks(session, tools, call_all=False)  # type: ignore[arg-type]
+        # alpha: structured-content pass; invalid-arguments... alpha returns a
+        # success result for the invalid call → fail. Unknown tool → pass.
+        assert (report.passed, report.failed, report.skipped) == (2, 1, 0)
+
+        payload = report.to_dict()
+        assert payload["executed"] is True
+        assert payload["call_all"] is False
+        assert payload["summary"] == {"passed": 2, "failed": 1, "skipped": 0}
+        assert len(payload["checks"]) == 3
+        first = payload["checks"][0]
+        assert first == {
+            "check_id": CHECK_STRUCTURED_CONTENT,
+            "tool_name": "alpha",
+            "verdict": "pass",
+            "message": first["message"],
+            "details": first["details"],
+        }
+        assert "basis" in first["details"]
+
+    async def test_not_executed_report(self) -> None:
+        report = SmokeReport.not_executed("no session")
+        assert report.executed is False
+        assert report.reason == "no session"
+        assert (report.passed, report.failed, report.skipped) == (0, 0, 0)
+        payload = report.to_dict()
+        assert payload["executed"] is False
+        assert payload["reason"] == "no session"
+        assert payload["checks"] == []

--- a/tests/test_smoke_stdio_e2e.py
+++ b/tests/test_smoke_stdio_e2e.py
@@ -42,7 +42,7 @@ async def _run_against_fixture(*, call_all: bool, only_tools: set[str] | None = 
         if only_tools is not None:
             tools = [tool for tool in tools if tool.name in only_tools]
         assert client.session is not None
-        return await run_smoke_checks(client.session, tools, call_all=call_all)
+        return await run_smoke_checks(client.session, tools, call_all=call_all, catalog_complete=True)
     finally:
         await client.cleanup()
 

--- a/tests/test_smoke_stdio_e2e.py
+++ b/tests/test_smoke_stdio_e2e.py
@@ -1,0 +1,107 @@
+"""Real-process smoke-mode test against the stdio fixture server.
+
+Launches ``stdio_smoke_server.py`` as a genuine subprocess over the SDK's
+stdio transport and runs the full smoke suite on the live session — the same
+path ``mcpscore <target> --smoke`` takes after an audit. Each fixture tool
+scripts one verdict, so this proves the checks against a real wire exchange
+rather than a scripted session: schema-conforming structuredContent passes,
+a schema-violating one fails, accepted invalid arguments fail, rejections
+pass, and the unannotated tool is never called (the fixture kills the server
+process if it ever is).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+
+from mcpscore import MCPClient, StdioCommand
+from mcpscore.smoke import (
+    CHECK_INVALID_ARGUMENTS,
+    CHECK_STRUCTURED_CONTENT,
+    CHECK_UNKNOWN_TOOL,
+    SmokeReport,
+    SmokeVerdict,
+    run_smoke_checks,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+SERVER = str(Path(__file__).parent / "stdio_smoke_server.py")
+
+
+async def _run_against_fixture(*, call_all: bool, only_tools: set[str] | None = None) -> SmokeReport:
+    client = MCPClient()
+    try:
+        success, _transport = await client.detect_and_connect(StdioCommand(command=sys.executable, args=(SERVER,)))
+        assert success
+        tools = await client.list_tools()
+        assert tools is not None
+        if only_tools is not None:
+            tools = [tool for tool in tools if tool.name in only_tools]
+        assert client.session is not None
+        return await run_smoke_checks(client.session, tools, call_all=call_all)
+    finally:
+        await client.cleanup()
+
+
+class TestSmokeRealProcess:
+    async def test_verdicts_against_the_fixture_server(self) -> None:
+        report = await _run_against_fixture(call_all=False)
+
+        by_subject = {(check.check_id, check.tool_name): check for check in report.checks}
+
+        # honest: conforming structuredContent, proper -32602 rejection.
+        assert by_subject[(CHECK_STRUCTURED_CONTENT, "honest")].verdict is SmokeVerdict.PASS
+        assert by_subject[(CHECK_INVALID_ARGUMENTS, "honest")].verdict is SmokeVerdict.PASS
+
+        # dishonest: declared outputSchema, non-conforming structuredContent —
+        # the quickstart-resources#163 defect, caught only by calling.
+        dishonest = by_subject[(CHECK_STRUCTURED_CONTENT, "dishonest")]
+        assert dishonest.verdict is SmokeVerdict.FAIL
+        assert "not honored" in dishonest.message
+        assert by_subject[(CHECK_INVALID_ARGUMENTS, "dishonest")].verdict is SmokeVerdict.PASS
+
+        # sloppy: no outputSchema to verify; accepts schema-invalid arguments.
+        assert by_subject[(CHECK_STRUCTURED_CONTENT, "sloppy")].verdict is SmokeVerdict.SKIP
+        sloppy = by_subject[(CHECK_INVALID_ARGUMENTS, "sloppy")]
+        assert sloppy.verdict is SmokeVerdict.FAIL
+        assert "accepted schema-invalid arguments" in sloppy.message
+
+        # writer is unannotated: the safety default skips it (the fixture
+        # kills the whole server if it is ever actually called).
+        for check_id in (CHECK_STRUCTURED_CONTENT, CHECK_INVALID_ARGUMENTS):
+            writer = by_subject[(check_id, "writer")]
+            assert writer.verdict is SmokeVerdict.SKIP
+            assert "--call-all" in writer.message
+
+        # Unknown tool: rejected with the spec's exemplary -32602.
+        unknown = by_subject[(CHECK_UNKNOWN_TOOL, None)]
+        assert unknown.verdict is SmokeVerdict.PASS
+        assert unknown.details["error_code"] == -32602
+
+        assert (report.passed, report.failed, report.skipped) == (4, 2, 3)
+
+    async def test_call_all_really_calls_the_unannotated_tool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Prove --call-all lifts the safety default.
+
+        The fixture's writer tool dies on invocation, so the smoke run must
+        observe the crashed server rather than report a safety skip.
+        """
+        from mcpscore import smoke
+
+        # The crashed transport should surface as immediate errors; the
+        # shortened deadline is a hang tripwire, not part of the contract.
+        monkeypatch.setattr(smoke, "SMOKE_CALL_TIMEOUT_S", 5.0)
+
+        report = await _run_against_fixture(call_all=True, only_tools={"writer"})
+
+        structured = next(check for check in report.checks if check.check_id == CHECK_STRUCTURED_CONTENT)
+        assert structured.tool_name == "writer"
+        # The call was attempted (no safety skip); the dead process shows up
+        # as an unexercisable schema, and the later checks fail on the crash.
+        assert "--call-all" not in structured.message
+        assert structured.verdict is not SmokeVerdict.PASS
+        assert report.failed >= 1


### PR DESCRIPTION
  The audit itself still never calls `tools/call`; smoke mode is the separate,
  opt-in surface for developers testing a server they operate (typically in
  CI). It verifies what listing alone cannot: that a declared `outputSchema`
  is honored by real `structuredContent` (per MCP 2025-11-25 Tools §Output
  Schema, a MUST), that schema-invalid arguments are rejected with an
  `isError` result or a protocol error, and that unknown tool names get a
  protocol error rather than a result. By default only tools annotated
  `readOnlyHint: true` are called; `--call-all` is the explicit consent for
  the rest — so unannotated tools visibly cost smoke coverage. Argument
  synthesis is deterministic (defaults / const / examples / enum-first / type
  zero-values — never an LLM). Verdicts are pass/fail/skip, and a tool whose
  upstream is down reports as *skip*: someone else's outage should not fail
  the build. Results land in a new `smoke` section of the `--json` report and
  never touch `score`/`max_score`; any smoke failure exits with the new code
  **4** (a failed `--fail-under` gate still takes precedence with 3). The
  web service deliberately has no smoke mode — CLI (and the GitHub Action,
  in a coming release) only.