### PR TITLE
Npm wrapper improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions: {}
 
 jobs:
   npm-wrapper:
-    name: npm wrapper / ${{ matrix.os }}
+    name: npm wrapper / ${{ matrix.os }} / node${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -34,13 +34,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: ["22.23.2"]
+        include:
+          # Compatibility coverage for the declared minimum major version.
+          - os: ubuntu-latest
+            node-version: "18.20.8"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: "22.23.2"
+          node-version: ${{ matrix.node-version }}
       - run: npm --prefix npm test
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,24 @@ concurrency:
 permissions: {}
 
 jobs:
+  npm-wrapper:
+    name: npm wrapper / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: "22.23.2"
+      - run: npm --prefix npm test
+
   lint:
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The npm wrapper now explains its Python-runner prerequisite and provides
+  platform-specific uv installation, PATH verification, and retry steps when
+  neither uvx nor pipx is available. Setup guides state the prerequisite
+  before the first audit command; runner selection and audit exit codes are
+  unchanged.
+
 ## [1.14.1] - 2026-09-11
 
 Documentation-site release: no change to the CLI or the engine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@ requests, and pull requests are all welcome.
 
 ## Development setup
 
-Requirements: Python 3.11+ and [uv](https://docs.astral.sh/uv/).
+Requirements: Python 3.11+, [uv](https://docs.astral.sh/uv/), and
+[Node.js](https://nodejs.org/) with npm for the wrapper tests in `make all`.
+Use Node.js 22 or newer for development; the wrapper also supports Node.js 18.
 
 ```bash
 git clone https://github.com/mcp-box/mcpscore.git
@@ -21,11 +23,13 @@ make lint           # Lint without fixing
 make typecheck      # Pyright (0 errors required in mcpscore/)
 make test           # Run the test suite
 make testcov        # Tests with coverage report (97% minimum enforced)
+make test-npm       # npm wrapper tests (Node.js; no npm install needed)
 make all            # Everything CI runs
 ```
 
 `make all` must pass before a PR — CI runs the same checks on Linux, macOS,
-and Windows against Python 3.11–3.13.
+and Windows against Python 3.11–3.13. Wrapper tests run on Node.js 22 across
+all three operating systems, plus Node.js 18 on Linux for compatibility.
 
 ## Adding an audit rule
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,11 @@ release-dry-run: ## Run all release checks without creating anything
 	uv run python scripts/release.py --dry-run
 
 .PHONY: all
-all: lint typecheck testcov ## Run all checks (mirrors CI)
+all: lint typecheck testcov test-npm ## Run all checks (mirrors CI)
+
+.PHONY: test-npm
+test-npm: ## Test the npm launcher (requires Node.js 18+)
+	npm --prefix npm test
 
 .PHONY: clean
 clean: ## Clean build artifacts and caches

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ mcpscore https://your-server.example/mcp --token "$TOKEN"
 mcpscore https://your-server.example/mcp --oauth
 ```
 
-No install at all: `uvx mcpscore <target>` or `npx @mcp-box/mcpscore <target>`.
+With uv installed: `uvx mcpscore <target>`. Node users can run
+`npx @mcp-box/mcpscore <target>` with **uv or pipx also on PATH**; the npm
+package launches the Python engine. See the [npm setup guide](npm/README.md).
 Guides: [authenticated servers](https://docs.mcpscore.dev/authenticated-servers),
 [CLI reference](https://docs.mcpscore.dev/cli).
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,13 +12,20 @@ in seconds, with no API key and no sign-up.
 
 ## Quick start
 
+The `uvx` command requires [uv](https://docs.astral.sh/uv/getting-started/installation/).
+The npm command requires Node.js **and uv or pipx on PATH**: it launches the
+Python engine in an isolated environment. Node.js alone is not enough.
+See the [npm setup guide](https://github.com/mcp-box/mcpscore/tree/main/npm#requirements)
+for installation and troubleshooting. The first run may take longer while
+the runner downloads the engine.
+
 <CodeGroup>
 
-```bash uvx (no install)
+```bash uvx
 uvx mcpscore https://mcp.deepwiki.com/mcp
 ```
 
-```bash npx (no install)
+```bash npx (requires uv or pipx)
 npx @mcp-box/mcpscore https://mcp.deepwiki.com/mcp
 ```
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -3,22 +3,56 @@
 **Lighthouse for MCP** — audit any [Model Context Protocol](https://modelcontextprotocol.io)
 server and get a scored, actionable report in seconds.
 
+## Requirements
+
+- Node.js 18 or newer.
+- **uv (which provides `uvx`) or pipx on your PATH.** Node.js alone is not
+  enough: this package launches the Python engine, not a JavaScript port.
+- For local servers, their runtime and any required configuration.
+
+Already have uv or pipx? Skip to **Run an audit**. Otherwise install uv:
+
+```bash
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+```powershell
+# Windows
+winget install --id=astral-sh.uv -e
+```
+
+See [uv installation](https://docs.astral.sh/uv/getting-started/installation/)
+for alternative methods. Open a new terminal and verify:
+
+```bash
+uvx --version
+npx @mcp-box/mcpscore --help
+```
+
+## Run an audit
+
 ```bash
 npx @mcp-box/mcpscore https://your-server.example/mcp
 ```
 
 This npm package is a thin wrapper around the Python
 [mcpscore](https://pypi.org/project/mcpscore/) CLI, pinned to the matching
-version — `npx @mcp-box/mcpscore` and `uvx mcpscore` behave identically. It requires
-[uv](https://docs.astral.sh/uv/) or [pipx](https://pipx.pypa.io/) on your PATH
-(no packages are installed into your environment).
+version. It tries `uvx` first, then `pipx` if `uvx` is absent. The runner
+installs the engine in an isolated environment; the first run needs network
+access and can take longer. The wrapper does not install uv or pipx itself.
+
+If neither runner is found, follow the printed installation steps, open a new
+terminal, and retry your original command. If a runner is already installed,
+check that its executable directory is on PATH. A runner or audit failure is
+returned directly rather than retried through the other runner.
 
 ## What you get
 
 - A severity-weighted quality score across protocol compliance, server
   metadata, capabilities, tools, security, and transport — deterministic,
   no API keys, CI-ready (`--json`).
-- A separate readiness score for the upcoming MCP spec revision
+- A separate readiness score for the MCP spec revision
   (2026-07-28, stateless lifecycle).
 - Actionable messages: every failed check says what to fix, and every rule
   is anchored to the spec.

--- a/npm/bin/mcpscore.js
+++ b/npm/bin/mcpscore.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // mcpscore npm wrapper: runs the Python mcpscore CLI at the exact version
 // this package pins (package.json -> mcpscore.pythonVersion), so
-// `npx mcpscore <target>` and `uvx mcpscore <target>` behave identically.
+// `npx @mcp-box/mcpscore <target>` runs the matching Python release.
 //
 // Resolution order: uvx (uv) -> pipx. No implicit installs into the user's
 // environment; if neither runner exists, print clear instructions and exit 1.
@@ -26,22 +26,34 @@ function tryRun(cmd, prefix) {
     process.exit(1);
   }
   // Propagate the CLI's exit code (mcpscore's codes are a documented contract:
-  // 0 ok, 1 usage error, 2 connection failure).
+  // 0 ok, 1 usage error, 2 connection failure, 3 score gate, 4 smoke gate).
   process.exit(result.status === null ? 1 : result.status);
 }
 
 tryRun("uvx", [spec]);
 tryRun("pipx", ["run", spec]);
 
+// Show a harmless verification command, not a reconstruction of argv: targets
+// and flags can contain credentials, and quoting differs across user shells.
+const installCommand = process.platform === "win32"
+  ? "winget install --id=astral-sh.uv -e"
+  : "curl -LsSf https://astral.sh/uv/install.sh | sh";
+
 console.error(
   [
-    `mcpscore is a Python CLI (this npm package is a thin wrapper for ${spec}).`,
-    "It needs one of these Python runners on your PATH:",
+    `mcpscore needs a Python runner (this npm package launches ${spec}).`,
+    "Neither uvx nor pipx was found on PATH. Node.js alone is not enough.",
     "",
-    "  uv    https://docs.astral.sh/uv/  (then this command just works)",
-    "  pipx  https://pipx.pypa.io/",
+    "1. Install uv (includes uvx):",
+    `   ${installCommand}`,
+    "   Other installation methods: https://docs.astral.sh/uv/getting-started/installation/",
+    "2. Open a new terminal, then verify:",
+    "   uvx --version",
+    "   npx @mcp-box/mcpscore --help",
+    "3. Retry your original command.",
     "",
-    "Or install it directly:  pip install mcpscore",
+    "Already installed uv or pipx? Ensure its executable directory is on PATH.",
+    "The wrapper does not install a runner automatically.",
     "Docs: https://docs.mcpscore.dev",
   ].join("\n"),
 );

--- a/npm/package.json
+++ b/npm/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "mcpscore": "bin/mcpscore.js"
   },
+  "scripts": {
+    "test": "node --test test/wrapper.test.js"
+  },
   "files": [
     "bin/"
   ],

--- a/npm/test/wrapper.test.js
+++ b/npm/test/wrapper.test.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { readFileSync, mkdtempSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+const { runInNewContext } = require("node:vm");
+const pkg = require("../package.json");
+const wrapper = path.join(__dirname, "../bin/mcpscore.js");
+const source = readFileSync(wrapper, "utf8");
+const missing = { error: { code: "ENOENT" } };
+
+// Execute the shipped entry point, replacing only OS boundaries. No Python
+// runners or network are needed, including on Windows.
+function run(platform, args, outcomes) {
+  const calls = [];
+  const errors = [];
+  const exited = {};
+  let code;
+  assert.throws(() => runInNewContext(source, {
+    require(name) {
+      if (name === "../package.json") return pkg;
+      assert.equal(name, "node:child_process");
+      return { spawnSync(command, argv, options) {
+        calls.push({ command, argv: Array.from(argv), options });
+        assert.ok(outcomes.length, "unexpected extra runner invocation");
+        return outcomes.shift();
+      } };
+    },
+    process: { platform, argv: ["node", wrapper, ...args], exit(value) {
+      code = value;
+      throw exited;
+    } },
+    console: { error(message) { errors.push(message); } },
+  }), (error) => error === exited);
+  return { calls, errors: errors.join("\n"), code };
+}
+
+for (const [platform, command] of [
+  ["linux", "curl -LsSf https://astral.sh/uv/install.sh | sh"],
+  ["darwin", "curl -LsSf https://astral.sh/uv/install.sh | sh"],
+  ["win32", "winget install --id=astral-sh.uv -e"],
+]) {
+  test(`missing runners give recovery steps on ${platform}`, () => {
+    const result = run(platform, ["--token", "private-token"], [missing, missing]);
+    assert.equal(result.code, 1);
+    assert.match(result.errors, /Python/);
+    assert.ok(result.errors.includes(command));
+    assert.match(result.errors, /new terminal/);
+    assert.match(result.errors, /uvx --version/);
+    assert.match(result.errors, /npx @mcp-box\/mcpscore --help/);
+    assert.match(result.errors, /original command/);
+    assert.ok(!result.errors.includes("private-token"));
+  });
+}
+
+for (const code of [0, 1, 2, 3, 4]) {
+  test(`uvx preserves arguments and exit ${code} without fallback`, () => {
+    const args = ["--json", "--env", "NAME=a b", "--stdio", "node", "a path/server.js", "$(literal)"];
+    const result = run("linux", args, [{ status: code }]);
+    assert.equal(result.code, code);
+    assert.equal(result.calls.length, 1);
+    assert.deepEqual(result.calls[0].argv, [`mcpscore==${pkg.mcpscore.pythonVersion}`, ...args]);
+    assert.equal(result.calls[0].command, "uvx");
+    assert.equal(result.calls[0].options.stdio, "inherit");
+    assert.ok(!result.calls[0].options.shell);
+    assert.equal(result.errors, "");
+  });
+}
+
+test("pipx is used only when uvx is absent", () => {
+  const result = run("win32", ["--json", "a path/server.py"], [missing, { status: 3 }]);
+  assert.equal(result.code, 3);
+  assert.deepEqual(result.calls.map((call) => call.command), ["uvx", "pipx"]);
+  assert.deepEqual(result.calls[1].argv, ["run", `mcpscore==${pkg.mcpscore.pythonVersion}`, "--json", "a path/server.py"]);
+});
+
+test("a runner launch error is not mistaken for an absent runner", () => {
+  const result = run("linux", [], [{ error: { code: "EACCES", message: "permission denied" } }]);
+  assert.equal(result.code, 1);
+  assert.match(result.errors, /permission denied/);
+  assert.equal(result.calls.length, 1);
+});
+
+test("a terminated runner does not trigger a second audit", () => {
+  const result = run("linux", [], [{ status: null, signal: "SIGTERM" }]);
+  assert.equal(result.code, 1);
+  assert.equal(result.calls.length, 1);
+});
+
+test("real entry point fails cleanly with no runners and keeps stdout empty", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "mcpscore npm test "));
+  try {
+    const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => key.toLowerCase() !== "path"));
+    env.PATH = directory;
+    const result = spawnSync(process.execPath, [wrapper, "--json"], { env, encoding: "utf8" });
+    assert.equal(result.status, 1, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, /uvx --version/);
+    assert.match(result.stderr, /npx @mcp-box\/mcpscore --help/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
The npm wrapper now explains its Python-runner prerequisite and provides  
platform-specific uv installation, PATH verification, and retry steps when
  neither uvx nor pipx is available. Setup guides state the prerequisite
  before the first audit command; runner selection and audit exit codes are
  unchanged.