### PR TITLE
Add mcpscore.toml feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Per-project rule configuration.** A `mcpscore.toml` next to your code, or
-  a `[tool.mcpscore]` table in `pyproject.toml`, turns rules off (`"off"`,
+  a `[tool.mcpscore]` table in `pyproject.toml`, turns rules off (`"off"`:
   they do not run and are reported as `disabled-by-config`) and re-ranks the
-  rest by severity name, keyed on `rule_id`; a `[gate] fail_on = "<severity>"`
-  table fails the build (exit 3) on any failed rule at or above it, after
-  re-ranking. `--config FILE` names a file, `--no-config` ignores every
-  source, and otherwise the nearest file up to the repository root is used.
-  The score line carries the file and what it changed, and the JSON report
-  gains an additive `config` block. The configuration changes the score for
-  the run that used it and nothing else: the badge and mcpscore.dev never
-  apply one. Library users pass `RuleConfig` to `MCPAuditor(config=...)`.
-  Unknown and retired rule ids warn and are ignored.
+  rest by severity name, keyed on `rule_id`. A `[gate] fail_on = "<severity>"`
+  table fails the build (exit 3) on any failed rule counted in the main score
+  at or above it, after re-ranking; readiness rules count only when promoted.
+  `--config FILE` names a file, `--no-config` ignores every source, and
+  otherwise the nearest file up to the repository root is used. The score
+  line carries the file and what it changed, and the JSON report gains an
+  additive `config` block. The configuration changes the score for the run
+  that used it and nothing else: the badge and mcpscore.dev never apply one.
+  Library users pass `RuleConfig` to `MCPAuditor(config=...)`. Unknown and
+  retired rule ids warn and are ignored.
 
 ## [1.11.2] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-project rule configuration.** A `mcpscore.toml` next to your code, or
+  a `[tool.mcpscore]` table in `pyproject.toml`, turns rules off (`"off"`,
+  they do not run and are reported as `disabled-by-config`) and re-ranks the
+  rest by severity name, keyed on `rule_id`; a `[gate] fail_on = "<severity>"`
+  table fails the build (exit 3) on any failed rule at or above it, after
+  re-ranking. `--config FILE` names a file, `--no-config` ignores every
+  source, and otherwise the nearest file up to the repository root is used.
+  The score line carries the file and what it changed, and the JSON report
+  gains an additive `config` block. The configuration changes the score for
+  the run that used it and nothing else: the badge and mcpscore.dev never
+  apply one. Library users pass `RuleConfig` to `MCPAuditor(config=...)`.
+  Unknown and retired rule ids warn and are ignored.
+
 ## [1.11.2] - 2026-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ mcpscore https://your-server.example/mcp --fail-under 80
 mcpscore path/to/server.py --smoke
 ```
 
+Rules that don't apply to your server, or matter more to you, go in a
+`mcpscore.toml` next to your code: `off` turns a rule off, a severity name
+re-ranks it, and `[gate] fail_on = "high"` fails the build on any failed rule
+at or above it. It changes the score in your CI only, never the badge.
+Details: [configure rules](https://docs.mcpscore.dev/configure-rules).
+
 | Exit code | Meaning                                                      |
 |-----------|--------------------------------------------------------------|
 | `0`       | Audit completed and every gate passed                        |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ mcpscore path/to/server.py --smoke
 Rules that don't apply to your server, or matter more to you, go in a
 `mcpscore.toml` next to your code: `off` turns a rule off, a severity name
 re-ranks it, and `[gate] fail_on = "high"` fails the build on any failed rule
-at or above it. It changes the score in your CI only, never the badge.
+counted in the main score at or above it. It changes the score in your CI only, never the badge.
 Details: [configure rules](https://docs.mcpscore.dev/configure-rules).
 
 | Exit code | Meaning                                                      |

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -24,6 +24,8 @@ other language run through `--stdio`.
 | `--env NAME` | — | Copy `NAME` from mcpscore's own environment into the server's. The form for secrets: the value never appears on a command line or in the report. It does sit in the server process's environment, which process inspection can read with enough privilege, as with any secret passed by environment. |
 | `--package <coordinate>` | — | Score a published package instead of a running server: `npm:@scope/name`, `npm:name@1.2.3`, `pypi:name==1.2.3`. Reads registry metadata only. See [package audits](/package-audits). |
 | `--json` | off | Write one JSON document to stdout. All logs go to stderr. Schema in the [stability contract](/stability). |
+| `--config FILE` | nearest `mcpscore.toml` or `[tool.mcpscore]` | Apply a per-project rule configuration: rules off, re-ranked, and a severity gate. Changes the score for this run only. See [configure rules](/configure-rules). |
+| `--no-config` | off | Ignore any configuration and audit with the canonical rule set and weights. |
 | `--fail-under PCT` | none | Exit `3` when the main score percentage (0–100, rounded) is below `PCT`. A partial audit always fails this gate. |
 | `--fail-under-readiness PCT` | none | Exit `3` when the readiness percentage is below `PCT`. Skipped when readiness was not assessed at all. |
 | `--smoke` | off | After the audit, call the server's tools and check they behave. Only tools annotated `readOnlyHint: true` are called. Unavailable with `--package`; does not run on partial or modern-only probe audits. See [smoke mode](/smoke-mode). |
@@ -55,7 +57,7 @@ your server's variable, not mcpscore's.
 | `0` | Audit completed and every gate that was set passed | Green |
 | `1` | Audit never ran: a usage error, or an `--oauth` flow that timed out, was refused, or failed registration or token exchange | Fix the invocation |
 | `2` | Could not connect to the server, or a package's registry could not be read | Fix the target or the network |
-| `3` | Audit completed but `--fail-under` or `--fail-under-readiness` was not met. A partial audit always fails `--fail-under` | The server needs work |
+| `3` | Audit completed but `--fail-under`, `--fail-under-readiness`, or a configured `[gate]` was not met. A partial audit always fails `--fail-under` | The server needs work |
 | `4` | Audit completed but a `--smoke` check failed. When a threshold gate also fails, `3` wins | The tools are broken |
 
 Without gate flags, a completed audit exits `0` whatever the score.

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -60,7 +60,7 @@ your server's variable, not mcpscore's.
 | `3` | Audit completed but `--fail-under`, `--fail-under-readiness`, or a configured `[gate]` was not met. A partial audit always fails `--fail-under` | The server needs work |
 | `4` | Audit completed but a `--smoke` check failed. When a threshold gate also fails, `3` wins | The tools are broken |
 
-Without gate flags, a completed audit exits `0` whatever the score.
+Without gate flags or a configured `[gate]`, a completed audit exits `0` whatever the score.
 
 ## Output
 

--- a/docs/configure-rules.mdx
+++ b/docs/configure-rules.mdx
@@ -1,0 +1,134 @@
+---
+title: "Configure Rules"
+description: "Turn rules off and re-rank the rest for your own CI with a mcpscore.toml — the way you configure a linter. Your badge and mcpscore.dev stay canonical."
+icon: "sliders"
+---
+
+Some rules won't apply to your server, and some matter more to you than their
+default weight says. A `mcpscore.toml` next to your code turns rules off and
+re-ranks the rest by `rule_id`, and the score you see in CI is the score under
+that policy. The badge and mcpscore.dev never read it: they always show the
+canonical score.
+
+```toml
+# mcpscore.toml — checked in next to your server
+[rules]
+server_websiteurl_present = "off"       # we don't publish a website
+server_icons_present      = "off"
+server_title_present      = "critical"  # our agent picks tools by title
+
+[gate]
+fail_on = "critical"   # any failed rule at or above CRITICAL fails the build
+```
+
+```text
+Config: mcpscore.toml — 2 rules off, 1 re-ranked, gate at CRITICAL
+...
+⏭️ Skipping rule 'server_websiteurl_present': disabled-by-config
+⏭️ Skipping rule 'server_icons_present': disabled-by-config
+...
+Audit finished. Final score: 78/92 (mcpscore.toml: 2 rules off, 1 re-ranked, gate at CRITICAL)
+Gate failed — [gate] fail_on = "critical": 1 failed rule at or above CRITICAL: server_title_present
+```
+
+The score line names the file so a pasted number keeps its qualifier, and the
+gate says exactly which rule failed the build.
+
+## What each entry does
+
+| Entry | Effect |
+|---|---|
+| `rule_id = "off"` | The rule does not run. It appears in the report's `skipped_rules` with reason `disabled-by-config` and counts toward neither the score nor the maximum |
+| `rule_id = "low"` / `"medium"` / `"high"` / `"critical"` | The rule runs and counts at that severity, worth 1, 2, 3, or 5 points. The result records the rule's own severity as `details.severity_default` |
+| `[gate] fail_on = "high"` | Exit code `3` when any failed rule sits at or above that severity after re-ranking. Promote a rule to `critical` and it now blocks the build; a rule that is off cannot |
+
+Values are case-insensitive. A `rule_id` that mcpscore doesn't know, including
+one it has retired, is warned about and ignored, so a file written for a newer
+release still works on an older one. Any other value is a usage error and exit
+code `1`. Every `rule_id` is in the [rules reference](/rules).
+
+## Where the file lives
+
+mcpscore looks, in this order, and says which it used:
+
+1. `--config FILE`, any path. A missing file is a usage error.
+2. `mcpscore.toml` in the working directory, then each parent up to the
+   repository root, the first directory that contains `.git`.
+3. `[tool.mcpscore]` in a `pyproject.toml`, searched the same way:
+
+```toml
+[tool.mcpscore.rules]
+server_websiteurl_present = "off"
+
+[tool.mcpscore.gate]
+fail_on = "high"
+```
+
+`--no-config` ignores all of it, which is how you reproduce the canonical
+number inside a configured repository.
+
+## What it changes, and what it doesn't
+
+A configuration changes the score for the run that used it. It does not touch
+the [badge](/badge) or the report on [mcpscore.dev](https://mcpscore.dev),
+which only ever show audits run by the website itself, with every rule at its
+default weight. Two teams with different files get different numbers for the
+same server, and that is the point: compare configured scores only across runs
+with the same `config.sha256`, which the report carries.
+
+In the JSON report the applied configuration is a `config` block:
+
+```json
+"config": {
+  "source": "mcpscore.toml",
+  "sha256": "72346634bd0c…",
+  "disabled": ["server_websiteurl_present", "server_icons_present"],
+  "reranked": {"server_title_present": {"from": "MEDIUM", "to": "CRITICAL"}},
+  "unknown": [],
+  "gate": {"fail_on": "CRITICAL", "failed": ["server_title_present"]}
+}
+```
+
+The [GitHub Action](/github-action) picks the file up from your checkout, so
+`min-score` gates the configured score, and the PR comment carries the same
+qualifier.
+
+## When it fails
+
+**`Usage error: mcpscore.toml: rule 'x' has value 'skip'; expected off, low, medium, high, or critical`** (exit `1`)
+
+- Cause: an unsupported value. `off` is the one spelling.
+- Fix: use `off` or a severity name.
+
+**`Config: unknown rule 'x'; ignored`**
+
+- Cause: a `rule_id` this release doesn't have, or a typo.
+- Fix: check the id in the [rules reference](/rules). A retired rule says so
+  in the warning and can be deleted from the file.
+
+**`Gate failed — [gate] fail_on = "high": …`** (exit `3`)
+
+- Cause: a rule at or above your threshold failed. That is the gate working.
+- Fix: fix the rule, lower the threshold, or re-rank that rule below it.
+
+**The badge still shows the old score after you turned rules off**
+
+- Cause: the badge is canonical by design and never applies a configuration.
+- Fix: none needed. Your CI number and the badge answer different questions.
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Rules reference" icon="list-check" href="/rules">
+    Every `rule_id` you can turn off or re-rank
+  </Card>
+  <Card title="GitHub Action" icon="github" href="/github-action">
+    Gate pull requests on the configured score
+  </Card>
+  <Card title="Stability contract" icon="file-contract" href="/stability">
+    The `config` report block, field by field
+  </Card>
+  <Card title="Scoring methodology" icon="scale-balanced" href="/methodology">
+    What the default weights mean before you change them
+  </Card>
+</CardGroup>

--- a/docs/configure-rules.mdx
+++ b/docs/configure-rules.mdx
@@ -38,9 +38,9 @@ gate says exactly which rule failed the build.
 
 | Entry | Effect |
 |---|---|
-| `rule_id = "off"` | The rule does not run. It appears in the report's `skipped_rules` with reason `disabled-by-config` and counts toward neither the score nor the maximum |
+| `rule_id = "off"` | The rule does not run and counts toward neither the score nor the maximum. It appears in the report's `skipped_rules` with reason `disabled-by-config`, unless the engine could not have judged it anyway, in which case the canonical reason (`not-applicable`, `insufficient-data`) is kept |
 | `rule_id = "low"` / `"medium"` / `"high"` / `"critical"` | The rule runs and counts at that severity, worth 1, 2, 3, or 5 points. The result records the rule's own severity as `details.severity_default` |
-| `[gate] fail_on = "high"` | Exit code `3` when any failed rule sits at or above that severity after re-ranking. Promote a rule to `critical` and it now blocks the build; a rule that is off cannot |
+| `[gate] fail_on = "high"` | Exit code `3` when any failed rule counted in the main score sits at or above that severity after re-ranking. Readiness rules count only when a modern-lifecycle server promotes them, matching `--fail-under`. Promote a rule to `critical` and it now blocks the build; a rule that is off cannot |
 
 Values are case-insensitive. A `rule_id` that mcpscore doesn't know, including
 one it has retired, is warned about and ignored, so a file written for a newer
@@ -52,9 +52,11 @@ code `1`. Every `rule_id` is in the [rules reference](/rules).
 mcpscore looks, in this order, and says which it used:
 
 1. `--config FILE`, any path. A missing file is a usage error.
-2. `mcpscore.toml` in the working directory, then each parent up to the
-   repository root, the first directory that contains `.git`.
-3. `[tool.mcpscore]` in a `pyproject.toml`, searched the same way:
+2. Otherwise the nearest configuration, walking from the working directory up
+   to the repository root, the first directory that contains `.git`. In each
+   directory a `mcpscore.toml` wins over a `pyproject.toml` with a
+   `[tool.mcpscore]` table, and a nearer `pyproject.toml` wins over a
+   `mcpscore.toml` further up:
 
 ```toml
 [tool.mcpscore.rules]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,6 +29,7 @@
         "group": "Use in CI",
         "pages": [
           "smoke-mode",
+          "configure-rules",
           "github-action"
         ]
       },

--- a/docs/github-action.mdx
+++ b/docs/github-action.mdx
@@ -80,8 +80,10 @@ and transport surface. Pass a credential before trusting the gate. See
 ### Turn rules off for this repository
 
 A `mcpscore.toml` in the checkout is picked up on its own, so rules you have
-turned off or re-ranked shape the score the action gates on and comments with.
-It never changes the badge. See [configure rules](/configure-rules).
+turned off or re-ranked shape the score the action gates on and comments with,
+and a configured `[gate]` failure is reported by name. It never changes the
+badge. See [configure rules](/configure-rules). Needs mcpscore-action 1.x
+from the same release as this feature; `@v1` follows it.
 
 ```toml
 [rules]

--- a/docs/github-action.mdx
+++ b/docs/github-action.mdx
@@ -77,6 +77,20 @@ and transport surface. Pass a credential before trusting the gate. See
 [authenticated servers](/authenticated-servers).
 </Note>
 
+### Turn rules off for this repository
+
+A `mcpscore.toml` in the checkout is picked up on its own, so rules you have
+turned off or re-ranked shape the score the action gates on and comments with.
+It never changes the badge. See [configure rules](/configure-rules).
+
+```toml
+[rules]
+server_websiteurl_present = "off"
+
+[gate]
+fail_on = "high"
+```
+
 ### Also require readiness for MCP 2026-07-28
 
 ```yaml
@@ -120,7 +134,7 @@ a commit and `version` to an mcpscore release:
 | Input | Default | What it does |
 |---|---|---|
 | `target` | required | Server URL, or a local `.py` or `.js` path |
-| `min-score` | no gate | Fail the job when the main score percentage (0–100) is below this |
+| `min-score` | no gate | Fail the job when the main score percentage (0–100) is below this. With a `mcpscore.toml` in the repo, that is the configured score |
 | `min-readiness` | no gate | Fail the job when the readiness percentage (0–100) is below this. Skipped when readiness was not assessed |
 | `comment` | `true` | Post or update the report comment on the pull request |
 | `args` | — | Extra arguments passed to the mcpscore CLI, split on whitespace. Write each as one token, for example `--header=X-Api-Key:$KEY` |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -105,7 +105,9 @@ mcpscore https://your-server.example/mcp --fail-under 80 --json > report.json
 
 Exit code `3` means the gate failed. `1` means the audit never ran, `2` means
 it could not connect, `0` means it passed. The
-[GitHub Action](/github-action) turns this into one step with a PR comment.
+[GitHub Action](/github-action) turns this into one step with a PR comment,
+and a [`mcpscore.toml`](/configure-rules) turns off the rules that don't apply
+to you.
 
 ## What's next
 

--- a/docs/rules.mdx
+++ b/docs/rules.mdx
@@ -4,7 +4,8 @@ description: "Every rule mcpscore runs — generated from the rule registry, so 
 icon: "list-check"
 ---
 
-Use this page to look up any `rule_id` from a report or a CI comment. It is
+Use this page to look up any `rule_id` from a report or a CI comment, or to
+turn one off or re-rank it in a [`mcpscore.toml`](/configure-rules). It is
 regenerated from the rule registry on every change (`make docs-rules`), so the
 tables below always match the code.
 

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -85,7 +85,9 @@ through the report's score fields.
 `config` is absent unless a `mcpscore.toml` or `[tool.mcpscore]` was applied
 ([configure rules](/configure-rules)). When present, the score was computed
 under that policy: rules turned off did not run and appear in
-`skipped_rules[]` with reason `disabled-by-config`, and re-ranked rules carry
+`skipped_rules[]` with reason `disabled-by-config` (a canonical skip reason
+is kept when the engine could not have judged the rule anyway), and
+re-ranked rules carry
 their configured severity in `results[]` with the default in
 `details.severity_default`. A configured score is comparable only across
 runs with the same `config.sha256` and engine version. The badge and

--- a/docs/stability.mdx
+++ b/docs/stability.mdx
@@ -45,6 +45,7 @@ type change bumps `schema_version`.
 | `spec` | object | `negotiated_version`, `latest_version`, `readiness_target`, `era` |
 | `readiness` | object | `score`, `max_score`, `counted_in_main`, `results[]`, plus `assessed`, `skipped`, `total` coverage counts |
 | `smoke` | object | Present only when the run used `--smoke`. See below |
+| `config` | object | Present only when a per-project configuration was applied. See below |
 
 ### Package audits
 
@@ -79,6 +80,25 @@ through the report's score fields.
 
 `check_id` values are stable in the same way `rule_id`s are.
 
+### Configuration
+
+`config` is absent unless a `mcpscore.toml` or `[tool.mcpscore]` was applied
+([configure rules](/configure-rules)). When present, the score was computed
+under that policy: rules turned off did not run and appear in
+`skipped_rules[]` with reason `disabled-by-config`, and re-ranked rules carry
+their configured severity in `results[]` with the default in
+`details.severity_default`. A configured score is comparable only across
+runs with the same `config.sha256` and engine version. The badge and
+mcpscore.dev never apply a configuration.
+
+| Field | Meaning |
+|---|---|
+| `source`, `sha256` | The file that was applied and a digest of its bytes |
+| `disabled` | Rule ids turned off |
+| `reranked` | Rule id to `{"from": default, "to": configured}` severity names |
+| `unknown` | Configured ids this engine does not have; warned and ignored |
+| `gate` | Present when `[gate]` is set: `fail_on` and the `failed` rule ids that tripped it |
+
 ### CLI interface
 
 The invocation shape is stable: `mcpscore <target>` with `--json`, `--header`,
@@ -92,7 +112,7 @@ document to stdout with all logs on stderr.
 | `0` | Audit completed. With no gate flags, this regardless of score |
 | `1` | Audit never attempted: usage error, or `--oauth` failed (timeout, refusal, registration or token-exchange failure) |
 | `2` | Could not connect to the target, with no fallback available |
-| `3` | Audit completed but `--fail-under` or `--fail-under-readiness` was not met. A partial audit always fails `--fail-under` |
+| `3` | Audit completed but `--fail-under`, `--fail-under-readiness`, or a configured `[gate]` was not met. A partial audit always fails `--fail-under` |
 | `4` | Audit completed but a `--smoke` check failed. When a threshold also fails, `3` is returned |
 
 ### Credentials
@@ -107,6 +127,7 @@ commitment, not a default.
 |---|---|---|
 | `score` and `max_score` | Rules are added in most releases, so both numbers change. A score is comparable only within one mcpscore version against one server | Store `mcpscore_version` with every score. Compare across versions by `rule_id`, not by total |
 | `partial: true` | Fewer checks ran | Never compare with a full audit |
+| `config` present | The run applied a per-project configuration | Compare only across runs with the same `config.sha256` |
 | `readiness.counted_in_main: true` | A modern-lifecycle server's readiness points are inside the main score | A `min-score` threshold means something slightly different on either side of this flag |
 | `message`, `details`, `rule_name`, severities, category groupings | Improved in any release | Show them to humans. Never key logic on them |
 | Readiness rules | Target the newest revision, currently 2026-07-28. As adoption matures they migrate into the main axis and new ones appear for the next draft | Their `rule_id`s still follow the never-reused rule |

--- a/mcpscore/__init__.py
+++ b/mcpscore/__init__.py
@@ -13,6 +13,7 @@ aspects of MCP compliance and contributes to an overall audit score.
 """
 
 from . import spec
+from .config import ConfigError, RuleConfig
 from .enums import ConnectionErrorReason, MCPProtocolVersion, MCPTransportType
 from .mcp_auditor import MCPAuditor
 from .mcp_client import ConnectionFailure, MCPClient, StdioCommand
@@ -27,12 +28,14 @@ from .rules import (
 __all__ = (
     "AuditData",
     "BaseRule",
+    "ConfigError",
     "ConnectionErrorReason",
     "ConnectionFailure",
     "MCPAuditor",
     "MCPClient",
     "MCPProtocolVersion",
     "MCPTransportType",
+    "RuleConfig",
     "RuleResult",
     "RuleSeverity",
     "SkippedRule",

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -138,7 +138,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Per-project rule configuration to apply: a mcpscore.toml, or a pyproject.toml with a "
             '[tool.mcpscore] table. Rules set to "off" do not run; rules set to a severity name count at '
-            "that severity; [gate] fail_on fails the build (exit 3) on any failed rule at or above it. "
+            "that severity; [gate] fail_on fails the build (exit 3) on any failed rule counted in the main "
+            "score at or above it. "
             "Without this flag, the nearest mcpscore.toml or [tool.mcpscore] up to the repository root is "
             "used. The configuration changes the score for this run only; the badge and mcpscore.dev "
             "never apply one."
@@ -399,7 +400,9 @@ async def run_package_audit(
 
     Exit codes match the server flow's meaning: 0 audited, 2 could not look the
     package up (the analogue of "could not connect"), 3 audited but a
-    --fail-under threshold was not met.
+    --fail-under threshold or a configured [gate] was not met. The
+    configuration applies to the packaging rules like any other, so the score
+    line carries the same qualifier as a server audit's.
     """
     auditor = MCPAuditor(config=config)
     await auditor.audit_package(coordinate)
@@ -411,7 +414,7 @@ async def run_package_audit(
         logger.error("Could not read %s metadata: %s", package["registry"], package["error"])
         return 2
 
-    logger.info("Audit finished. Final score: %s/%s", report["score"], report["max_score"])
+    logger.info("Audit finished. Final score: %s/%s%s", report["score"], report["max_score"], config_qualifier(report))
     logger.info(
         "Packaging audit of %s — metadata only, the package was not downloaded or run.",
         coordinate.display,

--- a/mcpscore/cli.py
+++ b/mcpscore/cli.py
@@ -9,10 +9,12 @@ from importlib.metadata import PackageNotFoundError, version
 import json
 import logging
 import os
+from pathlib import Path
 import sys
 from typing import TYPE_CHECKING, NoReturn
 
 from mcpscore import MCPAuditor, MCPClient, StdioCommand
+from mcpscore.config import ConfigError, RuleConfig
 from mcpscore.enums import ConnectionErrorReason
 from mcpscore.mcp_auditor import has_authorization_credential
 from mcpscore.packages import InvalidCoordinateError, PackageCoordinate
@@ -129,6 +131,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Emit a machine-readable JSON report to stdout (logs go to stderr)",
+    )
+    parser.add_argument(
+        "--config",
+        metavar="FILE",
+        help=(
+            "Per-project rule configuration to apply: a mcpscore.toml, or a pyproject.toml with a "
+            '[tool.mcpscore] table. Rules set to "off" do not run; rules set to a severity name count at '
+            "that severity; [gate] fail_on fails the build (exit 3) on any failed rule at or above it. "
+            "Without this flag, the nearest mcpscore.toml or [tool.mcpscore] up to the repository root is "
+            "used. The configuration changes the score for this run only; the badge and mcpscore.dev "
+            "never apply one."
+        ),
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Ignore any mcpscore.toml or [tool.mcpscore]: audit with the canonical rule set and weights.",
     )
     parser.add_argument(
         "--fail-under",
@@ -369,7 +388,9 @@ def _mcpscore_version() -> str:
         return "unknown"
 
 
-async def run_package_audit(args: argparse.Namespace, coordinate: PackageCoordinate) -> int:
+async def run_package_audit(
+    args: argparse.Namespace, coordinate: PackageCoordinate, config: RuleConfig | None = None
+) -> int:
     """Score a package coordinate and report it. Returns the process exit code.
 
     Its own entry point rather than a branch inside the server flow: there is no
@@ -380,7 +401,7 @@ async def run_package_audit(args: argparse.Namespace, coordinate: PackageCoordin
     package up (the analogue of "could not connect"), 3 audited but a
     --fail-under threshold was not met.
     """
-    auditor = MCPAuditor()
+    auditor = MCPAuditor(config=config)
     await auditor.audit_package(coordinate)
     report = auditor.get_audit_report()
     package = report["package"]
@@ -459,9 +480,77 @@ def fail_under_exit_code(args: argparse.Namespace, report: dict) -> int:
                     f"{args.fail_under_readiness}%"
                 )
 
+    gate = (report.get("config") or {}).get("gate")
+    if gate and gate["failed"]:
+        failed = gate["failed"]
+        failures.append(
+            f'[gate] fail_on = "{gate["fail_on"].lower()}": {len(failed)} failed rule{"s" if len(failed) != 1 else ""} '
+            f"at or above {gate['fail_on']}: {', '.join(failed)}"
+        )
+
     for failure in failures:
         logger.error("Gate failed — %s", failure)
     return 3 if failures else 0
+
+
+def load_rule_config(args: argparse.Namespace) -> RuleConfig | None:
+    """Resolve the per-project configuration for this run and log what it changes.
+
+    ``--config`` names a file; otherwise the nearest ``mcpscore.toml`` or
+    ``[tool.mcpscore]`` up to the repository root is used; ``--no-config``
+    ignores both. Unknown and retired rule ids warn and are ignored, so a
+    configuration written for a newer engine still runs on an older one.
+
+    Raises:
+        ValueError: ``--config`` and ``--no-config`` together, or a file that
+            cannot be applied. The caller reports it as a usage error.
+
+    """
+    if args.no_config:
+        if args.config:
+            raise ValueError("--config and --no-config cannot be combined")
+        return None
+    try:
+        config = RuleConfig.load(Path(args.config)) if args.config else RuleConfig.discover()
+    except ConfigError as e:
+        raise ValueError(str(e)) from e
+    if config is None:
+        return None
+    logger.info("Config: %s — %s", config.source, config.summary())
+    retired = dict(config.retired)
+    for rule_id in config.unknown:
+        if rule_id in retired:
+            logger.warning("Config: rule '%s' was retired in mcpscore %s; ignored", rule_id, retired[rule_id])
+        else:
+            logger.warning("Config: unknown rule '%s'; ignored", rule_id)
+    return config
+
+
+def resolve_rule_config(args: argparse.Namespace) -> RuleConfig | None:
+    """Load the run's configuration, or exit 1 with a usage error; keeps async_main flat."""
+    try:
+        return load_rule_config(args)
+    except ValueError as e:
+        logger.error("Usage error: %s", e)  # noqa: TRY400 — usage error, not an exception to trace
+        sys.exit(1)
+
+
+def config_qualifier(report: dict) -> str:
+    """Return the score-line qualifier for a configured run, e.g. `` (mcpscore.toml: 2 rules off, 1 re-ranked)``.
+
+    Built from the report rather than the RuleConfig so the line and the JSON
+    cannot disagree. Empty for an unconfigured run.
+    """
+    block = report.get("config")
+    if not block:
+        return ""
+    off, reranked = len(block.get("disabled", [])), len(block.get("reranked", {}))
+    parts = [f"{off} rule{'s' if off != 1 else ''} off"] if off else []
+    if reranked:
+        parts.append(f"{reranked} re-ranked")
+    if block.get("gate"):
+        parts.append(f"gate at {block['gate']['fail_on']}")
+    return f" ({block['source']}: {', '.join(parts) if parts else 'no overrides'})"
 
 
 def finish_server_audit(
@@ -526,14 +615,17 @@ def log_audit_outcome(auditor: MCPAuditor) -> None:
         # a chat or a slide (external feedback, 2026-08-18). Saying how many
         # checks actually ran is what makes "25/25" interpretable.
         logger.info(
-            "Audit finished. PARTIAL score: %s/%s from %s of %s checks — not comparable to a full audit.",
+            "Audit finished. PARTIAL score: %s/%s from %s of %s checks — not comparable to a full audit.%s",
             report["score"],
             report["max_score"],
             scored,
             considered,
+            config_qualifier(report),
         )
     else:
-        logger.info("Audit finished. Final score: %s/%s", report["score"], report["max_score"])
+        logger.info(
+            "Audit finished. Final score: %s/%s%s", report["score"], report["max_score"], config_qualifier(report)
+        )
     logger.info(
         "Spec: %s negotiated (latest: %s) · era: %s",
         spec["negotiated_version"] or "unknown",
@@ -707,10 +799,12 @@ async def async_main() -> None:
 
     logger.info("Welcome to mcpscore!")
 
+    config = resolve_rule_config(args)
+
     # A package audit shares no machinery with a server audit past this point:
     # no headers, no OAuth, no client, no transport detection, no cleanup.
     if isinstance(target, PackageCoordinate):
-        sys.exit(await run_package_audit(args, target))
+        sys.exit(await run_package_audit(args, target, config))
 
     try:
         headers = collect_headers(args)
@@ -728,7 +822,7 @@ async def async_main() -> None:
         logger.info("Using %d custom header(s).", len(headers))
 
     client: MCPClient = MCPClient(headers=headers or None)
-    auditor: MCPAuditor = MCPAuditor(headers=headers or None)
+    auditor: MCPAuditor = MCPAuditor(headers=headers or None, config=config)
 
     # Everything below runs inside one try/finally: failed detection attempts
     # can leave resources on the client's exit stack, so every path out —

--- a/mcpscore/config.py
+++ b/mcpscore/config.py
@@ -1,0 +1,253 @@
+"""Per-project rule configuration: ``mcpscore.toml`` or ``[tool.mcpscore]`` in ``pyproject.toml``.
+
+A team turns rules off and re-ranks the rest by severity name, keyed on
+``rule_id``, the way a ``ruff.toml`` works::
+
+    [rules]
+    server_websiteurl_present = "off"  # does not run
+    tools_title_present_in_all = "critical"  # runs, counts as CRITICAL
+
+    [gate]
+    fail_on = "high"  # any failed rule at or above HIGH fails the build
+
+The configuration changes the score for the run that used it and nothing
+else: the website and the badge never see one (the backend never constructs
+a ``RuleConfig``), and the JSON report records what was applied. Design and
+decision: ``project/tech-design/design-rule-config.md``,
+``project/decision-records/2026-09-04-rule-config-off-rerank-gate.md``.
+
+Discovery lives here and is used by the CLI only; ``MCPAuditor`` applies a
+configuration solely when handed one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+from pathlib import Path
+import tomllib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+from .rules.base import RuleSeverity
+from .rules.registry import all_rule_ids
+from .rules.retired import RETIRED_RULES
+
+CONFIG_FILENAME = "mcpscore.toml"
+PYPROJECT_FILENAME = "pyproject.toml"
+PYPROJECT_TABLE = "mcpscore"  # [tool.mcpscore]
+
+OFF = "off"
+"""The one spelling for "this rule does not run"."""
+
+SKIP_REASON_DISABLED_BY_CONFIG = "disabled-by-config"
+"""``skipped_rules[].reason`` for a rule the configuration turned off."""
+
+# Hints list the choices ascending, the order people think in; the enum declares them descending.
+_SEVERITY_NAMES = tuple(s.name.lower() for s in sorted(RuleSeverity, key=int))
+_VALUE_HINT = ", ".join((OFF, *_SEVERITY_NAMES[:-1])) + f", or {_SEVERITY_NAMES[-1]}"
+_SEVERITY_HINT = ", ".join(_SEVERITY_NAMES[:-1]) + f", or {_SEVERITY_NAMES[-1]}"
+
+
+class ConfigError(ValueError):
+    """A configuration file that cannot be applied. The CLI reports it as a usage error."""
+
+
+@dataclass(frozen=True)
+class RuleConfig:
+    """A parsed, validated configuration.
+
+    Attributes:
+        source: Where it came from, as the CLI and the report name it (a path
+            relative to the working directory, or absolute for ``--config``).
+        sha256: Hex digest of the file's bytes, so two reports with the same
+            digest and engine version are comparable.
+        overrides: ``rule_id`` to configured severity, or ``None`` for off.
+            Only ids the registry knows; unknown ones are in ``unknown``.
+        fail_on: The ``[gate]`` threshold, or ``None`` when no gate is set.
+        unknown: Configured ids the registry does not have, in file order.
+            They warn and are reported, never applied and never fatal, so a
+            configuration written for a newer engine still runs on an older one.
+        retired: Unknown ids that ``rules/retired.py`` explains, as
+            ``(rule_id, version)`` pairs, so the warning can say why.
+
+    """
+
+    source: str
+    sha256: str
+    overrides: Mapping[str, RuleSeverity | None] = field(default_factory=dict)
+    fail_on: RuleSeverity | None = None
+    unknown: tuple[str, ...] = ()
+    retired: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def disabled(self) -> tuple[str, ...]:
+        """Rule ids turned off, in file order."""
+        return tuple(rule_id for rule_id, severity in self.overrides.items() if severity is None)
+
+    @property
+    def reranked(self) -> dict[str, RuleSeverity]:
+        """Rule ids given a configured severity, in file order."""
+        return {rule_id: severity for rule_id, severity in self.overrides.items() if severity is not None}
+
+    def summary(self) -> str:
+        """One clause for the score line, e.g. ``2 rules off, 1 re-ranked``."""
+        off, reranked = len(self.disabled), len(self.reranked)
+        parts = [f"{off} rule{'s' if off != 1 else ''} off"] if off else []
+        if reranked:
+            parts.append(f"{reranked} re-ranked")
+        if self.fail_on is not None:
+            parts.append(f"gate at {self.fail_on.name}")
+        return ", ".join(parts) if parts else "no overrides"
+
+    # ---------------------------------------------------------------- parsing
+
+    @classmethod
+    def parse(cls, text: str, *, source: str, sha256: str | None = None) -> RuleConfig:
+        """Parse a ``mcpscore.toml`` document (``[rules]`` and ``[gate]`` at the top level)."""
+        try:
+            data = tomllib.loads(text)
+        except tomllib.TOMLDecodeError as e:
+            raise ConfigError(f"{source}: not valid TOML: {e}") from e
+        return cls._from_tables(data, source=source, sha256=sha256 or _digest(text.encode("utf-8")))
+
+    @classmethod
+    def parse_pyproject(cls, text: str, *, source: str, sha256: str | None = None) -> RuleConfig | None:
+        """Parse the ``[tool.mcpscore]`` table of a ``pyproject.toml``; None when it has none."""
+        try:
+            data = tomllib.loads(text)
+        except tomllib.TOMLDecodeError as e:
+            raise ConfigError(f"{source}: not valid TOML: {e}") from e
+        tool = data.get("tool")
+        if not isinstance(tool, dict) or PYPROJECT_TABLE not in tool:
+            return None
+        table = tool[PYPROJECT_TABLE]
+        if not isinstance(table, dict):
+            raise ConfigError(f"{source}: [tool.{PYPROJECT_TABLE}] must be a table")
+        return cls._from_tables(table, source=source, sha256=sha256 or _digest(text.encode("utf-8")))
+
+    @classmethod
+    def load(cls, path: Path, *, source: str | None = None) -> RuleConfig:
+        """Load a configuration file by path; a ``pyproject.toml`` is read through its tool table.
+
+        Raises:
+            ConfigError: the file is missing, unreadable, invalid TOML, has an
+                invalid value, or is a ``pyproject.toml`` with no
+                ``[tool.mcpscore]`` table.
+
+        """
+        display = source or str(path)
+        try:
+            raw = path.read_bytes()
+        except OSError as e:
+            raise ConfigError(f"{display}: cannot read config file: {e.strerror or e}") from e
+        text = raw.decode("utf-8")
+        digest = _digest(raw)
+        if path.name == PYPROJECT_FILENAME:
+            config = cls.parse_pyproject(text, source=display, sha256=digest)
+            if config is None:
+                raise ConfigError(f"{display}: no [tool.{PYPROJECT_TABLE}] table")
+            return config
+        return cls.parse(text, source=display, sha256=digest)
+
+    @classmethod
+    def discover(cls, start: Path | None = None) -> RuleConfig | None:
+        """Find the nearest configuration, walking up from ``start`` (default: the working directory).
+
+        In each directory ``mcpscore.toml`` wins over a ``pyproject.toml`` with a
+        ``[tool.mcpscore]`` table. The walk stops after the first directory that
+        contains ``.git``, so a configuration in one checkout cannot leak into an
+        audit run inside another. Returns None when nothing is found.
+        """
+        here = (start or Path.cwd()).resolve()
+        cwd = Path.cwd().resolve()
+        for directory in (here, *here.parents):
+            candidate = directory / CONFIG_FILENAME
+            if candidate.is_file():
+                return cls.load(candidate, source=_display(candidate, cwd))
+            pyproject = directory / PYPROJECT_FILENAME
+            if pyproject.is_file():
+                raw = pyproject.read_bytes()
+                found = cls.parse_pyproject(raw.decode("utf-8"), source=_display(pyproject, cwd), sha256=_digest(raw))
+                if found is not None:
+                    return found
+            if (directory / ".git").exists():
+                break
+        return None
+
+    @classmethod
+    def _from_tables(cls, data: Mapping[str, Any], *, source: str, sha256: str) -> RuleConfig:
+        unexpected = sorted(set(data) - {"rules", "gate"})
+        if unexpected:
+            raise ConfigError(f"{source}: unexpected table(s) {', '.join(unexpected)}; expected [rules] and [gate]")
+
+        rules = data.get("rules", {})
+        if not isinstance(rules, dict):
+            raise ConfigError(f"{source}: [rules] must be a table of rule_id = value")
+        known = set(all_rule_ids())
+        retired_versions = {r.rule_id: r.version for r in RETIRED_RULES}
+        overrides: dict[str, RuleSeverity | None] = {}
+        unknown: list[str] = []
+        retired: list[tuple[str, str]] = []
+        for rule_id, value in rules.items():
+            severity = _parse_rule_value(rule_id, value, source)
+            if rule_id in known:
+                overrides[rule_id] = severity
+            else:
+                unknown.append(rule_id)
+                if rule_id in retired_versions:
+                    retired.append((rule_id, retired_versions[rule_id]))
+
+        gate = data.get("gate", {})
+        if not isinstance(gate, dict):
+            raise ConfigError(f"{source}: [gate] must be a table")
+        unexpected_gate = sorted(set(gate) - {"fail_on"})
+        if unexpected_gate:
+            raise ConfigError(f"{source}: [gate] has unexpected key(s) {', '.join(unexpected_gate)}; expected fail_on")
+        fail_on: RuleSeverity | None = None
+        if "fail_on" in gate:
+            fail_on = _parse_severity(gate["fail_on"])
+            if fail_on is None:
+                raise ConfigError(f"{source}: [gate] fail_on has value {gate['fail_on']!r}; expected {_SEVERITY_HINT}")
+
+        return cls(
+            source=source,
+            sha256=sha256,
+            overrides=overrides,
+            fail_on=fail_on,
+            unknown=tuple(unknown),
+            retired=tuple(retired),
+        )
+
+
+def _parse_rule_value(rule_id: str, value: object, source: str) -> RuleSeverity | None:
+    """Return the configured severity for a rule entry, or None for off; raise on anything else."""
+    if isinstance(value, str):
+        if value.lower() == OFF:
+            return None
+        severity = _parse_severity(value)
+        if severity is not None:
+            return severity
+    raise ConfigError(f"{source}: rule '{rule_id}' has value {value!r}; expected {_VALUE_HINT}")
+
+
+def _parse_severity(value: object) -> RuleSeverity | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return RuleSeverity[value.upper()]
+    except KeyError:
+        return None
+
+
+def _digest(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _display(path: Path, cwd: Path) -> str:
+    try:
+        return str(path.relative_to(cwd))
+    except ValueError:
+        return str(path)

--- a/mcpscore/config.py
+++ b/mcpscore/config.py
@@ -144,7 +144,7 @@ class RuleConfig:
             raw = path.read_bytes()
         except OSError as e:
             raise ConfigError(f"{display}: cannot read config file: {e.strerror or e}") from e
-        text = raw.decode("utf-8")
+        text = _decode(raw, display)
         digest = _digest(raw)
         if path.name == PYPROJECT_FILENAME:
             config = cls.parse_pyproject(text, source=display, sha256=digest)
@@ -175,7 +175,7 @@ class RuleConfig:
                     raw = pyproject.read_bytes()
                 except OSError as e:
                     raise ConfigError(f"{display}: cannot read config file: {e.strerror or e}") from e
-                found = cls.parse_pyproject(raw.decode("utf-8"), source=display, sha256=_digest(raw))
+                found = cls.parse_pyproject(_decode(raw, display), source=display, sha256=_digest(raw))
                 if found is not None:
                     return found
             if (directory / ".git").exists():
@@ -245,6 +245,14 @@ def _parse_severity(value: object) -> RuleSeverity | None:
         return RuleSeverity[value.upper()]
     except KeyError:
         return None
+
+
+def _decode(raw: bytes, source: str) -> str:
+    """Decode a config file as UTF-8, or raise the usage error the CLI expects."""
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as e:
+        raise ConfigError(f"{source}: not valid UTF-8 (byte {e.start})") from e
 
 
 def _digest(raw: bytes) -> str:

--- a/mcpscore/config.py
+++ b/mcpscore/config.py
@@ -12,9 +12,10 @@ A team turns rules off and re-ranks the rest by severity name, keyed on
 
 The configuration changes the score for the run that used it and nothing
 else: the website and the badge never see one (the backend never constructs
-a ``RuleConfig``), and the JSON report records what was applied. Design and
-decision: ``project/tech-design/design-rule-config.md``,
-``project/decision-records/2026-09-04-rule-config-off-rerank-gate.md``.
+a ``RuleConfig``), and the JSON report records what was applied. The gate
+covers failed rules counted in the main score, so readiness rules count only
+when a modern-lifecycle server promotes them. User-facing description:
+https://docs.mcpscore.dev/configure-rules
 
 Discovery lives here and is used by the CLI only; ``MCPAuditor`` applies a
 configuration solely when handed one.
@@ -169,8 +170,12 @@ class RuleConfig:
                 return cls.load(candidate, source=_display(candidate, cwd))
             pyproject = directory / PYPROJECT_FILENAME
             if pyproject.is_file():
-                raw = pyproject.read_bytes()
-                found = cls.parse_pyproject(raw.decode("utf-8"), source=_display(pyproject, cwd), sha256=_digest(raw))
+                display = _display(pyproject, cwd)
+                try:
+                    raw = pyproject.read_bytes()
+                except OSError as e:
+                    raise ConfigError(f"{display}: cannot read config file: {e.strerror or e}") from e
+                found = cls.parse_pyproject(raw.decode("utf-8"), source=display, sha256=_digest(raw))
                 if found is not None:
                     return found
             if (directory / ".git").exists():

--- a/mcpscore/mcp_auditor.py
+++ b/mcpscore/mcp_auditor.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 from mcp import StdioServerParameters
 from pydantic import ValidationError
 
+from .config import SKIP_REASON_DISABLED_BY_CONFIG, RuleConfig
 from .enums import MCPTransportType
 from .mcp_client import MCPClient
 from .packages import PackageCoordinate, PackageOutcome, fetch_package_metadata
@@ -92,7 +93,7 @@ class MCPAuditor:
     aspects of MCP compliance and contributes to an overall audit score.
     """
 
-    def __init__(self, headers: dict[str, str] | None = None) -> None:
+    def __init__(self, headers: dict[str, str] | None = None, config: RuleConfig | None = None) -> None:
         """Initialize a new MCPAuditor instance.
 
         Args:
@@ -101,6 +102,11 @@ class MCPAuditor:
                 Should match the headers passed to the MCPClient. Sensitive —
                 never logged or included in the report (only the boolean
                 ``authenticated`` flag is reported).
+            config: A per-project rule configuration (rules turned off,
+                re-ranked, and an optional severity gate). Applied only when
+                given: the backend never passes one, so the website and the
+                badge stay canonical. With None the audit and its report are
+                identical to an unconfigured run.
 
         Sets up the auditor with:
         - Empty audit data container
@@ -111,6 +117,9 @@ class MCPAuditor:
         """
         super().__init__()
         self.headers: dict[str, str] | None = headers or None
+        self.config: RuleConfig | None = config
+        self.config_defaults: dict[str, RuleSeverity] = {}
+        """Own severity of every re-ranked rule that ran, for the report's ``from``."""
         self.mcp_client: MCPClient | None = None
         self.audit_data: AuditData = AuditData()
         self.score: int = 0
@@ -505,6 +514,11 @@ class MCPAuditor:
                 skip_reason = SKIP_REASON_INSUFFICIENT_DATA
             else:
                 skip_reason = rule.skip_reason(self.audit_data)
+            # A rule the configuration turned off does not run. Checked last so
+            # a canonical reason wins when both apply: the report should say
+            # why the engine could not judge, not merely that nobody asked.
+            if skip_reason is None and self._disabled_by_config(rule):
+                skip_reason = SKIP_REASON_DISABLED_BY_CONFIG
 
             if skip_reason is not None:
                 logger.info("⏭️ Skipping rule '%s': %s", rule.rule_id, skip_reason)
@@ -522,6 +536,7 @@ class MCPAuditor:
             res.rule_id = rule.rule_id
             if rule.basis and (res.details is None or "basis" not in res.details):
                 res.details = {**(res.details or {}), "basis": rule.basis}
+            self._apply_rerank(res)
             logger.info(res.message)
 
             if rule.group_name == READINESS_GROUP:
@@ -541,6 +556,65 @@ class MCPAuditor:
                 if res.passed:
                     self.score += res.severity.value
                 self.results.append(res)
+
+    def _disabled_by_config(self, rule: BaseRule) -> bool:
+        return (
+            self.config is not None
+            and rule.rule_id in self.config.overrides
+            and self.config.overrides[rule.rule_id] is None
+        )
+
+    def _apply_rerank(self, res: RuleResult) -> None:
+        """Give a result its configured severity, recording the rule's own in ``details``.
+
+        The configured severity is what the result earns and what it adds to
+        the maximum: re-ranking is a change of weight, nothing else. The
+        default is kept in ``details.severity_default`` so a report is
+        self-explaining without the configuration file beside it.
+        """
+        if self.config is None:
+            return
+        configured = self.config.overrides.get(res.rule_id)
+        if configured is None or configured == res.severity:
+            return
+        self.config_defaults[res.rule_id] = res.severity
+        res.details = {**(res.details or {}), "severity_default": res.severity.name}
+        res.severity = configured
+
+    def config_gate_failures(self) -> list[str]:
+        """Return the rule ids whose failed result is at or above the configured ``[gate] fail_on`` threshold.
+
+        Empty when no gate is configured. Only results that count toward the
+        main score can trip the gate: readiness results are included only when
+        this run promoted them, matching how ``--fail-under`` treats them; the
+        informative axis never fails a build.
+        """
+        if self.config is None or self.config.fail_on is None:
+            return []
+        counted = list(self.results)
+        if self.readiness_promoted:
+            counted.extend(self.readiness_results)
+        return [res.rule_id for res in counted if not res.passed and res.severity >= self.config.fail_on]
+
+    def _config_report(self, config: RuleConfig) -> dict:
+        """Build the additive ``config`` block: what was applied, so a configured score explains itself."""
+        by_id = {rule.rule_id: rule for rule in self.rules}
+        reranked = {}
+        for rule_id, severity in config.reranked.items():
+            default = self.config_defaults.get(rule_id)
+            if default is None and rule_id in by_id:
+                default = by_id[rule_id].severity
+            reranked[rule_id] = {"from": default.name if default is not None else None, "to": severity.name}
+        block: dict = {
+            "source": config.source,
+            "sha256": config.sha256,
+            "disabled": list(config.disabled),
+            "reranked": reranked,
+            "unknown": list(config.unknown),
+        }
+        if config.fail_on is not None:
+            block["gate"] = {"fail_on": config.fail_on.name, "failed": self.config_gate_failures()}
+        return block
 
     async def _collect_transport_metadata(self) -> None:
         """Collect transport and connection metadata from the MCP client.
@@ -796,7 +870,7 @@ class MCPAuditor:
               revision, with its per-rule results and the counted_in_main flag
 
         """
-        return {
+        report: dict = {
             "score": self.score,
             "max_score": self.max_score,
             # True when the audit sent an Authorization credential (--token or
@@ -854,6 +928,11 @@ class MCPAuditor:
                 + sum(1 for s in self.skipped_rules if s.group_name == READINESS_GROUP),
             },
         }
+        # Present only when a configuration was applied, so an unconfigured
+        # report is byte-identical to one from an engine without this feature.
+        if self.config is not None:
+            report["config"] = self._config_report(self.config)
+        return report
 
     def _package_report(self) -> dict | None:
         """Serialize the audited package coordinate and what the registry said.

--- a/mcpscore/rules/registry.py
+++ b/mcpscore/rules/registry.py
@@ -116,3 +116,12 @@ def create_all_rules(**kwargs: Any) -> Iterable[BaseRule]:
 
     """
     return _registry.create_all_rules(**kwargs)
+
+
+def all_rule_ids() -> tuple[str, ...]:
+    """Return every registered rule_id, in registration order.
+
+    The public view of the registry's keys, for callers that validate
+    rule_ids without instantiating rules (the per-project configuration).
+    """
+    return tuple(_registry._types)

--- a/scripts/generate_rules_doc.py
+++ b/scripts/generate_rules_doc.py
@@ -21,7 +21,8 @@ description: "Every rule mcpscore runs — generated from the rule registry, so 
 icon: "list-check"
 ---
 
-Use this page to look up any `rule_id` from a report or a CI comment. It is
+Use this page to look up any `rule_id` from a report or a CI comment, or to
+turn one off or re-rank it in a [`mcpscore.toml`](/configure-rules). It is
 regenerated from the rule registry on every change (`make docs-rules`), so the
 tables below always match the code.
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -206,3 +206,39 @@ def test_resolve_rule_config_exits_1_on_a_usage_error(caplog: pytest.LogCaptureF
 
     assert exc.value.code == 1
     assert "Usage error: --config and --no-config cannot be combined" in caplog.text
+
+
+async def test_package_audit_score_line_carries_the_qualifier_and_gates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """The configuration applies to packaging rules too: same score-line contract, same exit 3."""
+    from mcpscore.cli import run_package_audit
+    from mcpscore.packages import PackageCoordinate, PackageMetadata, PackageOutcome
+
+    async def fake_fetch(coordinate, client=None):
+        # Resolves, versioned, not withdrawn; no repository, license, or description.
+        return PackageMetadata(coordinate=coordinate, outcome=PackageOutcome.OK, resolved_version="1.0.0")
+
+    monkeypatch.setattr("mcpscore.mcp_auditor.fetch_package_metadata", fake_fetch)
+    config_file = tmp_path / "mcpscore.toml"
+    config_file.write_text(
+        "[rules]\n"
+        'package_description_present = "off"\n'
+        'package_license_declared = "critical"\n'
+        "[gate]\n"
+        'fail_on = "critical"\n',
+        encoding="utf-8",
+    )
+    argv = build_parser().parse_args(["--package", "npm:server", "--config", str(config_file)])
+    config = load_rule_config(argv)
+
+    with caplog.at_level(logging.INFO, logger="mcpscore.cli"):
+        code = await run_package_audit(argv, PackageCoordinate.parse("npm:server"), config)
+
+    assert code == 3
+    # 16 canonical points: -1 for the description rule turned off, +3 for license promoted MEDIUM -> CRITICAL.
+    assert f"Final score: 11/18 ({config_file}: 1 rule off, 1 re-ranked, gate at CRITICAL)" in caplog.text
+    assert (
+        'Gate failed — [gate] fail_on = "critical": 1 failed rule at or above CRITICAL: package_license_declared'
+        in caplog.text
+    )

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,208 @@
+"""Tests for the CLI side of per-project rule configuration: flags, loading, the gate, the score line."""
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcpscore import MCPAuditor, RuleConfig, RuleSeverity
+from mcpscore.cli import build_parser, config_qualifier, fail_under_exit_code, load_rule_config, log_audit_outcome
+from mcpscore.rules.retired import RETIRED_RULES
+
+KNOWN = "server_icons_present"
+
+
+def args(*argv: str):
+    return build_parser().parse_args(["https://x", *argv])
+
+
+def report(**overrides) -> dict:
+    base = {
+        "score": 80,
+        "max_score": 85,
+        "partial": False,
+        "partial_reason": None,
+        "summary": {"total": 10, "skipped": 2},
+        "spec": {
+            "negotiated_version": "2025-11-25",
+            "latest_version": "2026-07-28",
+            "readiness_target": "2026-07-28",
+            "era": "legacy",
+        },
+        "readiness": {"score": 0, "max_score": 0, "results": [], "skipped": 0, "counted_in_main": False},
+    }
+    base.update(overrides)
+    return base
+
+
+# --- flags and loading --------------------------------------------------------
+
+
+def test_flags_parse():
+    assert args("--config", "x.toml").config == "x.toml"
+    assert args("--no-config").no_config is True
+    assert args().config is None
+    assert args().no_config is False
+
+
+def test_no_config_returns_none_even_inside_a_configured_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / "mcpscore.toml").write_text(f'[rules]\n{KNOWN} = "off"\n', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert load_rule_config(args("--no-config")) is None
+
+
+def test_config_and_no_config_together_is_a_usage_error():
+    with pytest.raises(ValueError, match="--config and --no-config cannot be combined"):
+        load_rule_config(args("--config", "x.toml", "--no-config"))
+
+
+def test_explicit_config_is_loaded_and_summarised(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    path = tmp_path / "team.toml"
+    path.write_text(f'[rules]\n{KNOWN} = "off"\n[gate]\nfail_on = "high"\n', encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="mcpscore.cli"):
+        config = load_rule_config(args("--config", str(path)))
+
+    assert config is not None
+    assert config.disabled == (KNOWN,)
+    assert config.fail_on is RuleSeverity.HIGH
+    assert f"Config: {path} — 1 rule off, gate at HIGH" in caplog.text
+
+
+def test_missing_explicit_config_is_a_usage_error(tmp_path: Path):
+    with pytest.raises(ValueError, match="cannot read config file"):
+        load_rule_config(args("--config", str(tmp_path / "absent.toml")))
+
+
+def test_invalid_config_is_a_usage_error(tmp_path: Path):
+    path = tmp_path / "mcpscore.toml"
+    path.write_text(f'[rules]\n{KNOWN} = "skip"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected off, low, medium, high, or critical"):
+        load_rule_config(args("--config", str(path)))
+
+
+def test_discovery_finds_the_nearest_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "mcpscore.toml").write_text(f'[rules]\n{KNOWN} = "off"\n', encoding="utf-8")
+    nested = tmp_path / "src"
+    nested.mkdir()
+    monkeypatch.chdir(nested)
+
+    config = load_rule_config(args())
+
+    assert config is not None
+    assert config.disabled == (KNOWN,)
+
+
+def test_no_config_anywhere_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    assert load_rule_config(args()) is None
+
+
+def test_unknown_and_retired_ids_warn_and_are_ignored(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    retired = RETIRED_RULES[0]
+    path = tmp_path / "mcpscore.toml"
+    path.write_text(f'[rules]\nnot_a_rule = "off"\n{retired.rule_id} = "low"\n{KNOWN} = "off"\n', encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="mcpscore.cli"):
+        config = load_rule_config(args("--config", str(path)))
+
+    assert config is not None
+    assert config.overrides == {KNOWN: None}
+    assert "Config: unknown rule 'not_a_rule'; ignored" in caplog.text
+    assert f"Config: rule '{retired.rule_id}' was retired in mcpscore {retired.version}; ignored" in caplog.text
+
+
+# --- the gate in the exit-3 path ---------------------------------------------
+
+
+def test_gate_failures_exit_3_with_the_rules_named(caplog: pytest.LogCaptureFixture):
+    gated = report(config={"gate": {"fail_on": "HIGH", "failed": ["a", "b"]}})
+
+    with caplog.at_level(logging.ERROR, logger="mcpscore.cli"):
+        code = fail_under_exit_code(args(), gated)
+
+    assert code == 3
+    assert 'Gate failed — [gate] fail_on = "high": 2 failed rules at or above HIGH: a, b' in caplog.text
+
+
+def test_gate_with_nothing_failed_is_clean():
+    assert fail_under_exit_code(args(), report(config={"gate": {"fail_on": "HIGH", "failed": []}})) == 0
+
+
+def test_config_without_a_gate_does_not_gate():
+    assert fail_under_exit_code(args(), report(config={"disabled": ["a"]})) == 0
+
+
+def test_gate_and_fail_under_both_report(caplog: pytest.LogCaptureFixture):
+    gated = report(score=10, max_score=100, config={"gate": {"fail_on": "HIGH", "failed": ["a"]}})
+
+    with caplog.at_level(logging.ERROR, logger="mcpscore.cli"):
+        code = fail_under_exit_code(args("--fail-under", "50"), gated)
+
+    assert code == 3
+    assert "--fail-under 50" in caplog.text
+    assert "1 failed rule at or above HIGH: a" in caplog.text
+
+
+# --- the score line -----------------------------------------------------------
+
+
+def test_qualifier_is_empty_without_a_config():
+    assert config_qualifier(report()) == ""
+
+
+def test_qualifier_describes_the_config():
+    block = {"source": "mcpscore.toml", "disabled": ["a", "b"], "reranked": {"c": {}}, "gate": {"fail_on": "HIGH"}}
+
+    assert config_qualifier(report(config=block)) == " (mcpscore.toml: 2 rules off, 1 re-ranked, gate at HIGH)"
+    assert config_qualifier(report(config={"source": "pyproject.toml", "disabled": [], "reranked": {}})) == (
+        " (pyproject.toml: no overrides)"
+    )
+
+
+def test_final_score_line_carries_the_qualifier(caplog: pytest.LogCaptureFixture):
+    auditor = MagicMock(spec=MCPAuditor)
+    auditor.get_audit_report = MagicMock(
+        return_value=report(config={"source": "mcpscore.toml", "disabled": ["a"], "reranked": {}})
+    )
+
+    with caplog.at_level(logging.INFO, logger="mcpscore.cli"):
+        log_audit_outcome(auditor)
+
+    assert "Audit finished. Final score: 80/85 (mcpscore.toml: 1 rule off)" in caplog.text
+
+
+def test_partial_score_line_carries_the_qualifier(caplog: pytest.LogCaptureFixture):
+    auditor = MagicMock(spec=MCPAuditor)
+    auditor.get_audit_report = MagicMock(
+        return_value=report(
+            partial=True,
+            partial_reason="gated",
+            config={"source": "mcpscore.toml", "disabled": [], "reranked": {"a": {}}},
+        )
+    )
+
+    with caplog.at_level(logging.INFO, logger="mcpscore.cli"):
+        log_audit_outcome(auditor)
+
+    assert "not comparable to a full audit. (mcpscore.toml: 1 re-ranked)" in caplog.text
+
+
+def test_rule_config_is_exported_for_library_users():
+    assert RuleConfig.__name__ == "RuleConfig"
+
+
+def test_resolve_rule_config_exits_1_on_a_usage_error(caplog: pytest.LogCaptureFixture):
+    from mcpscore.cli import resolve_rule_config
+
+    with caplog.at_level(logging.ERROR, logger="mcpscore.cli"), pytest.raises(SystemExit) as exc:
+        resolve_rule_config(args("--config", "x.toml", "--no-config"))
+
+    assert exc.value.code == 1
+    assert "Usage error: --config and --no-config cannot be combined" in caplog.text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -324,3 +324,20 @@ def test_discover_outside_any_repository_walks_to_the_root_and_finds_nothing(tmp
     # No .git anywhere above a temp dir, and no config on the way up: the walk
     # ends at the filesystem root rather than at a repository boundary.
     assert RuleConfig.discover(tmp_path / "nowhere") is None
+
+
+def test_discover_reports_an_unreadable_pyproject_as_a_config_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / ".git").mkdir()
+    pyproject = tmp_path / PYPROJECT_FILENAME
+    pyproject.write_text(f'[tool.mcpscore.rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    original = Path.read_bytes
+
+    def denied(self: Path) -> bytes:
+        if self == pyproject:
+            raise PermissionError(13, "Permission denied")
+        return original(self)
+
+    monkeypatch.setattr(Path, "read_bytes", denied)
+
+    with pytest.raises(ConfigError, match=r"pyproject\.toml: cannot read config file: Permission denied"):
+        RuleConfig.discover(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -274,3 +274,53 @@ def test_discover_names_the_source_relative_to_the_working_directory(tmp_path: P
 
     assert config is not None
     assert config.source == CONFIG_FILENAME
+
+
+def test_pyproject_with_invalid_toml_is_a_config_error():
+    with pytest.raises(ConfigError, match=r"pyproject\.toml: not valid TOML"):
+        RuleConfig.parse_pyproject("[tool\n", source="pyproject.toml")
+
+
+def test_discover_finds_a_pyproject_table_when_there_is_no_mcpscore_toml(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / PYPROJECT_FILENAME).write_text(f'[tool.mcpscore.rules]\n{KNOWN_B} = "high"\n', encoding="utf-8")
+
+    config = RuleConfig.discover(tmp_path)
+
+    assert config is not None
+    assert config.reranked == {KNOWN_B: RuleSeverity.HIGH}
+    assert config.sha256 == hashlib.sha256((tmp_path / PYPROJECT_FILENAME).read_bytes()).hexdigest()
+
+
+def test_discover_defaults_to_the_working_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / CONFIG_FILENAME).write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    config = RuleConfig.discover()
+
+    assert config is not None
+    assert config.source == CONFIG_FILENAME
+
+
+def test_discover_names_a_source_outside_the_working_directory_by_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / CONFIG_FILENAME).write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    config = RuleConfig.discover(project)
+
+    assert config is not None
+    assert config.source == str((project / CONFIG_FILENAME).resolve())
+
+
+def test_discover_outside_any_repository_walks_to_the_root_and_finds_nothing(tmp_path: Path):
+    # No .git anywhere above a temp dir, and no config on the way up: the walk
+    # ends at the filesystem root rather than at a repository boundary.
+    assert RuleConfig.discover(tmp_path / "nowhere") is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -341,3 +341,19 @@ def test_discover_reports_an_unreadable_pyproject_as_a_config_error(tmp_path: Pa
 
     with pytest.raises(ConfigError, match=r"pyproject\.toml: cannot read config file: Permission denied"):
         RuleConfig.discover(tmp_path)
+
+
+def test_load_rejects_a_file_that_is_not_utf8(tmp_path: Path):
+    path = tmp_path / CONFIG_FILENAME
+    path.write_bytes(b"[rules]\n# \xe9\n" + f'{KNOWN_A} = "off"\n'.encode())  # a lone Latin-1 byte
+
+    with pytest.raises(ConfigError, match=r"mcpscore\.toml: not valid UTF-8 \(byte 10\)"):
+        RuleConfig.load(path)
+
+
+def test_discover_rejects_a_pyproject_that_is_not_utf8(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / PYPROJECT_FILENAME).write_bytes(b"[tool.mcpscore.rules]\n# \xff\n")
+
+    with pytest.raises(ConfigError, match=r"pyproject\.toml: not valid UTF-8"):
+        RuleConfig.discover(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,276 @@
+"""Tests for the per-project rule configuration (mcpscore.toml / [tool.mcpscore])."""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from mcpscore import ConfigError, RuleConfig, RuleSeverity
+from mcpscore.config import CONFIG_FILENAME, PYPROJECT_FILENAME, SKIP_REASON_DISABLED_BY_CONFIG
+from mcpscore.rules.registry import all_rule_ids
+from mcpscore.rules.retired import RETIRED_RULES
+
+KNOWN_A = "server_icons_present"
+KNOWN_B = "tools_title_present_in_all"
+KNOWN_C = "readiness_2026_no_get_stream"
+
+
+def parse(text: str) -> RuleConfig:
+    return RuleConfig.parse(text, source="mcpscore.toml")
+
+
+# --- registry accessor --------------------------------------------------------
+
+
+def test_all_rule_ids_is_the_registry_view():
+    ids = all_rule_ids()
+
+    assert KNOWN_A in ids
+    assert KNOWN_B in ids
+    assert len(ids) == len(set(ids))
+    assert not (set(ids) & {r.rule_id for r in RETIRED_RULES})  # retired ids are never re-registered
+
+
+# --- values -------------------------------------------------------------------
+
+
+def test_off_turns_a_rule_off_and_severities_rerank():
+    config = parse(f'[rules]\n{KNOWN_A} = "off"\n{KNOWN_B} = "critical"\n{KNOWN_C} = "low"\n')
+
+    assert config.disabled == (KNOWN_A,)
+    assert config.reranked == {KNOWN_B: RuleSeverity.CRITICAL, KNOWN_C: RuleSeverity.LOW}
+    assert config.overrides[KNOWN_A] is None
+    assert config.fail_on is None
+    assert config.unknown == ()
+
+
+@pytest.mark.parametrize("value", ["OFF", "Off", "off"])
+def test_off_is_case_insensitive(value: str):
+    assert parse(f'[rules]\n{KNOWN_A} = "{value}"\n').disabled == (KNOWN_A,)
+
+
+@pytest.mark.parametrize(
+    ("value", "severity"),
+    [
+        ("low", RuleSeverity.LOW),
+        ("Medium", RuleSeverity.MEDIUM),
+        ("HIGH", RuleSeverity.HIGH),
+        ("critical", RuleSeverity.CRITICAL),
+    ],
+)
+def test_severity_names_are_case_insensitive(value: str, severity: RuleSeverity):
+    assert parse(f'[rules]\n{KNOWN_A} = "{value}"\n').reranked == {KNOWN_A: severity}
+
+
+@pytest.mark.parametrize("value", ['"skip"', '"disabled"', '"5"', "5", "true", '"critical "'])
+def test_invalid_rule_value_is_a_config_error_naming_the_rule_and_the_choices(value: str):
+    with pytest.raises(
+        ConfigError, match=rf"mcpscore.toml: rule '{KNOWN_A}' has value .*expected off, low, medium, high, or critical"
+    ):
+        parse(f"[rules]\n{KNOWN_A} = {value}\n")
+
+
+def test_unknown_rule_ids_are_collected_not_fatal():
+    config = parse(f'[rules]\nnot_a_rule = "off"\n{KNOWN_A} = "high"\nanother_typo = "low"\n')
+
+    assert config.unknown == ("not_a_rule", "another_typo")
+    assert config.retired == ()
+    assert config.overrides == {KNOWN_A: RuleSeverity.HIGH}
+
+
+def test_retired_rule_ids_are_unknown_and_explained():
+    retired = RETIRED_RULES[0]
+
+    config = parse(f'[rules]\n{retired.rule_id} = "off"\n')
+
+    assert config.unknown == (retired.rule_id,)
+    assert config.retired == ((retired.rule_id, retired.version),)
+
+
+def test_invalid_toml_is_a_config_error():
+    with pytest.raises(ConfigError, match=r"mcpscore\.toml: not valid TOML"):
+        parse("[rules\n")
+
+
+def test_unexpected_tables_are_a_config_error():
+    # A typo'd table name would otherwise silently do nothing.
+    with pytest.raises(ConfigError, match=r"unexpected table\(s\) rule; expected \[rules\] and \[gate\]"):
+        parse(f'[rule]\n{KNOWN_A} = "off"\n')
+
+
+def test_rules_must_be_a_table():
+    with pytest.raises(ConfigError, match=r"\[rules\] must be a table"):
+        parse('rules = "off"\n')
+
+
+# --- gate ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("value", "severity"), [("high", RuleSeverity.HIGH), ("CRITICAL", RuleSeverity.CRITICAL)])
+def test_gate_fail_on_parses_a_severity(value: str, severity: RuleSeverity):
+    assert parse(f'[gate]\nfail_on = "{value}"\n').fail_on is severity
+
+
+@pytest.mark.parametrize("value", ['"off"', '"severe"', "3"])
+def test_gate_fail_on_rejects_non_severities(value: str):
+    with pytest.raises(ConfigError, match=r"\[gate\] fail_on has value .*expected low, medium, high, or critical"):
+        parse(f"[gate]\nfail_on = {value}\n")
+
+
+def test_gate_rejects_unknown_keys():
+    with pytest.raises(ConfigError, match=r"\[gate\] has unexpected key\(s\) fail_under; expected fail_on"):
+        parse('[gate]\nfail_under = "high"\n')
+
+
+def test_gate_must_be_a_table():
+    with pytest.raises(ConfigError, match=r"\[gate\] must be a table"):
+        parse('gate = "high"\n')
+
+
+# --- summary and identity -----------------------------------------------------
+
+
+def test_summary_counts_what_changed():
+    assert parse(f'[rules]\n{KNOWN_A} = "off"\n').summary() == "1 rule off"
+    assert (
+        parse(f'[rules]\n{KNOWN_A} = "off"\n{KNOWN_B} = "off"\n{KNOWN_C} = "low"\n').summary()
+        == "2 rules off, 1 re-ranked"
+    )
+    assert parse(f'[rules]\n{KNOWN_C} = "low"\n[gate]\nfail_on = "high"\n').summary() == "1 re-ranked, gate at HIGH"
+    assert parse("").summary() == "no overrides"
+
+
+def test_sha256_is_of_the_file_bytes():
+    text = f'[rules]\n{KNOWN_A} = "off"\n'
+
+    assert parse(text).sha256 == hashlib.sha256(text.encode()).hexdigest()
+    assert parse(text + "\n").sha256 != parse(text).sha256  # any byte change is a new identity
+
+
+def test_disabled_by_config_skip_reason_is_stable_text():
+    assert SKIP_REASON_DISABLED_BY_CONFIG == "disabled-by-config"
+
+
+# --- pyproject.toml -----------------------------------------------------------
+
+
+def test_pyproject_tool_table_is_read():
+    text = (
+        f'[project]\nname = "x"\n\n[tool.mcpscore.rules]\n{KNOWN_A} = "off"\n\n[tool.mcpscore.gate]\nfail_on = "high"\n'
+    )
+
+    config = RuleConfig.parse_pyproject(text, source="pyproject.toml")
+
+    assert config is not None
+    assert config.disabled == (KNOWN_A,)
+    assert config.fail_on is RuleSeverity.HIGH
+    assert config.source == "pyproject.toml"
+
+
+def test_pyproject_without_the_table_is_none():
+    assert RuleConfig.parse_pyproject('[project]\nname = "x"\n', source="pyproject.toml") is None
+    assert RuleConfig.parse_pyproject("[tool.ruff]\nline-length = 120\n", source="pyproject.toml") is None
+
+
+def test_pyproject_table_must_be_a_table():
+    with pytest.raises(ConfigError, match=r"\[tool.mcpscore\] must be a table"):
+        RuleConfig.parse_pyproject('[tool]\nmcpscore = "off"\n', source="pyproject.toml")
+
+
+# --- load ---------------------------------------------------------------------
+
+
+def test_load_reads_a_config_file(tmp_path: Path):
+    path = tmp_path / CONFIG_FILENAME
+    path.write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+
+    config = RuleConfig.load(path)
+
+    assert config.disabled == (KNOWN_A,)
+    assert config.source == str(path)
+    assert config.sha256 == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_load_missing_file_is_a_config_error(tmp_path: Path):
+    with pytest.raises(ConfigError, match="cannot read config file"):
+        RuleConfig.load(tmp_path / "absent.toml")
+
+
+def test_load_pyproject_dispatches_to_the_tool_table(tmp_path: Path):
+    path = tmp_path / PYPROJECT_FILENAME
+    path.write_text(f'[tool.mcpscore.rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+
+    assert RuleConfig.load(path).disabled == (KNOWN_A,)
+
+
+def test_load_pyproject_without_the_table_is_a_config_error(tmp_path: Path):
+    path = tmp_path / PYPROJECT_FILENAME
+    path.write_text('[project]\nname = "x"\n', encoding="utf-8")
+
+    with pytest.raises(ConfigError, match=r"no \[tool.mcpscore\] table"):
+        RuleConfig.load(path)
+
+
+# --- discovery ----------------------------------------------------------------
+
+
+def test_discover_returns_none_when_nothing_is_configured(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+
+    assert RuleConfig.discover(tmp_path) is None
+
+
+def test_discover_prefers_mcpscore_toml_over_pyproject_in_the_same_directory(tmp_path: Path):
+    (tmp_path / CONFIG_FILENAME).write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    (tmp_path / PYPROJECT_FILENAME).write_text(f'[tool.mcpscore.rules]\n{KNOWN_B} = "off"\n', encoding="utf-8")
+
+    config = RuleConfig.discover(tmp_path)
+
+    assert config is not None
+    assert config.disabled == (KNOWN_A,)
+
+
+def test_discover_walks_up_to_the_repository_root(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / CONFIG_FILENAME).write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    nested = tmp_path / "packages" / "server"
+    nested.mkdir(parents=True)
+
+    config = RuleConfig.discover(nested)
+
+    assert config is not None
+    assert config.disabled == (KNOWN_A,)
+
+
+def test_discover_stops_at_the_repository_root(tmp_path: Path):
+    # A config above the repo root belongs to some other checkout.
+    (tmp_path / CONFIG_FILENAME).write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    assert RuleConfig.discover(repo) is None
+
+
+def test_discover_skips_a_pyproject_without_the_table_and_keeps_walking(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / CONFIG_FILENAME).write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    nested = tmp_path / "pkg"
+    nested.mkdir()
+    (nested / PYPROJECT_FILENAME).write_text('[project]\nname = "x"\n', encoding="utf-8")
+
+    config = RuleConfig.discover(nested)
+
+    assert config is not None
+    assert config.disabled == (KNOWN_A,)
+
+
+def test_discover_names_the_source_relative_to_the_working_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / CONFIG_FILENAME).write_text(f'[rules]\n{KNOWN_A} = "off"\n', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    config = RuleConfig.discover(tmp_path)
+
+    assert config is not None
+    assert config.source == CONFIG_FILENAME

--- a/tests/test_config_auditor.py
+++ b/tests/test_config_auditor.py
@@ -1,0 +1,250 @@
+"""Tests for applying a per-project rule configuration inside MCPAuditor."""
+
+from mcpscore import AuditData, BaseRule, MCPAuditor, RuleConfig, RuleResult, RuleSeverity
+from mcpscore.config import SKIP_REASON_DISABLED_BY_CONFIG
+from mcpscore.mcp_auditor import READINESS_GROUP, Era
+from mcpscore.rules.base import SKIP_REASON_NOT_APPLICABLE
+
+
+def make_rule(
+    rule_id: str,
+    severity: RuleSeverity,
+    *,
+    passed: bool,
+    group_name: str = "default",
+    min_spec_version: str | None = None,
+) -> BaseRule:
+    """Build a rule with a fixed verdict, for driving the auditor's scoring directly."""
+    fixed_severity, fixed_passed = severity, passed
+
+    class Rule(BaseRule):
+        pass
+
+    Rule.rule_id = rule_id
+    Rule.group_name = group_name
+    Rule.min_spec_version = min_spec_version
+
+    def rule_name(self: BaseRule) -> str:
+        return rule_id
+
+    def rule_severity(self: BaseRule) -> RuleSeverity:
+        return fixed_severity
+
+    def check(self: BaseRule, audit_data: AuditData) -> RuleResult:
+        return RuleResult(
+            rule_name=rule_id,
+            severity=fixed_severity,
+            passed=fixed_passed,
+            message=f"{rule_id}: {'ok' if fixed_passed else 'no'}",
+        )
+
+    # Abstract members are resolved when the class is created, so build the
+    # concrete class with them in its body rather than patching afterwards.
+    concrete = type(
+        "Rule",
+        (Rule,),
+        {"rule_name": property(rule_name), "severity": property(rule_severity), "check": check},
+    )
+    return concrete()
+
+
+def config(**overrides: RuleSeverity | None) -> RuleConfig:
+    return RuleConfig(source="mcpscore.toml", sha256="abc123", overrides=overrides)
+
+
+def run(
+    rules: list[BaseRule], cfg: RuleConfig | None = None, *, era: Era | None = None, partial: bool = False
+) -> MCPAuditor:
+    auditor = MCPAuditor(config=cfg)
+    auditor.rules = rules
+    auditor.audit_data = AuditData(protocol_version="2025-11-25", partial=partial)
+    auditor.era = era
+    auditor._run_all_rules()
+    return auditor
+
+
+def skip_reasons(auditor: MCPAuditor) -> dict[str, str]:
+    return {s.rule_id: s.reason for s in auditor.skipped_rules}
+
+
+# --- no configuration: nothing changes --------------------------------------
+
+
+def test_report_has_no_config_block_without_a_configuration():
+    rules = [make_rule("a", RuleSeverity.HIGH, passed=True)]
+
+    assert "config" not in run(rules).get_audit_report()
+    assert "config" not in run(rules, None).get_audit_report()
+
+
+def test_unconfigured_scoring_is_unchanged():
+    auditor = run([make_rule("a", RuleSeverity.HIGH, passed=True), make_rule("b", RuleSeverity.LOW, passed=False)])
+
+    assert (auditor.score, auditor.max_score) == (3, 4)
+    assert auditor.skipped_rules == []
+
+
+# --- off ----------------------------------------------------------------------
+
+
+def test_off_rule_does_not_run_and_is_a_config_skip():
+    auditor = run(
+        [make_rule("a", RuleSeverity.HIGH, passed=True), make_rule("b", RuleSeverity.CRITICAL, passed=False)],
+        config(b=None),
+    )
+
+    assert (auditor.score, auditor.max_score) == (3, 3)  # b contributes to neither
+    assert [r.rule_id for r in auditor.results] == ["a"]
+    assert skip_reasons(auditor) == {"b": SKIP_REASON_DISABLED_BY_CONFIG}
+    report = auditor.get_audit_report()
+    assert report["config"]["disabled"] == ["b"]
+    assert [s["reason"] for s in report["skipped_rules"]] == [SKIP_REASON_DISABLED_BY_CONFIG]
+
+
+def test_canonical_skip_reason_wins_over_off():
+    # A rule the engine could not judge anyway says why, rather than "disabled".
+    rule = make_rule("future", RuleSeverity.HIGH, passed=False, min_spec_version="2026-07-28")
+
+    auditor = run([rule], config(future=None))
+
+    assert skip_reasons(auditor) == {"future": SKIP_REASON_NOT_APPLICABLE}
+
+
+# --- re-rank ------------------------------------------------------------------
+
+
+def test_reranked_rule_counts_at_the_configured_severity():
+    auditor = run(
+        [make_rule("a", RuleSeverity.LOW, passed=True), make_rule("b", RuleSeverity.LOW, passed=False)],
+        config(a=RuleSeverity.CRITICAL, b=RuleSeverity.HIGH),
+    )
+
+    assert (auditor.score, auditor.max_score) == (5, 8)
+    by_id = {r.rule_id: r for r in auditor.results}
+    assert by_id["a"].severity is RuleSeverity.CRITICAL
+    assert by_id["a"].details == {"severity_default": "LOW"}
+    report = auditor.get_audit_report()
+    assert report["results"][0]["severity"] == "CRITICAL"
+    assert report["results"][0]["severity_value"] == 5
+    assert report["config"]["reranked"] == {"a": {"from": "LOW", "to": "CRITICAL"}, "b": {"from": "LOW", "to": "HIGH"}}
+
+
+def test_rerank_to_the_rules_own_severity_is_a_no_op():
+    auditor = run([make_rule("a", RuleSeverity.HIGH, passed=True)], config(a=RuleSeverity.HIGH))
+
+    assert auditor.results[0].details is None
+    assert auditor.get_audit_report()["config"]["reranked"] == {"a": {"from": "HIGH", "to": "HIGH"}}
+
+
+def test_rerank_keeps_existing_details_and_basis():
+    rule = make_rule("a", RuleSeverity.LOW, passed=False)
+    rule.basis = "MCP 2025-11-25 §Test"
+
+    auditor = run([rule], config(a=RuleSeverity.MEDIUM))
+
+    assert auditor.results[0].details == {"basis": "MCP 2025-11-25 §Test", "severity_default": "LOW"}
+
+
+def test_reranked_rule_that_could_not_run_still_reports_its_default():
+    rule = make_rule("future", RuleSeverity.LOW, passed=False, min_spec_version="2026-07-28")
+
+    report = run([rule], config(future=RuleSeverity.CRITICAL)).get_audit_report()
+
+    assert report["config"]["reranked"] == {"future": {"from": "LOW", "to": "CRITICAL"}}
+
+
+# --- readiness axis -----------------------------------------------------------
+
+
+def test_readiness_rerank_follows_the_promotion_rule():
+    rules = [
+        make_rule("main", RuleSeverity.HIGH, passed=True),
+        make_rule("ready", RuleSeverity.LOW, passed=True, group_name=READINESS_GROUP),
+    ]
+    cfg = config(ready=RuleSeverity.CRITICAL)
+
+    legacy = run(rules, cfg, era=Era.LEGACY)
+    assert (legacy.score, legacy.max_score) == (3, 3)
+    assert (legacy.readiness_score, legacy.readiness_max) == (5, 5)
+
+    modern = run(rules, cfg, era=Era.MODERN)
+    assert (modern.score, modern.max_score) == (8, 8)
+    assert (modern.readiness_score, modern.readiness_max) == (5, 5)
+
+
+def test_readiness_rule_can_be_turned_off():
+    auditor = run([make_rule("ready", RuleSeverity.HIGH, passed=False, group_name=READINESS_GROUP)], config(ready=None))
+
+    assert (auditor.readiness_score, auditor.readiness_max) == (0, 0)
+    assert skip_reasons(auditor) == {"ready": SKIP_REASON_DISABLED_BY_CONFIG}
+    assert auditor.get_audit_report()["readiness"]["skipped"] == 1
+
+
+# --- gate ---------------------------------------------------------------------
+
+
+def gated(fail_on: RuleSeverity, **overrides: RuleSeverity | None) -> RuleConfig:
+    return RuleConfig(source="mcpscore.toml", sha256="abc123", overrides=overrides, fail_on=fail_on)
+
+
+def test_gate_lists_failed_rules_at_or_above_the_threshold():
+    rules = [
+        make_rule("crit_fail", RuleSeverity.CRITICAL, passed=False),
+        make_rule("high_fail", RuleSeverity.HIGH, passed=False),
+        make_rule("high_pass", RuleSeverity.HIGH, passed=True),
+        make_rule("low_fail", RuleSeverity.LOW, passed=False),
+    ]
+
+    auditor = run(rules, gated(RuleSeverity.HIGH))
+
+    assert auditor.config_gate_failures() == ["crit_fail", "high_fail"]
+    assert auditor.get_audit_report()["config"]["gate"] == {"fail_on": "HIGH", "failed": ["crit_fail", "high_fail"]}
+
+
+def test_gate_sees_reranked_severities_and_ignores_off_rules():
+    rules = [
+        make_rule("promoted", RuleSeverity.LOW, passed=False),
+        make_rule("silenced", RuleSeverity.CRITICAL, passed=False),
+    ]
+
+    auditor = run(rules, gated(RuleSeverity.HIGH, promoted=RuleSeverity.CRITICAL, silenced=None))
+
+    assert auditor.config_gate_failures() == ["promoted"]
+
+
+def test_gate_counts_readiness_only_when_promoted():
+    rules = [make_rule("ready", RuleSeverity.CRITICAL, passed=False, group_name=READINESS_GROUP)]
+
+    assert run(rules, gated(RuleSeverity.HIGH), era=Era.LEGACY).config_gate_failures() == []
+    assert run(rules, gated(RuleSeverity.HIGH), era=Era.MODERN).config_gate_failures() == ["ready"]
+
+
+def test_no_gate_means_no_failures_and_no_gate_block():
+    auditor = run([make_rule("crit_fail", RuleSeverity.CRITICAL, passed=False)], config())
+
+    assert auditor.config_gate_failures() == []
+    assert "gate" not in auditor.get_audit_report()["config"]
+
+
+# --- report block -------------------------------------------------------------
+
+
+def test_config_block_records_identity_and_unknown_ids():
+    cfg = RuleConfig(source="pyproject.toml", sha256="deadbeef", overrides={"a": None}, unknown=("nope", "old_rule"))
+
+    report = run([make_rule("a", RuleSeverity.LOW, passed=True)], cfg).get_audit_report()
+
+    assert report["config"] == {
+        "source": "pyproject.toml",
+        "sha256": "deadbeef",
+        "disabled": ["a"],
+        "reranked": {},
+        "unknown": ["nope", "old_rule"],
+    }
+
+
+def test_config_applies_to_partial_audits_too():
+    auditor = run([make_rule("a", RuleSeverity.HIGH, passed=True)], config(a=None), partial=True)
+
+    assert skip_reasons(auditor) == {"a": SKIP_REASON_DISABLED_BY_CONFIG}
+    assert auditor.get_audit_report()["partial"] is True


### PR DESCRIPTION
Adds project-level rule configuration via mcpscore.toml or pyproject.toml, supporting disabled rules, severity overrides, and CI gates.

Changes:

- Implements configuration parsing, discovery, reporting, and public exports.
- Applies overrides and gates throughout auditor and CLI flows.
- Adds comprehensive tests and user documentation.